### PR TITLE
Add graph engine abstraction layer

### DIFF
--- a/src/hc_enterprise_kg/engine/__init__.py
+++ b/src/hc_enterprise_kg/engine/__init__.py
@@ -1,0 +1,13 @@
+"""Graph engine abstraction layer."""
+
+from hc_enterprise_kg.engine.abstract import AbstractGraphEngine
+from hc_enterprise_kg.engine.factory import GraphEngineFactory
+from hc_enterprise_kg.engine.networkx_engine import NetworkXGraphEngine
+from hc_enterprise_kg.engine.query import QueryBuilder
+
+__all__ = [
+    "AbstractGraphEngine",
+    "GraphEngineFactory",
+    "NetworkXGraphEngine",
+    "QueryBuilder",
+]

--- a/src/hc_enterprise_kg/engine/abstract.py
+++ b/src/hc_enterprise_kg/engine/abstract.py
@@ -1,0 +1,144 @@
+"""Abstract graph engine interface defining the backend contract."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from hc_enterprise_kg.domain.base import (
+    BaseEntity,
+    BaseRelationship,
+    EntityType,
+    RelationshipType,
+)
+
+
+class AbstractGraphEngine(ABC):
+    """Abstract interface for graph storage backends.
+
+    All graph operations go through this interface. Concrete implementations
+    (NetworkX, Neo4j, etc.) implement these methods. Business logic in the
+    graph/ layer ONLY depends on this interface, never on a concrete backend.
+    """
+
+    # --- Entity CRUD ---
+
+    @abstractmethod
+    def add_entity(self, entity: BaseEntity) -> str:
+        """Add an entity to the graph. Returns the entity ID."""
+        ...
+
+    @abstractmethod
+    def get_entity(self, entity_id: str) -> BaseEntity | None:
+        """Retrieve an entity by its ID. Returns None if not found."""
+        ...
+
+    @abstractmethod
+    def update_entity(self, entity_id: str, updates: dict[str, Any]) -> BaseEntity:
+        """Update attributes on an existing entity. Returns updated entity."""
+        ...
+
+    @abstractmethod
+    def remove_entity(self, entity_id: str) -> bool:
+        """Remove an entity and all its relationships. Returns True if found."""
+        ...
+
+    @abstractmethod
+    def list_entities(
+        self,
+        entity_type: EntityType | None = None,
+        filters: dict[str, Any] | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[BaseEntity]:
+        """List entities, optionally filtered by type and attribute filters."""
+        ...
+
+    @abstractmethod
+    def entity_count(self, entity_type: EntityType | None = None) -> int:
+        """Count entities, optionally filtered by type."""
+        ...
+
+    # --- Relationship CRUD ---
+
+    @abstractmethod
+    def add_relationship(self, relationship: BaseRelationship) -> str:
+        """Add a relationship between two entities. Returns relationship ID."""
+        ...
+
+    @abstractmethod
+    def get_relationship(self, relationship_id: str) -> BaseRelationship | None:
+        """Retrieve a relationship by its ID."""
+        ...
+
+    @abstractmethod
+    def remove_relationship(self, relationship_id: str) -> bool:
+        """Remove a relationship. Returns True if found."""
+        ...
+
+    @abstractmethod
+    def get_relationships(
+        self,
+        entity_id: str,
+        direction: str = "both",
+        relationship_type: RelationshipType | None = None,
+    ) -> list[BaseRelationship]:
+        """Get all relationships for an entity, with optional filters."""
+        ...
+
+    @abstractmethod
+    def relationship_count(self, relationship_type: RelationshipType | None = None) -> int:
+        """Count relationships, optionally filtered by type."""
+        ...
+
+    # --- Traversal ---
+
+    @abstractmethod
+    def neighbors(
+        self,
+        entity_id: str,
+        direction: str = "both",
+        relationship_type: RelationshipType | None = None,
+        entity_type: EntityType | None = None,
+    ) -> list[BaseEntity]:
+        """Get neighboring entities, optionally filtered."""
+        ...
+
+    @abstractmethod
+    def shortest_path(self, source_id: str, target_id: str) -> list[str] | None:
+        """Find shortest path between two entities. Returns list of entity IDs."""
+        ...
+
+    @abstractmethod
+    def subgraph(self, entity_ids: list[str]) -> AbstractGraphEngine:
+        """Extract a subgraph containing only the specified entities."""
+        ...
+
+    # --- Bulk Operations ---
+
+    @abstractmethod
+    def add_entities_bulk(self, entities: list[BaseEntity]) -> list[str]:
+        """Add multiple entities efficiently. Returns list of IDs."""
+        ...
+
+    @abstractmethod
+    def add_relationships_bulk(self, relationships: list[BaseRelationship]) -> list[str]:
+        """Add multiple relationships efficiently. Returns list of IDs."""
+        ...
+
+    # --- Introspection ---
+
+    @abstractmethod
+    def get_statistics(self) -> dict[str, Any]:
+        """Return summary statistics about the graph."""
+        ...
+
+    @abstractmethod
+    def clear(self) -> None:
+        """Remove all entities and relationships."""
+        ...
+
+    @abstractmethod
+    def get_native_graph(self) -> Any:
+        """Return the underlying native graph object (e.g., nx.MultiDiGraph)."""
+        ...

--- a/src/hc_enterprise_kg/engine/factory.py
+++ b/src/hc_enterprise_kg/engine/factory.py
@@ -1,0 +1,39 @@
+"""Factory for creating graph engine instances."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hc_enterprise_kg.engine.abstract import AbstractGraphEngine
+
+
+class GraphEngineFactory:
+    """Factory for creating graph engine instances.
+
+    Supports registration of custom backends.
+    """
+
+    _backends: dict[str, type[AbstractGraphEngine]] = {}
+
+    @classmethod
+    def register(cls, name: str, engine_class: type[AbstractGraphEngine]) -> None:
+        cls._backends[name] = engine_class
+
+    @classmethod
+    def create(cls, backend: str = "networkx", **kwargs: Any) -> AbstractGraphEngine:
+        if backend not in cls._backends:
+            raise ValueError(
+                f"Unknown backend '{backend}'. Available: {list(cls._backends.keys())}"
+            )
+        return cls._backends[backend](**kwargs)
+
+    @classmethod
+    def available_backends(cls) -> list[str]:
+        return list(cls._backends.keys())
+
+    @classmethod
+    def auto_discover(cls) -> None:
+        """Register all built-in engine backends."""
+        from hc_enterprise_kg.engine.networkx_engine import NetworkXGraphEngine
+
+        cls.register("networkx", NetworkXGraphEngine)

--- a/src/hc_enterprise_kg/engine/networkx_engine.py
+++ b/src/hc_enterprise_kg/engine/networkx_engine.py
@@ -1,0 +1,286 @@
+"""NetworkX-backed graph engine implementation."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import networkx as nx
+
+from hc_enterprise_kg.domain.base import (
+    BaseEntity,
+    BaseRelationship,
+    EntityType,
+    RelationshipType,
+)
+from hc_enterprise_kg.domain.registry import EntityRegistry
+from hc_enterprise_kg.engine.abstract import AbstractGraphEngine
+
+
+class NetworkXGraphEngine(AbstractGraphEngine):
+    """In-memory graph engine backed by NetworkX MultiDiGraph.
+
+    Entities are stored as nodes with their Pydantic model dict as attributes.
+    Relationships are stored as edges keyed by relationship ID.
+    """
+
+    def __init__(self) -> None:
+        self._graph = nx.MultiDiGraph()
+        self._relationship_index: dict[str, tuple[str, str, str]] = {}
+
+    # --- Entity CRUD ---
+
+    def add_entity(self, entity: BaseEntity) -> str:
+        data = entity.model_dump(mode="python")
+        # Store entity_type as string for serialization
+        data["entity_type"] = entity.entity_type.value
+        self._graph.add_node(entity.id, **data)
+        return entity.id
+
+    def get_entity(self, entity_id: str) -> BaseEntity | None:
+        if entity_id not in self._graph:
+            return None
+        data = dict(self._graph.nodes[entity_id])
+        return self._deserialize_entity(data)
+
+    def update_entity(self, entity_id: str, updates: dict[str, Any]) -> BaseEntity:
+        if entity_id not in self._graph:
+            raise KeyError(f"Entity not found: {entity_id}")
+        node_data = self._graph.nodes[entity_id]
+        node_data.update(updates)
+        node_data["updated_at"] = datetime.utcnow()
+        node_data["version"] = node_data.get("version", 1) + 1
+        return self._deserialize_entity(dict(node_data))
+
+    def remove_entity(self, entity_id: str) -> bool:
+        if entity_id not in self._graph:
+            return False
+        # Remove all relationships involving this entity from the index
+        edges_to_remove = []
+        for rel_id, (src, tgt, key) in list(self._relationship_index.items()):
+            if src == entity_id or tgt == entity_id:
+                edges_to_remove.append(rel_id)
+        for rel_id in edges_to_remove:
+            del self._relationship_index[rel_id]
+        self._graph.remove_node(entity_id)
+        return True
+
+    def list_entities(
+        self,
+        entity_type: EntityType | None = None,
+        filters: dict[str, Any] | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[BaseEntity]:
+        results: list[BaseEntity] = []
+        for node_id, data in self._graph.nodes(data=True):
+            if entity_type and data.get("entity_type") != entity_type.value:
+                continue
+            if filters:
+                if not all(data.get(k) == v for k, v in filters.items()):
+                    continue
+            entity = self._deserialize_entity(dict(data))
+            if entity:
+                results.append(entity)
+
+        results = results[offset:]
+        if limit is not None:
+            results = results[:limit]
+        return results
+
+    def entity_count(self, entity_type: EntityType | None = None) -> int:
+        if entity_type is None:
+            return self._graph.number_of_nodes()
+        return sum(
+            1
+            for _, data in self._graph.nodes(data=True)
+            if data.get("entity_type") == entity_type.value
+        )
+
+    # --- Relationship CRUD ---
+
+    def add_relationship(self, relationship: BaseRelationship) -> str:
+        if relationship.source_id not in self._graph:
+            raise KeyError(f"Source entity not found: {relationship.source_id}")
+        if relationship.target_id not in self._graph:
+            raise KeyError(f"Target entity not found: {relationship.target_id}")
+
+        data = relationship.model_dump(mode="python")
+        data["relationship_type"] = relationship.relationship_type.value
+        key = self._graph.add_edge(
+            relationship.source_id,
+            relationship.target_id,
+            key=relationship.id,
+            **data,
+        )
+        self._relationship_index[relationship.id] = (
+            relationship.source_id,
+            relationship.target_id,
+            key,
+        )
+        return relationship.id
+
+    def get_relationship(self, relationship_id: str) -> BaseRelationship | None:
+        if relationship_id not in self._relationship_index:
+            return None
+        src, tgt, key = self._relationship_index[relationship_id]
+        data = dict(self._graph.edges[src, tgt, key])
+        return self._deserialize_relationship(data)
+
+    def remove_relationship(self, relationship_id: str) -> bool:
+        if relationship_id not in self._relationship_index:
+            return False
+        src, tgt, key = self._relationship_index[relationship_id]
+        self._graph.remove_edge(src, tgt, key=key)
+        del self._relationship_index[relationship_id]
+        return True
+
+    def get_relationships(
+        self,
+        entity_id: str,
+        direction: str = "both",
+        relationship_type: RelationshipType | None = None,
+    ) -> list[BaseRelationship]:
+        results: list[BaseRelationship] = []
+        rel_type_val = relationship_type.value if relationship_type else None
+
+        if direction in ("out", "both"):
+            for _, tgt, data in self._graph.out_edges(entity_id, data=True):
+                if rel_type_val and data.get("relationship_type") != rel_type_val:
+                    continue
+                rel = self._deserialize_relationship(dict(data))
+                if rel:
+                    results.append(rel)
+
+        if direction in ("in", "both"):
+            for src, _, data in self._graph.in_edges(entity_id, data=True):
+                if rel_type_val and data.get("relationship_type") != rel_type_val:
+                    continue
+                rel = self._deserialize_relationship(dict(data))
+                if rel:
+                    results.append(rel)
+
+        return results
+
+    def relationship_count(self, relationship_type: RelationshipType | None = None) -> int:
+        if relationship_type is None:
+            return self._graph.number_of_edges()
+        rel_type_val = relationship_type.value
+        return sum(
+            1
+            for _, _, data in self._graph.edges(data=True)
+            if data.get("relationship_type") == rel_type_val
+        )
+
+    # --- Traversal ---
+
+    def neighbors(
+        self,
+        entity_id: str,
+        direction: str = "both",
+        relationship_type: RelationshipType | None = None,
+        entity_type: EntityType | None = None,
+    ) -> list[BaseEntity]:
+        neighbor_ids: set[str] = set()
+        rel_type_val = relationship_type.value if relationship_type else None
+
+        if direction in ("out", "both"):
+            for _, tgt, data in self._graph.out_edges(entity_id, data=True):
+                if rel_type_val and data.get("relationship_type") != rel_type_val:
+                    continue
+                neighbor_ids.add(tgt)
+
+        if direction in ("in", "both"):
+            for src, _, data in self._graph.in_edges(entity_id, data=True):
+                if rel_type_val and data.get("relationship_type") != rel_type_val:
+                    continue
+                neighbor_ids.add(src)
+
+        results: list[BaseEntity] = []
+        for nid in neighbor_ids:
+            entity = self.get_entity(nid)
+            if entity is None:
+                continue
+            if entity_type and entity.entity_type != entity_type:
+                continue
+            results.append(entity)
+        return results
+
+    def shortest_path(self, source_id: str, target_id: str) -> list[str] | None:
+        try:
+            return nx.shortest_path(self._graph, source_id, target_id)
+        except (nx.NetworkXNoPath, nx.NodeNotFound):
+            return None
+
+    def subgraph(self, entity_ids: list[str]) -> NetworkXGraphEngine:
+        sub = NetworkXGraphEngine()
+        sub_nx = self._graph.subgraph(entity_ids).copy()
+        sub._graph = sub_nx
+        # Rebuild relationship index for the subgraph
+        for src, tgt, key, data in sub_nx.edges(keys=True, data=True):
+            rel_id = data.get("id", key)
+            sub._relationship_index[rel_id] = (src, tgt, key)
+        return sub
+
+    # --- Bulk Operations ---
+
+    def add_entities_bulk(self, entities: list[BaseEntity]) -> list[str]:
+        ids: list[str] = []
+        for entity in entities:
+            ids.append(self.add_entity(entity))
+        return ids
+
+    def add_relationships_bulk(self, relationships: list[BaseRelationship]) -> list[str]:
+        ids: list[str] = []
+        for rel in relationships:
+            ids.append(self.add_relationship(rel))
+        return ids
+
+    # --- Introspection ---
+
+    def get_statistics(self) -> dict[str, Any]:
+        g = self._graph
+        type_counts: dict[str, int] = {}
+        for _, data in g.nodes(data=True):
+            t = data.get("entity_type", "unknown")
+            type_counts[t] = type_counts.get(t, 0) + 1
+
+        rel_type_counts: dict[str, int] = {}
+        for _, _, data in g.edges(data=True):
+            t = data.get("relationship_type", "unknown")
+            rel_type_counts[t] = rel_type_counts.get(t, 0) + 1
+
+        return {
+            "total_entities": g.number_of_nodes(),
+            "total_relationships": g.number_of_edges(),
+            "entity_type_counts": type_counts,
+            "relationship_type_counts": rel_type_counts,
+            "density": nx.density(g),
+            "is_weakly_connected": (
+                nx.is_weakly_connected(g) if g.number_of_nodes() > 0 else True
+            ),
+        }
+
+    def clear(self) -> None:
+        self._graph.clear()
+        self._relationship_index.clear()
+
+    def get_native_graph(self) -> nx.MultiDiGraph:
+        return self._graph
+
+    # --- Internal helpers ---
+
+    def _deserialize_entity(self, data: dict[str, Any]) -> BaseEntity | None:
+        try:
+            entity_type = EntityType(data["entity_type"])
+            entity_class = EntityRegistry.get(entity_type)
+            return entity_class.model_validate(data)
+        except (KeyError, ValueError):
+            return None
+
+    def _deserialize_relationship(self, data: dict[str, Any]) -> BaseRelationship | None:
+        try:
+            data["relationship_type"] = RelationshipType(data["relationship_type"])
+            return BaseRelationship.model_validate(data)
+        except (KeyError, ValueError):
+            return None

--- a/src/hc_enterprise_kg/engine/query.py
+++ b/src/hc_enterprise_kg/engine/query.py
@@ -1,0 +1,102 @@
+"""Fluent query builder for graph queries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from hc_enterprise_kg.domain.base import BaseEntity, EntityType, RelationshipType
+from hc_enterprise_kg.engine.abstract import AbstractGraphEngine
+
+
+@dataclass
+class QuerySpec:
+    """Declarative query specification built by QueryBuilder."""
+
+    entity_type: EntityType | None = None
+    filters: dict[str, Any] = field(default_factory=dict)
+    relationship_traversals: list[dict[str, Any]] = field(default_factory=list)
+    limit: int | None = None
+    offset: int = 0
+
+
+class QueryBuilder:
+    """Fluent API for constructing graph queries.
+
+    Usage:
+        results = (
+            QueryBuilder(engine)
+            .entities(EntityType.PERSON)
+            .where(is_active=True)
+            .connected_to(dept_id, via=RelationshipType.WORKS_IN)
+            .limit(50)
+            .execute()
+        )
+    """
+
+    def __init__(self, engine: AbstractGraphEngine) -> None:
+        self._engine = engine
+        self._spec = QuerySpec()
+
+    def entities(self, entity_type: EntityType) -> QueryBuilder:
+        self._spec.entity_type = entity_type
+        return self
+
+    def where(self, **filters: Any) -> QueryBuilder:
+        self._spec.filters.update(filters)
+        return self
+
+    def connected_to(
+        self,
+        entity_id: str,
+        via: RelationshipType | None = None,
+        direction: str = "both",
+    ) -> QueryBuilder:
+        self._spec.relationship_traversals.append(
+            {
+                "entity_id": entity_id,
+                "relationship_type": via,
+                "direction": direction,
+            }
+        )
+        return self
+
+    def limit(self, n: int) -> QueryBuilder:
+        self._spec.limit = n
+        return self
+
+    def offset(self, n: int) -> QueryBuilder:
+        self._spec.offset = n
+        return self
+
+    def execute(self) -> list[BaseEntity]:
+        """Execute the query and return matching entities."""
+        results = self._engine.list_entities(
+            entity_type=self._spec.entity_type,
+            filters=self._spec.filters if self._spec.filters else None,
+            limit=None,  # Apply limit after traversal filters
+            offset=0,
+        )
+
+        # Apply traversal filters
+        for traversal in self._spec.relationship_traversals:
+            neighbor_ids = {
+                e.id
+                for e in self._engine.neighbors(
+                    traversal["entity_id"],
+                    direction=traversal["direction"],
+                    relationship_type=traversal.get("relationship_type"),
+                )
+            }
+            results = [e for e in results if e.id in neighbor_ids]
+
+        # Apply offset and limit
+        results = results[self._spec.offset :]
+        if self._spec.limit is not None:
+            results = results[: self._spec.limit]
+
+        return results
+
+    def count(self) -> int:
+        """Execute the query and return the count of matching entities."""
+        return len(self.execute())


### PR DESCRIPTION
## Summary
- `AbstractGraphEngine` ABC with full CRUD, traversal, bulk ops, and introspection contract
- `NetworkXGraphEngine` backed by MultiDiGraph with relationship index and entity deserialization
- `GraphEngineFactory` with auto-discovery and plugin registration
- `QueryBuilder` fluent API with entity type, attribute filters, and relationship traversal

## Test plan
- [ ] Engine contract tests: add/get/update/remove entity round-trip
- [ ] Relationship CRUD with source/target validation
- [ ] Traversal: neighbors, shortest_path, subgraph
- [ ] QueryBuilder: filter by type, attribute, connected_to