### PR TITLE
Add synthetic data generation module

### DIFF
--- a/src/hc_enterprise_kg/synthetic/__init__.py
+++ b/src/hc_enterprise_kg/synthetic/__init__.py
@@ -1,0 +1,19 @@
+"""Synthetic data generation for the enterprise knowledge graph."""
+
+from hc_enterprise_kg.synthetic.base import (
+    AbstractGenerator,
+    GenerationContext,
+    GeneratorRegistry,
+)
+from hc_enterprise_kg.synthetic.orchestrator import SyntheticOrchestrator
+from hc_enterprise_kg.synthetic.profiles.base_profile import OrgProfile
+from hc_enterprise_kg.synthetic.relationships import RelationshipWeaver
+
+__all__ = [
+    "AbstractGenerator",
+    "GenerationContext",
+    "GeneratorRegistry",
+    "OrgProfile",
+    "RelationshipWeaver",
+    "SyntheticOrchestrator",
+]

--- a/src/hc_enterprise_kg/synthetic/base.py
+++ b/src/hc_enterprise_kg/synthetic/base.py
@@ -1,0 +1,88 @@
+"""Base classes for synthetic data generation."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TypeVar
+
+from faker import Faker
+
+from hc_enterprise_kg.domain.base import BaseEntity, EntityType
+
+T = TypeVar("T", bound=BaseEntity)
+
+
+class GenerationContext:
+    """Shared context passed to all generators during a generation run.
+
+    Holds the org profile parameters, the Faker instance, previously
+    generated entities (so generators can reference each other), and
+    the random seed for reproducibility.
+    """
+
+    def __init__(
+        self,
+        profile: "OrgProfile",  # noqa: F821 — forward ref
+        seed: int | None = None,
+    ) -> None:
+        self.profile = profile
+        self.seed = seed
+        self.faker = Faker()
+        if seed is not None:
+            Faker.seed(seed)
+            import random
+
+            random.seed(seed)
+        self.generated: dict[EntityType, list[BaseEntity]] = {}
+        self.id_pool: dict[EntityType, list[str]] = {}
+
+    def get_entities(self, entity_type: EntityType) -> list[BaseEntity]:
+        return self.generated.get(entity_type, [])
+
+    def get_ids(self, entity_type: EntityType) -> list[str]:
+        return self.id_pool.get(entity_type, [])
+
+    def store(self, entity_type: EntityType, entities: list[BaseEntity]) -> None:
+        self.generated[entity_type] = entities
+        self.id_pool[entity_type] = [e.id for e in entities]
+
+
+class AbstractGenerator(ABC):
+    """Base class for all entity generators."""
+
+    GENERATES: EntityType
+
+    @abstractmethod
+    def generate(self, count: int, context: GenerationContext) -> list[BaseEntity]:
+        """Generate `count` entities using the provided context."""
+        ...
+
+
+class GeneratorRegistry:
+    """Registry for entity generators. Supports dynamic registration."""
+
+    _registry: dict[EntityType, type[AbstractGenerator]] = {}
+
+    @classmethod
+    def register(cls, generator_class: type[AbstractGenerator]) -> type[AbstractGenerator]:
+        """Can be used as a decorator: @GeneratorRegistry.register"""
+        cls._registry[generator_class.GENERATES] = generator_class
+        return generator_class
+
+    @classmethod
+    def get(cls, entity_type: EntityType) -> type[AbstractGenerator]:
+        if entity_type not in cls._registry:
+            raise KeyError(f"No generator registered for type: {entity_type}")
+        return cls._registry[entity_type]
+
+    @classmethod
+    def all(cls) -> dict[EntityType, type[AbstractGenerator]]:
+        return dict(cls._registry)
+
+    @classmethod
+    def is_registered(cls, entity_type: EntityType) -> bool:
+        return entity_type in cls._registry
+
+    @classmethod
+    def clear(cls) -> None:
+        cls._registry.clear()

--- a/src/hc_enterprise_kg/synthetic/generators/__init__.py
+++ b/src/hc_enterprise_kg/synthetic/generators/__init__.py
@@ -1,0 +1,31 @@
+"""Synthetic data generators for all entity types.
+
+Importing this module registers all generators with the GeneratorRegistry.
+"""
+
+from hc_enterprise_kg.synthetic.generators.data_assets import DataAssetGenerator
+from hc_enterprise_kg.synthetic.generators.departments import DepartmentGenerator
+from hc_enterprise_kg.synthetic.generators.incidents import IncidentGenerator
+from hc_enterprise_kg.synthetic.generators.locations import LocationGenerator
+from hc_enterprise_kg.synthetic.generators.networks import NetworkGenerator
+from hc_enterprise_kg.synthetic.generators.people import PeopleGenerator
+from hc_enterprise_kg.synthetic.generators.policies import PolicyGenerator
+from hc_enterprise_kg.synthetic.generators.roles import RoleGenerator
+from hc_enterprise_kg.synthetic.generators.security import ThreatActorGenerator, VulnerabilityGenerator
+from hc_enterprise_kg.synthetic.generators.systems import SystemGenerator
+from hc_enterprise_kg.synthetic.generators.vendors import VendorGenerator
+
+__all__ = [
+    "DataAssetGenerator",
+    "DepartmentGenerator",
+    "IncidentGenerator",
+    "LocationGenerator",
+    "NetworkGenerator",
+    "PeopleGenerator",
+    "PolicyGenerator",
+    "RoleGenerator",
+    "SystemGenerator",
+    "ThreatActorGenerator",
+    "VendorGenerator",
+    "VulnerabilityGenerator",
+]

--- a/src/hc_enterprise_kg/synthetic/generators/data_assets.py
+++ b/src/hc_enterprise_kg/synthetic/generators/data_assets.py
@@ -1,0 +1,61 @@
+"""Generator for DataAsset entities."""
+
+from __future__ import annotations
+
+import random
+
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.domain.entities.data_asset import DataAsset
+from hc_enterprise_kg.synthetic.base import AbstractGenerator, GenerationContext, GeneratorRegistry
+
+DATA_TYPES = ["pii", "phi", "financial", "intellectual_property", "operational", "public"]
+CLASSIFICATIONS = ["public", "internal", "confidential", "restricted"]
+FORMATS = ["sql", "nosql", "file", "api", "stream", "data_lake"]
+REGULATIONS = ["GDPR", "HIPAA", "PCI-DSS", "SOX", "CCPA", "FERPA"]
+
+ASSET_NAMES = [
+    "Customer Database", "Employee Records", "Financial Ledger",
+    "Product Catalog", "Audit Logs", "Email Archive", "Source Code Repository",
+    "Marketing Analytics", "Sales Pipeline Data", "Support Tickets",
+    "Compliance Reports", "Network Logs", "Backup Archives",
+    "Research Data", "Client Contracts", "Vendor Records",
+    "Payroll Data", "Health Records", "Transaction History",
+    "User Activity Logs", "API Keys Vault", "Configuration Store",
+]
+
+
+@GeneratorRegistry.register
+class DataAssetGenerator(AbstractGenerator):
+    """Generates DataAsset entities."""
+
+    GENERATES = EntityType.DATA_ASSET
+
+    def generate(self, count: int, context: GenerationContext) -> list[DataAsset]:
+        faker = context.faker
+        assets: list[DataAsset] = []
+
+        for i in range(count):
+            name = ASSET_NAMES[i] if i < len(ASSET_NAMES) else f"{faker.word().title()} Data Store"
+            data_type = random.choice(DATA_TYPES)
+            classification = random.choice(CLASSIFICATIONS)
+
+            asset = DataAsset(
+                name=name,
+                description=faker.sentence(nb_words=10),
+                data_type=data_type,
+                classification=classification,
+                format=random.choice(FORMATS),
+                retention_days=random.choice([30, 90, 365, 730, 2555]),
+                is_encrypted=random.random() < 0.6,
+                record_count=random.randint(1000, 10000000),
+                regulations=(
+                    random.sample(REGULATIONS, k=random.randint(1, 3))
+                    if classification in ("confidential", "restricted")
+                    else []
+                ),
+                tags=[classification, data_type],
+            )
+            assets.append(asset)
+
+        context.store(EntityType.DATA_ASSET, assets)
+        return assets

--- a/src/hc_enterprise_kg/synthetic/generators/departments.py
+++ b/src/hc_enterprise_kg/synthetic/generators/departments.py
@@ -1,0 +1,34 @@
+"""Generator for Department entities."""
+
+from __future__ import annotations
+
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.domain.entities.department import Department
+from hc_enterprise_kg.synthetic.base import AbstractGenerator, GenerationContext, GeneratorRegistry
+
+
+@GeneratorRegistry.register
+class DepartmentGenerator(AbstractGenerator):
+    """Generates Department entities from the org profile department specs."""
+
+    GENERATES = EntityType.DEPARTMENT
+
+    def generate(self, count: int, context: GenerationContext) -> list[Department]:
+        faker = context.faker
+        profile = context.profile
+        departments: list[Department] = []
+
+        for spec in profile.department_specs:
+            dept = Department(
+                name=spec.name,
+                description=f"{spec.name} department at {profile.name}",
+                code=spec.name.upper().replace(" ", "_")[:8],
+                headcount=int(profile.employee_count * spec.headcount_fraction),
+                tags=[spec.data_sensitivity],
+                metadata={"data_sensitivity": spec.data_sensitivity},
+                budget=round(faker.pyfloat(min_value=100000, max_value=10000000), 2),
+            )
+            departments.append(dept)
+
+        context.store(EntityType.DEPARTMENT, departments)
+        return departments

--- a/src/hc_enterprise_kg/synthetic/generators/incidents.py
+++ b/src/hc_enterprise_kg/synthetic/generators/incidents.py
@@ -1,0 +1,61 @@
+"""Generator for Incident entities."""
+
+from __future__ import annotations
+
+import random
+
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.domain.entities.incident import Incident
+from hc_enterprise_kg.synthetic.base import AbstractGenerator, GenerationContext, GeneratorRegistry
+
+INCIDENT_TYPES = [
+    "data_breach", "malware", "phishing", "dos", "insider_threat",
+    "ransomware", "account_compromise", "supply_chain", "misconfiguration",
+]
+DETECTION_METHODS = ["siem", "ids", "user_report", "threat_intel", "audit", "edr", "soar"]
+STATUSES = ["open", "investigating", "contained", "resolved", "closed"]
+
+
+@GeneratorRegistry.register
+class IncidentGenerator(AbstractGenerator):
+    """Generates Incident entities."""
+
+    GENERATES = EntityType.INCIDENT
+
+    def generate(self, count: int, context: GenerationContext) -> list[Incident]:
+        faker = context.faker
+        incidents: list[Incident] = []
+
+        system_ids = context.get_ids(EntityType.SYSTEM)
+        actor_ids = context.get_ids(EntityType.THREAT_ACTOR)
+
+        for _ in range(count):
+            inc_type = random.choice(INCIDENT_TYPES)
+            occurred = faker.date_time_between(start_date="-1y", end_date="now")
+            detected = faker.date_time_between(start_date=occurred, end_date="now")
+
+            incident = Incident(
+                name=f"{inc_type.replace('_', ' ').title()} Incident - {faker.date()}",
+                description=faker.paragraph(nb_sentences=2),
+                incident_type=inc_type,
+                severity=random.choice(["low", "medium", "high", "critical"]),
+                status=random.choice(STATUSES),
+                detection_method=random.choice(DETECTION_METHODS),
+                occurred_at=str(occurred),
+                detected_at=str(detected),
+                impact_description=faker.sentence(nb_words=10),
+                root_cause=faker.sentence(nb_words=8),
+                affected_system_ids=(
+                    random.sample(system_ids, k=min(random.randint(1, 3), len(system_ids)))
+                    if system_ids
+                    else []
+                ),
+                threat_actor_id=(
+                    random.choice(actor_ids) if actor_ids and random.random() < 0.5 else None
+                ),
+                tags=[inc_type],
+            )
+            incidents.append(incident)
+
+        context.store(EntityType.INCIDENT, incidents)
+        return incidents

--- a/src/hc_enterprise_kg/synthetic/generators/locations.py
+++ b/src/hc_enterprise_kg/synthetic/generators/locations.py
@@ -1,0 +1,46 @@
+"""Generator for Location entities."""
+
+from __future__ import annotations
+
+import random
+
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.domain.entities.location import Location
+from hc_enterprise_kg.synthetic.base import AbstractGenerator, GenerationContext, GeneratorRegistry
+
+LOCATION_TYPES = ["headquarters", "office", "data_center", "warehouse", "remote_hub"]
+SECURITY_LEVELS = ["standard", "enhanced", "restricted"]
+
+
+@GeneratorRegistry.register
+class LocationGenerator(AbstractGenerator):
+    """Generates Location entities."""
+
+    GENERATES = EntityType.LOCATION
+
+    def generate(self, count: int, context: GenerationContext) -> list[Location]:
+        faker = context.faker
+        locations: list[Location] = []
+
+        for i in range(count):
+            loc_type = LOCATION_TYPES[i] if i < len(LOCATION_TYPES) else random.choice(LOCATION_TYPES)
+
+            location = Location(
+                name=f"{faker.city()} {loc_type.replace('_', ' ').title()}",
+                description=f"{loc_type.replace('_', ' ').title()} facility",
+                address=faker.street_address(),
+                city=faker.city(),
+                state=faker.state_abbr(),
+                country=faker.country_code(),
+                zip_code=faker.zipcode(),
+                location_type=loc_type,
+                capacity=random.randint(50, 5000),
+                is_primary=i == 0,
+                security_level=random.choice(SECURITY_LEVELS),
+                has_physical_security=loc_type != "remote_hub",
+                tags=[loc_type],
+            )
+            locations.append(location)
+
+        context.store(EntityType.LOCATION, locations)
+        return locations

--- a/src/hc_enterprise_kg/synthetic/generators/networks.py
+++ b/src/hc_enterprise_kg/synthetic/generators/networks.py
@@ -1,0 +1,40 @@
+"""Generator for Network entities."""
+
+from __future__ import annotations
+
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.domain.entities.network import Network
+from hc_enterprise_kg.synthetic.base import AbstractGenerator, GenerationContext, GeneratorRegistry
+
+
+@GeneratorRegistry.register
+class NetworkGenerator(AbstractGenerator):
+    """Generates Network entities from the org profile network specs."""
+
+    GENERATES = EntityType.NETWORK
+
+    def generate(self, count: int, context: GenerationContext) -> list[Network]:
+        faker = context.faker
+        profile = context.profile
+        networks: list[Network] = []
+
+        for spec in profile.network_specs:
+            cidr_parts = spec.cidr.split("/")
+            base_ip = cidr_parts[0]
+            gateway = base_ip.rsplit(".", 1)[0] + ".1"
+
+            network = Network(
+                name=spec.name,
+                description=f"{spec.name} network ({spec.zone} zone)",
+                cidr=spec.cidr,
+                zone=spec.zone,
+                vlan_id=faker.random_int(min=10, max=4094),
+                gateway=gateway,
+                dns_servers=[faker.ipv4_private(), faker.ipv4_private()],
+                is_monitored=spec.zone != "guest",
+                tags=[spec.zone],
+            )
+            networks.append(network)
+
+        context.store(EntityType.NETWORK, networks)
+        return networks

--- a/src/hc_enterprise_kg/synthetic/generators/people.py
+++ b/src/hc_enterprise_kg/synthetic/generators/people.py
@@ -1,0 +1,45 @@
+"""Generator for Person entities."""
+
+from __future__ import annotations
+
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.domain.entities.person import Person
+from hc_enterprise_kg.synthetic.base import AbstractGenerator, GenerationContext, GeneratorRegistry
+
+
+@GeneratorRegistry.register
+class PeopleGenerator(AbstractGenerator):
+    """Generates Person entities based on the org profile."""
+
+    GENERATES = EntityType.PERSON
+
+    def generate(self, count: int, context: GenerationContext) -> list[Person]:
+        faker = context.faker
+        profile = context.profile
+        people: list[Person] = []
+        domain = profile.name.lower().replace(" ", "") + ".com"
+
+        clearance_levels = ["none", "basic", "elevated", "privileged", "admin"]
+
+        for i in range(count):
+            first = faker.first_name()
+            last = faker.last_name()
+            is_contractor = (i / max(count, 1)) > (1 - profile.contractor_fraction)
+
+            person = Person(
+                first_name=first,
+                last_name=last,
+                name=f"{first} {last}",
+                email=f"{first.lower()}.{last.lower()}@{domain}",
+                title=faker.job(),
+                employee_id=f"EMP-{faker.unique.random_number(digits=6):06d}",
+                clearance_level=faker.random_element(clearance_levels),
+                is_active=faker.boolean(chance_of_getting_true=95),
+                hire_date=str(faker.date_between(start_date="-10y", end_date="today")),
+                phone=faker.phone_number(),
+                tags=["contractor"] if is_contractor else ["employee"],
+            )
+            people.append(person)
+
+        context.store(EntityType.PERSON, people)
+        return people

--- a/src/hc_enterprise_kg/synthetic/generators/policies.py
+++ b/src/hc_enterprise_kg/synthetic/generators/policies.py
@@ -1,0 +1,61 @@
+"""Generator for Policy entities."""
+
+from __future__ import annotations
+
+import random
+
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.domain.entities.policy import Policy
+from hc_enterprise_kg.synthetic.base import AbstractGenerator, GenerationContext, GeneratorRegistry
+
+POLICY_TEMPLATES = [
+    ("Access Control Policy", "access_control", "NIST", "AC-1"),
+    ("Data Classification Policy", "data_protection", "ISO27001", "A.8.2"),
+    ("Incident Response Plan", "incident_response", "NIST", "IR-1"),
+    ("Acceptable Use Policy", "acceptable_use", "CIS", "CIS-1.1"),
+    ("Password Policy", "authentication", "NIST", "IA-5"),
+    ("Network Security Policy", "network_security", "ISO27001", "A.13.1"),
+    ("Encryption Policy", "encryption", "PCI-DSS", "3.4"),
+    ("Remote Access Policy", "remote_access", "NIST", "AC-17"),
+    ("Change Management Policy", "change_management", "ITIL", "CHG-1"),
+    ("Backup and Recovery Policy", "backup", "ISO27001", "A.12.3"),
+    ("Third-Party Risk Policy", "vendor_management", "SOC2", "CC9.2"),
+    ("Data Retention Policy", "data_retention", "GDPR", "Art-5"),
+    ("Physical Security Policy", "physical_security", "ISO27001", "A.11.1"),
+    ("Security Awareness Training", "training", "NIST", "AT-2"),
+    ("Vulnerability Management Policy", "vulnerability_management", "NIST", "RA-5"),
+    ("Business Continuity Plan", "business_continuity", "ISO22301", "BC-1"),
+    ("Privacy Policy", "privacy", "GDPR", "Art-13"),
+    ("Mobile Device Policy", "mobile_security", "CIS", "CIS-5.1"),
+    ("Cloud Security Policy", "cloud_security", "CSA", "CCM-1"),
+    ("Logging and Monitoring Policy", "monitoring", "NIST", "AU-2"),
+]
+
+
+@GeneratorRegistry.register
+class PolicyGenerator(AbstractGenerator):
+    """Generates Policy entities."""
+
+    GENERATES = EntityType.POLICY
+
+    def generate(self, count: int, context: GenerationContext) -> list[Policy]:
+        faker = context.faker
+        policies: list[Policy] = []
+
+        templates = POLICY_TEMPLATES[:count] if count <= len(POLICY_TEMPLATES) else POLICY_TEMPLATES
+        for name, ptype, framework, control_id in templates:
+            policy = Policy(
+                name=name,
+                description=faker.sentence(nb_words=15),
+                policy_type=ptype,
+                framework=framework,
+                control_id=control_id,
+                severity=random.choice(["low", "medium", "high", "critical"]),
+                is_enforced=random.random() < 0.85,
+                review_frequency_days=random.choice([90, 180, 365]),
+                tags=[framework.lower()],
+            )
+            policies.append(policy)
+
+        context.store(EntityType.POLICY, policies)
+        return policies

--- a/src/hc_enterprise_kg/synthetic/generators/roles.py
+++ b/src/hc_enterprise_kg/synthetic/generators/roles.py
@@ -1,0 +1,63 @@
+"""Generator for Role entities."""
+
+from __future__ import annotations
+
+import random
+
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.domain.entities.role import Role
+from hc_enterprise_kg.synthetic.base import AbstractGenerator, GenerationContext, GeneratorRegistry
+
+ROLE_TEMPLATES = {
+    "Engineering": ["Software Engineer", "Senior Engineer", "Tech Lead", "DevOps Engineer", "QA Engineer"],
+    "Product": ["Product Manager", "Product Analyst", "UX Designer"],
+    "Sales": ["Account Executive", "Sales Manager", "SDR"],
+    "Marketing": ["Marketing Manager", "Content Strategist", "Growth Analyst"],
+    "HR": ["HR Generalist", "Recruiter", "HR Manager"],
+    "Finance": ["Financial Analyst", "Controller", "Accountant"],
+    "Legal": ["Legal Counsel", "Paralegal", "Compliance Analyst"],
+    "IT Operations": ["System Administrator", "Network Engineer", "Help Desk Analyst", "DBA"],
+    "Security": ["Security Analyst", "Security Engineer", "SOC Analyst", "CISO"],
+    "Executive": ["CEO", "CTO", "CFO", "COO"],
+}
+
+ACCESS_LEVELS = ["standard", "elevated", "privileged", "admin"]
+PERMISSIONS = [
+    "read:internal", "write:internal", "read:confidential", "write:confidential",
+    "admin:systems", "admin:users", "deploy:production", "access:vpn",
+    "manage:budgets", "approve:changes",
+]
+
+
+@GeneratorRegistry.register
+class RoleGenerator(AbstractGenerator):
+    """Generates Role entities based on department specs."""
+
+    GENERATES = EntityType.ROLE
+
+    def generate(self, count: int, context: GenerationContext) -> list[Role]:
+        departments = context.get_entities(EntityType.DEPARTMENT)
+        roles: list[Role] = []
+
+        for dept in departments:
+            dept_roles = ROLE_TEMPLATES.get(dept.name, ["Analyst", "Manager", "Director"])
+            for role_name in dept_roles:
+                is_privileged = any(
+                    kw in role_name.lower()
+                    for kw in ["admin", "lead", "manager", "director", "ciso", "cto", "ceo", "cfo", "coo"]
+                )
+                access = "privileged" if is_privileged else random.choice(ACCESS_LEVELS[:2])
+
+                role = Role(
+                    name=role_name,
+                    description=f"{role_name} role in {dept.name}",
+                    department_id=dept.id,
+                    access_level=access,
+                    is_privileged=is_privileged,
+                    permissions=random.sample(PERMISSIONS, k=random.randint(2, 5)),
+                    tags=[dept.name.lower().replace(" ", "_")],
+                )
+                roles.append(role)
+
+        context.store(EntityType.ROLE, roles)
+        return roles

--- a/src/hc_enterprise_kg/synthetic/generators/security.py
+++ b/src/hc_enterprise_kg/synthetic/generators/security.py
@@ -1,0 +1,107 @@
+"""Generators for Vulnerability and ThreatActor entities."""
+
+from __future__ import annotations
+
+import random
+
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.domain.entities.threat_actor import ThreatActor
+from hc_enterprise_kg.domain.entities.vulnerability import Vulnerability
+from hc_enterprise_kg.synthetic.base import AbstractGenerator, GenerationContext, GeneratorRegistry
+
+VULN_TYPES = [
+    "SQL Injection", "Cross-Site Scripting", "Buffer Overflow",
+    "Remote Code Execution", "Privilege Escalation", "Authentication Bypass",
+    "Information Disclosure", "Denial of Service", "Path Traversal",
+    "Insecure Deserialization", "SSRF", "Broken Access Control",
+]
+
+SEVERITIES = ["low", "medium", "high", "critical"]
+CVSS_RANGES = {"low": (0.1, 3.9), "medium": (4.0, 6.9), "high": (7.0, 8.9), "critical": (9.0, 10.0)}
+
+THREAT_ACTOR_TYPES = ["nation_state", "cybercriminal", "hacktivist", "insider", "apt"]
+MOTIVATIONS = ["financial", "espionage", "disruption", "ideological", "retaliation"]
+SOPHISTICATION = ["low", "medium", "high", "advanced"]
+
+APT_NAMES = [
+    "Midnight Blizzard", "Cozy Bear", "Fancy Bear", "Lazarus Group",
+    "Equation Group", "Shadow Brokers", "DarkSide", "REvil",
+    "Sandworm", "Turla", "Kimsuky", "Charming Kitten",
+]
+
+TTPS = [
+    "T1566-Phishing", "T1059-Command Scripting", "T1078-Valid Accounts",
+    "T1021-Remote Services", "T1071-Application Layer Protocol",
+    "T1486-Data Encrypted for Impact", "T1053-Scheduled Task",
+    "T1027-Obfuscated Files", "T1105-Ingress Tool Transfer",
+    "T1070-Indicator Removal", "T1218-System Binary Proxy Execution",
+]
+
+
+@GeneratorRegistry.register
+class VulnerabilityGenerator(AbstractGenerator):
+    """Generates Vulnerability entities."""
+
+    GENERATES = EntityType.VULNERABILITY
+
+    def generate(self, count: int, context: GenerationContext) -> list[Vulnerability]:
+        faker = context.faker
+        vulns: list[Vulnerability] = []
+
+        for _ in range(count):
+            severity = random.choice(SEVERITIES)
+            cvss_min, cvss_max = CVSS_RANGES[severity]
+
+            vuln = Vulnerability(
+                name=random.choice(VULN_TYPES),
+                description=faker.sentence(nb_words=12),
+                cve_id=f"CVE-{random.randint(2020, 2025)}-{random.randint(10000, 99999)}",
+                cvss_score=round(random.uniform(cvss_min, cvss_max), 1),
+                severity=severity,
+                status=random.choice(["open", "mitigated", "accepted", "resolved"]),
+                exploit_available=random.random() < 0.3,
+                patch_available=random.random() < 0.6,
+                affected_component=faker.word(),
+                discovery_date=str(faker.date_between(start_date="-2y", end_date="today")),
+                tags=[severity],
+            )
+            vulns.append(vuln)
+
+        context.store(EntityType.VULNERABILITY, vulns)
+        return vulns
+
+
+@GeneratorRegistry.register
+class ThreatActorGenerator(AbstractGenerator):
+    """Generates ThreatActor entities."""
+
+    GENERATES = EntityType.THREAT_ACTOR
+
+    def generate(self, count: int, context: GenerationContext) -> list[ThreatActor]:
+        faker = context.faker
+        actors: list[ThreatActor] = []
+
+        for i in range(count):
+            actor_name = APT_NAMES[i] if i < len(APT_NAMES) else f"APT-{faker.word().title()}"
+
+            actor = ThreatActor(
+                name=actor_name,
+                description=faker.sentence(nb_words=10),
+                actor_type=random.choice(THREAT_ACTOR_TYPES),
+                sophistication=random.choice(SOPHISTICATION),
+                motivation=random.choice(MOTIVATIONS),
+                origin_country=faker.country_code(),
+                first_seen=str(faker.date_between(start_date="-5y", end_date="-1y")),
+                last_seen=str(faker.date_between(start_date="-1y", end_date="today")),
+                aliases=[faker.word().title() for _ in range(random.randint(1, 3))],
+                ttps=random.sample(TTPS, k=random.randint(2, 5)),
+                target_industries=random.sample(
+                    ["technology", "healthcare", "finance", "government", "energy", "defense"],
+                    k=random.randint(1, 3),
+                ),
+                tags=[random.choice(THREAT_ACTOR_TYPES)],
+            )
+            actors.append(actor)
+
+        context.store(EntityType.THREAT_ACTOR, actors)
+        return actors

--- a/src/hc_enterprise_kg/synthetic/generators/systems.py
+++ b/src/hc_enterprise_kg/synthetic/generators/systems.py
@@ -1,0 +1,66 @@
+"""Generator for System entities."""
+
+from __future__ import annotations
+
+import random
+
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.domain.entities.system import System
+from hc_enterprise_kg.synthetic.base import AbstractGenerator, GenerationContext, GeneratorRegistry
+
+SYSTEM_TYPES = ["server", "application", "database", "saas", "workstation", "appliance", "vm"]
+OS_CHOICES = ["Linux", "Windows Server 2022", "Ubuntu 22.04", "RHEL 9", "Windows 11", "macOS"]
+ENVIRONMENTS = ["production", "staging", "development", "test", "dr"]
+CRITICALITY = ["low", "medium", "high", "critical"]
+TECH_STACKS = [
+    ["python", "django", "postgresql"],
+    ["java", "spring", "mysql"],
+    ["node", "react", "mongodb"],
+    ["go", "grpc", "redis"],
+    [".net", "sql-server", "iis"],
+    ["ruby", "rails", "postgresql"],
+]
+APP_NAMES = [
+    "ERP System", "CRM Platform", "HR Portal", "Email Server", "File Server",
+    "Database Server", "Web Application", "API Gateway", "Load Balancer",
+    "DNS Server", "LDAP/AD Server", "Monitoring System", "Log Aggregator",
+    "CI/CD Pipeline", "Code Repository", "Wiki/Docs", "Chat Platform",
+    "VPN Gateway", "Firewall", "IDS/IPS", "SIEM", "Backup Server",
+    "Data Warehouse", "Analytics Platform", "SSO Provider",
+]
+
+
+@GeneratorRegistry.register
+class SystemGenerator(AbstractGenerator):
+    """Generates System entities."""
+
+    GENERATES = EntityType.SYSTEM
+
+    def generate(self, count: int, context: GenerationContext) -> list[System]:
+        faker = context.faker
+        systems: list[System] = []
+
+        for i in range(count):
+            sys_type = random.choice(SYSTEM_TYPES)
+            hostname = f"{faker.word()}-{sys_type[:3]}-{i:03d}"
+            app_name = random.choice(APP_NAMES) if i < len(APP_NAMES) else f"{faker.word().title()} Service"
+
+            system = System(
+                name=app_name,
+                description=f"{app_name} ({sys_type})",
+                system_type=sys_type,
+                hostname=hostname,
+                ip_address=faker.ipv4_private(),
+                os=random.choice(OS_CHOICES),
+                version=f"{random.randint(1, 12)}.{random.randint(0, 9)}.{random.randint(0, 20)}",
+                environment=random.choice(ENVIRONMENTS),
+                criticality=random.choice(CRITICALITY),
+                is_internet_facing=random.random() < 0.2,
+                ports=random.sample([22, 80, 443, 3306, 5432, 8080, 8443, 6379, 27017], k=random.randint(1, 4)),
+                technologies=random.choice(TECH_STACKS),
+                tags=[sys_type],
+            )
+            systems.append(system)
+
+        context.store(EntityType.SYSTEM, systems)
+        return systems

--- a/src/hc_enterprise_kg/synthetic/generators/vendors.py
+++ b/src/hc_enterprise_kg/synthetic/generators/vendors.py
@@ -1,0 +1,53 @@
+"""Generator for Vendor entities."""
+
+from __future__ import annotations
+
+import random
+
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.domain.entities.vendor import Vendor
+from hc_enterprise_kg.synthetic.base import AbstractGenerator, GenerationContext, GeneratorRegistry
+
+VENDOR_TYPES = ["saas", "iaas", "consulting", "hardware", "managed_service", "software_license"]
+CERTIFICATIONS = ["SOC2", "ISO27001", "HIPAA", "PCI-DSS", "FedRAMP", "CSA-STAR"]
+RISK_TIERS = ["low", "medium", "high", "critical"]
+
+
+@GeneratorRegistry.register
+class VendorGenerator(AbstractGenerator):
+    """Generates Vendor entities."""
+
+    GENERATES = EntityType.VENDOR
+
+    def generate(self, count: int, context: GenerationContext) -> list[Vendor]:
+        faker = context.faker
+        vendors: list[Vendor] = []
+
+        for _ in range(count):
+            vendor_type = random.choice(VENDOR_TYPES)
+            has_data = random.random() < 0.4
+
+            vendor = Vendor(
+                name=faker.company(),
+                description=f"{vendor_type.replace('_', ' ').title()} provider",
+                vendor_type=vendor_type,
+                contract_value=round(random.uniform(5000, 2000000), 2),
+                risk_tier=random.choice(RISK_TIERS),
+                has_data_access=has_data,
+                data_classification_access=(
+                    random.sample(["public", "internal", "confidential", "restricted"], k=random.randint(1, 2))
+                    if has_data
+                    else []
+                ),
+                compliance_certifications=random.sample(
+                    CERTIFICATIONS, k=random.randint(0, 3)
+                ),
+                contract_expiry=str(faker.date_between(start_date="today", end_date="+3y")),
+                primary_contact=faker.name(),
+                sla_uptime=round(random.uniform(99.0, 99.99), 2),
+                tags=[vendor_type],
+            )
+            vendors.append(vendor)
+
+        context.store(EntityType.VENDOR, vendors)
+        return vendors

--- a/src/hc_enterprise_kg/synthetic/orchestrator.py
+++ b/src/hc_enterprise_kg/synthetic/orchestrator.py
@@ -1,0 +1,106 @@
+"""SyntheticOrchestrator: coordinates full synthetic KG generation from an OrgProfile."""
+
+from __future__ import annotations
+
+import random
+
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.graph.knowledge_graph import KnowledgeGraph
+from hc_enterprise_kg.synthetic.base import GenerationContext, GeneratorRegistry
+
+# Import generators to trigger registration
+import hc_enterprise_kg.synthetic.generators  # noqa: F401
+from hc_enterprise_kg.synthetic.profiles.base_profile import OrgProfile
+from hc_enterprise_kg.synthetic.relationships import RelationshipWeaver
+
+# Generation order matters: some entities reference others
+GENERATION_ORDER: list[tuple[EntityType, str]] = [
+    (EntityType.LOCATION, "location_count"),
+    (EntityType.DEPARTMENT, "_department_count"),
+    (EntityType.ROLE, "_role_count"),
+    (EntityType.PERSON, "employee_count"),
+    (EntityType.NETWORK, "_network_count"),
+    (EntityType.SYSTEM, "system_count_range"),
+    (EntityType.DATA_ASSET, "data_asset_count_range"),
+    (EntityType.POLICY, "policy_count_range"),
+    (EntityType.VENDOR, "vendor_count_range"),
+    (EntityType.VULNERABILITY, "_vuln_count"),
+    (EntityType.THREAT_ACTOR, "threat_actor_count_range"),
+    (EntityType.INCIDENT, "incident_count_range"),
+]
+
+
+class SyntheticOrchestrator:
+    """Coordinates full synthetic KG generation from an OrgProfile.
+
+    Usage:
+        profile = mid_size_tech_company(500)
+        kg = KnowledgeGraph()
+        orchestrator = SyntheticOrchestrator(kg, profile, seed=42)
+        orchestrator.generate()
+    """
+
+    def __init__(
+        self,
+        knowledge_graph: KnowledgeGraph,
+        profile: OrgProfile,
+        seed: int | None = None,
+    ) -> None:
+        self._kg = knowledge_graph
+        self._profile = profile
+        self._context = GenerationContext(profile=profile, seed=seed)
+
+    def generate(self) -> dict[str, int]:
+        """Run the full generation pipeline. Returns counts by entity type."""
+        counts: dict[str, int] = {}
+
+        # Phase 1: Generate all entities in dependency order
+        for entity_type, count_key in GENERATION_ORDER:
+            if not GeneratorRegistry.is_registered(entity_type):
+                continue
+
+            count = self._resolve_count(entity_type, count_key)
+            if count <= 0:
+                continue
+
+            generator_class = GeneratorRegistry.get(entity_type)
+            generator = generator_class()
+            entities = generator.generate(count, self._context)
+
+            self._kg.add_entities_bulk(entities)
+            counts[entity_type.value] = len(entities)
+
+        # Phase 2: Weave relationships
+        weaver = RelationshipWeaver(self._context)
+        relationships = weaver.weave_all()
+        self._kg.add_relationships_bulk(relationships)
+        counts["_relationships"] = len(relationships)
+
+        return counts
+
+    def _resolve_count(self, entity_type: EntityType, count_key: str) -> int:
+        """Resolve the count for an entity type from the profile."""
+        profile = self._profile
+
+        if count_key.startswith("_"):
+            if entity_type == EntityType.DEPARTMENT:
+                return len(profile.department_specs)
+            elif entity_type == EntityType.NETWORK:
+                return len(profile.network_specs) if profile.network_specs else 0
+            elif entity_type == EntityType.ROLE:
+                return 0  # RoleGenerator derives count from departments
+            elif entity_type == EntityType.VULNERABILITY:
+                system_count = len(self._context.get_entities(EntityType.SYSTEM))
+                return max(1, int(system_count * profile.vulnerability_probability))
+            return 0
+
+        value = getattr(profile, count_key, None)
+        if isinstance(value, int):
+            return value
+        if isinstance(value, tuple) and len(value) == 2:
+            return random.randint(value[0], value[1])
+        return 0
+
+    @property
+    def context(self) -> GenerationContext:
+        return self._context

--- a/src/hc_enterprise_kg/synthetic/profiles/__init__.py
+++ b/src/hc_enterprise_kg/synthetic/profiles/__init__.py
@@ -1,0 +1,15 @@
+"""Organizational profiles for synthetic data generation."""
+
+from hc_enterprise_kg.synthetic.profiles.base_profile import DepartmentSpec, NetworkSpec, OrgProfile
+from hc_enterprise_kg.synthetic.profiles.financial_org import financial_org
+from hc_enterprise_kg.synthetic.profiles.healthcare_org import healthcare_org
+from hc_enterprise_kg.synthetic.profiles.tech_company import mid_size_tech_company
+
+__all__ = [
+    "DepartmentSpec",
+    "NetworkSpec",
+    "OrgProfile",
+    "financial_org",
+    "healthcare_org",
+    "mid_size_tech_company",
+]

--- a/src/hc_enterprise_kg/synthetic/profiles/base_profile.py
+++ b/src/hc_enterprise_kg/synthetic/profiles/base_profile.py
@@ -1,0 +1,48 @@
+"""Organizational profile definitions for synthetic data generation."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class DepartmentSpec(BaseModel):
+    """Specification for a department in the org profile."""
+
+    name: str
+    headcount_fraction: float
+    systems_count_range: tuple[int, int] = (2, 10)
+    data_sensitivity: str = "medium"
+
+
+class NetworkSpec(BaseModel):
+    """Specification for network segments."""
+
+    name: str
+    cidr: str
+    zone: str  # dmz, internal, restricted, guest
+
+
+class OrgProfile(BaseModel):
+    """Parameterized description of an organization.
+
+    This drives the synthetic data generation. Different profiles
+    produce different organizational structures.
+    """
+
+    name: str
+    industry: str
+    employee_count: int
+    department_specs: list[DepartmentSpec]
+    location_count: int = 1
+    system_count_range: tuple[int, int] = (20, 100)
+    network_specs: list[NetworkSpec] = Field(default_factory=list)
+    vendor_count_range: tuple[int, int] = (5, 30)
+    data_asset_count_range: tuple[int, int] = (10, 50)
+    policy_count_range: tuple[int, int] = (5, 20)
+    vulnerability_probability: float = 0.15
+    threat_actor_count_range: tuple[int, int] = (2, 8)
+    incident_count_range: tuple[int, int] = (0, 10)
+    contractor_fraction: float = 0.1
+    remote_fraction: float = 0.3
+    simulation_days: int = 365
+    daily_event_probability: float = 0.3

--- a/src/hc_enterprise_kg/synthetic/profiles/financial_org.py
+++ b/src/hc_enterprise_kg/synthetic/profiles/financial_org.py
@@ -1,0 +1,101 @@
+"""Pre-built profile for a financial services organization."""
+
+from __future__ import annotations
+
+from hc_enterprise_kg.synthetic.profiles.base_profile import (
+    DepartmentSpec,
+    NetworkSpec,
+    OrgProfile,
+)
+
+
+def financial_org(employee_count: int = 1000) -> OrgProfile:
+    """Create an org profile for a financial services organization."""
+    return OrgProfile(
+        name="Atlas Financial Group",
+        industry="financial_services",
+        employee_count=employee_count,
+        department_specs=[
+            DepartmentSpec(
+                name="Trading",
+                headcount_fraction=0.15,
+                systems_count_range=(10, 30),
+                data_sensitivity="critical",
+            ),
+            DepartmentSpec(
+                name="Risk Management",
+                headcount_fraction=0.10,
+                systems_count_range=(8, 20),
+                data_sensitivity="critical",
+            ),
+            DepartmentSpec(
+                name="Technology",
+                headcount_fraction=0.20,
+                systems_count_range=(20, 50),
+                data_sensitivity="high",
+            ),
+            DepartmentSpec(
+                name="Compliance & Legal",
+                headcount_fraction=0.08,
+                systems_count_range=(5, 15),
+                data_sensitivity="critical",
+            ),
+            DepartmentSpec(
+                name="Operations",
+                headcount_fraction=0.12,
+                systems_count_range=(10, 25),
+                data_sensitivity="high",
+            ),
+            DepartmentSpec(
+                name="Client Services",
+                headcount_fraction=0.10,
+                systems_count_range=(5, 15),
+                data_sensitivity="high",
+            ),
+            DepartmentSpec(
+                name="Finance & Accounting",
+                headcount_fraction=0.06,
+                systems_count_range=(5, 12),
+                data_sensitivity="critical",
+            ),
+            DepartmentSpec(
+                name="HR",
+                headcount_fraction=0.04,
+                data_sensitivity="high",
+            ),
+            DepartmentSpec(
+                name="Information Security",
+                headcount_fraction=0.08,
+                systems_count_range=(10, 25),
+                data_sensitivity="critical",
+            ),
+            DepartmentSpec(
+                name="Executive",
+                headcount_fraction=0.03,
+                data_sensitivity="critical",
+            ),
+            DepartmentSpec(
+                name="Internal Audit",
+                headcount_fraction=0.04,
+                systems_count_range=(3, 8),
+                data_sensitivity="critical",
+            ),
+        ],
+        location_count=4,
+        system_count_range=(60, 200),
+        network_specs=[
+            NetworkSpec(name="Trading Floor", cidr="10.0.0.0/24", zone="restricted"),
+            NetworkSpec(name="Corporate", cidr="10.1.0.0/16", zone="internal"),
+            NetworkSpec(name="DMZ", cidr="172.16.0.0/24", zone="dmz"),
+            NetworkSpec(name="DR Site", cidr="10.2.0.0/16", zone="internal"),
+            NetworkSpec(name="Guest", cidr="192.168.0.0/24", zone="guest"),
+        ],
+        vendor_count_range=(15, 50),
+        data_asset_count_range=(25, 80),
+        policy_count_range=(20, 50),
+        vulnerability_probability=0.12,
+        threat_actor_count_range=(5, 15),
+        incident_count_range=(1, 12),
+        contractor_fraction=0.20,
+        remote_fraction=0.25,
+    )

--- a/src/hc_enterprise_kg/synthetic/profiles/healthcare_org.py
+++ b/src/hc_enterprise_kg/synthetic/profiles/healthcare_org.py
@@ -1,0 +1,94 @@
+"""Pre-built profile for a healthcare organization."""
+
+from __future__ import annotations
+
+from hc_enterprise_kg.synthetic.profiles.base_profile import (
+    DepartmentSpec,
+    NetworkSpec,
+    OrgProfile,
+)
+
+
+def healthcare_org(employee_count: int = 2000) -> OrgProfile:
+    """Create an org profile for a healthcare organization."""
+    return OrgProfile(
+        name="MedCare Health Systems",
+        industry="healthcare",
+        employee_count=employee_count,
+        department_specs=[
+            DepartmentSpec(
+                name="Clinical Operations",
+                headcount_fraction=0.40,
+                systems_count_range=(20, 50),
+                data_sensitivity="critical",
+            ),
+            DepartmentSpec(
+                name="Nursing",
+                headcount_fraction=0.15,
+                systems_count_range=(5, 15),
+                data_sensitivity="critical",
+            ),
+            DepartmentSpec(
+                name="Administration",
+                headcount_fraction=0.08,
+                systems_count_range=(5, 10),
+            ),
+            DepartmentSpec(
+                name="IT",
+                headcount_fraction=0.06,
+                systems_count_range=(15, 40),
+                data_sensitivity="high",
+            ),
+            DepartmentSpec(
+                name="Finance & Billing",
+                headcount_fraction=0.07,
+                systems_count_range=(8, 20),
+                data_sensitivity="critical",
+            ),
+            DepartmentSpec(
+                name="Pharmacy",
+                headcount_fraction=0.05,
+                systems_count_range=(5, 12),
+                data_sensitivity="critical",
+            ),
+            DepartmentSpec(
+                name="Research",
+                headcount_fraction=0.06,
+                systems_count_range=(8, 20),
+                data_sensitivity="high",
+            ),
+            DepartmentSpec(
+                name="Compliance",
+                headcount_fraction=0.04,
+                systems_count_range=(3, 8),
+                data_sensitivity="critical",
+            ),
+            DepartmentSpec(
+                name="HR",
+                headcount_fraction=0.04,
+                data_sensitivity="high",
+            ),
+            DepartmentSpec(
+                name="Facilities",
+                headcount_fraction=0.05,
+                systems_count_range=(3, 8),
+            ),
+        ],
+        location_count=5,
+        system_count_range=(80, 250),
+        network_specs=[
+            NetworkSpec(name="Clinical Network", cidr="10.0.0.0/16", zone="restricted"),
+            NetworkSpec(name="Administrative", cidr="10.1.0.0/16", zone="internal"),
+            NetworkSpec(name="Medical Devices", cidr="10.2.0.0/24", zone="restricted"),
+            NetworkSpec(name="Guest WiFi", cidr="192.168.0.0/24", zone="guest"),
+            NetworkSpec(name="DMZ", cidr="172.16.0.0/24", zone="dmz"),
+        ],
+        vendor_count_range=(20, 60),
+        data_asset_count_range=(30, 100),
+        policy_count_range=(15, 40),
+        vulnerability_probability=0.18,
+        threat_actor_count_range=(3, 12),
+        incident_count_range=(2, 15),
+        contractor_fraction=0.15,
+        remote_fraction=0.10,
+    )

--- a/src/hc_enterprise_kg/synthetic/profiles/tech_company.py
+++ b/src/hc_enterprise_kg/synthetic/profiles/tech_company.py
@@ -1,0 +1,87 @@
+"""Pre-built profile for a mid-size technology company."""
+
+from __future__ import annotations
+
+from hc_enterprise_kg.synthetic.profiles.base_profile import (
+    DepartmentSpec,
+    NetworkSpec,
+    OrgProfile,
+)
+
+
+def mid_size_tech_company(employee_count: int = 500) -> OrgProfile:
+    """Create an org profile for a mid-size technology company."""
+    return OrgProfile(
+        name="Acme Technologies",
+        industry="technology",
+        employee_count=employee_count,
+        department_specs=[
+            DepartmentSpec(
+                name="Engineering",
+                headcount_fraction=0.35,
+                systems_count_range=(10, 30),
+                data_sensitivity="high",
+            ),
+            DepartmentSpec(
+                name="Product",
+                headcount_fraction=0.10,
+                systems_count_range=(3, 8),
+            ),
+            DepartmentSpec(
+                name="Sales",
+                headcount_fraction=0.15,
+                systems_count_range=(5, 12),
+            ),
+            DepartmentSpec(
+                name="Marketing",
+                headcount_fraction=0.08,
+                systems_count_range=(4, 10),
+            ),
+            DepartmentSpec(
+                name="HR",
+                headcount_fraction=0.05,
+                data_sensitivity="critical",
+            ),
+            DepartmentSpec(
+                name="Finance",
+                headcount_fraction=0.05,
+                data_sensitivity="critical",
+            ),
+            DepartmentSpec(
+                name="Legal",
+                headcount_fraction=0.03,
+                data_sensitivity="high",
+            ),
+            DepartmentSpec(
+                name="IT Operations",
+                headcount_fraction=0.10,
+                systems_count_range=(15, 40),
+                data_sensitivity="high",
+            ),
+            DepartmentSpec(
+                name="Security",
+                headcount_fraction=0.05,
+                systems_count_range=(5, 15),
+                data_sensitivity="critical",
+            ),
+            DepartmentSpec(
+                name="Executive",
+                headcount_fraction=0.04,
+                data_sensitivity="critical",
+            ),
+        ],
+        location_count=3,
+        system_count_range=(40, 120),
+        network_specs=[
+            NetworkSpec(name="Corporate", cidr="10.0.0.0/16", zone="internal"),
+            NetworkSpec(name="DMZ", cidr="172.16.0.0/24", zone="dmz"),
+            NetworkSpec(name="Dev/Staging", cidr="10.1.0.0/16", zone="internal"),
+            NetworkSpec(name="Guest WiFi", cidr="192.168.0.0/24", zone="guest"),
+        ],
+        vendor_count_range=(10, 40),
+        data_asset_count_range=(15, 60),
+        policy_count_range=(8, 25),
+        vulnerability_probability=0.20,
+        threat_actor_count_range=(3, 10),
+        incident_count_range=(1, 8),
+    )

--- a/src/hc_enterprise_kg/synthetic/relationships.py
+++ b/src/hc_enterprise_kg/synthetic/relationships.py
@@ -1,0 +1,334 @@
+"""RelationshipWeaver: creates realistic relationships between generated entities."""
+
+from __future__ import annotations
+
+import random
+
+from hc_enterprise_kg.domain.base import BaseRelationship, EntityType, RelationshipType
+from hc_enterprise_kg.synthetic.base import GenerationContext
+
+
+class RelationshipWeaver:
+    """Creates realistic relationships between generated entities.
+
+    This is where the organizational structure comes together: assigning
+    people to departments, systems to networks, policies to data assets, etc.
+    """
+
+    def __init__(self, context: GenerationContext) -> None:
+        self._ctx = context
+
+    def weave_all(self) -> list[BaseRelationship]:
+        """Generate all relationship types. Returns flat list."""
+        rels: list[BaseRelationship] = []
+        rels.extend(self._assign_people_to_departments())
+        rels.extend(self._create_management_chains())
+        rels.extend(self._assign_people_to_roles())
+        rels.extend(self._assign_systems_to_networks())
+        rels.extend(self._assign_systems_to_departments())
+        rels.extend(self._assign_data_to_systems())
+        rels.extend(self._assign_policies_to_assets())
+        rels.extend(self._assign_vulns_to_systems())
+        rels.extend(self._assign_threats_to_vulns())
+        rels.extend(self._assign_vendors_to_systems())
+        rels.extend(self._assign_locations())
+        return rels
+
+    def _assign_people_to_departments(self) -> list[BaseRelationship]:
+        people = self._ctx.get_entities(EntityType.PERSON)
+        departments = self._ctx.get_entities(EntityType.DEPARTMENT)
+        profile = self._ctx.profile
+        rels: list[BaseRelationship] = []
+
+        if not departments or not people:
+            return rels
+
+        idx = 0
+        for spec, dept in zip(profile.department_specs, departments):
+            count = max(1, int(len(people) * spec.headcount_fraction))
+            for person in people[idx : idx + count]:
+                rels.append(
+                    BaseRelationship(
+                        relationship_type=RelationshipType.WORKS_IN,
+                        source_id=person.id,
+                        target_id=dept.id,
+                    )
+                )
+                person.department_id = dept.id
+            idx += count
+
+        # Assign any remaining people to random departments
+        for person in people[idx:]:
+            dept = random.choice(departments)
+            rels.append(
+                BaseRelationship(
+                    relationship_type=RelationshipType.WORKS_IN,
+                    source_id=person.id,
+                    target_id=dept.id,
+                )
+            )
+            person.department_id = dept.id
+
+        return rels
+
+    def _create_management_chains(self) -> list[BaseRelationship]:
+        people = self._ctx.get_entities(EntityType.PERSON)
+        departments = self._ctx.get_entities(EntityType.DEPARTMENT)
+        rels: list[BaseRelationship] = []
+
+        if not departments or len(people) < 2:
+            return rels
+
+        # For each department, pick a manager from its people
+        dept_people: dict[str, list] = {}
+        for person in people:
+            did = getattr(person, "department_id", None)
+            if did:
+                dept_people.setdefault(did, []).append(person)
+
+        for dept in departments:
+            members = dept_people.get(dept.id, [])
+            if len(members) < 2:
+                continue
+            manager = members[0]
+            dept.head_id = manager.id
+            rels.append(
+                BaseRelationship(
+                    relationship_type=RelationshipType.MANAGES,
+                    source_id=manager.id,
+                    target_id=dept.id,
+                )
+            )
+            for report in members[1:]:
+                rels.append(
+                    BaseRelationship(
+                        relationship_type=RelationshipType.REPORTS_TO,
+                        source_id=report.id,
+                        target_id=manager.id,
+                    )
+                )
+
+        return rels
+
+    def _assign_people_to_roles(self) -> list[BaseRelationship]:
+        people = self._ctx.get_entities(EntityType.PERSON)
+        roles = self._ctx.get_entities(EntityType.ROLE)
+        rels: list[BaseRelationship] = []
+
+        if not roles or not people:
+            return rels
+
+        # Group roles by department
+        dept_roles: dict[str | None, list] = {}
+        for role in roles:
+            did = getattr(role, "department_id", None)
+            dept_roles.setdefault(did, []).append(role)
+
+        for person in people:
+            did = getattr(person, "department_id", None)
+            available = dept_roles.get(did, dept_roles.get(None, []))
+            if available:
+                role = random.choice(available)
+                rels.append(
+                    BaseRelationship(
+                        relationship_type=RelationshipType.HAS_ROLE,
+                        source_id=person.id,
+                        target_id=role.id,
+                    )
+                )
+
+        return rels
+
+    def _assign_systems_to_networks(self) -> list[BaseRelationship]:
+        systems = self._ctx.get_entities(EntityType.SYSTEM)
+        networks = self._ctx.get_entities(EntityType.NETWORK)
+        rels: list[BaseRelationship] = []
+
+        if not networks or not systems:
+            return rels
+
+        for system in systems:
+            network = random.choice(networks)
+            system.network_id = network.id
+            rels.append(
+                BaseRelationship(
+                    relationship_type=RelationshipType.CONNECTS_TO,
+                    source_id=system.id,
+                    target_id=network.id,
+                )
+            )
+
+        # Add some inter-system dependencies
+        for i in range(min(len(systems) // 3, 20)):
+            src, tgt = random.sample(systems, 2)
+            rels.append(
+                BaseRelationship(
+                    relationship_type=RelationshipType.DEPENDS_ON,
+                    source_id=src.id,
+                    target_id=tgt.id,
+                )
+            )
+
+        return rels
+
+    def _assign_systems_to_departments(self) -> list[BaseRelationship]:
+        systems = self._ctx.get_entities(EntityType.SYSTEM)
+        departments = self._ctx.get_entities(EntityType.DEPARTMENT)
+        rels: list[BaseRelationship] = []
+
+        if not departments or not systems:
+            return rels
+
+        for system in systems:
+            dept = random.choice(departments)
+            system.department_id = dept.id
+            rels.append(
+                BaseRelationship(
+                    relationship_type=RelationshipType.RESPONSIBLE_FOR,
+                    source_id=dept.id,
+                    target_id=system.id,
+                )
+            )
+
+        return rels
+
+    def _assign_data_to_systems(self) -> list[BaseRelationship]:
+        data_assets = self._ctx.get_entities(EntityType.DATA_ASSET)
+        systems = self._ctx.get_entities(EntityType.SYSTEM)
+        rels: list[BaseRelationship] = []
+
+        if not systems or not data_assets:
+            return rels
+
+        for asset in data_assets:
+            system = random.choice(systems)
+            asset.system_id = system.id
+            rels.append(
+                BaseRelationship(
+                    relationship_type=RelationshipType.STORES,
+                    source_id=system.id,
+                    target_id=asset.id,
+                )
+            )
+
+        return rels
+
+    def _assign_policies_to_assets(self) -> list[BaseRelationship]:
+        policies = self._ctx.get_entities(EntityType.POLICY)
+        data_assets = self._ctx.get_entities(EntityType.DATA_ASSET)
+        systems = self._ctx.get_entities(EntityType.SYSTEM)
+        rels: list[BaseRelationship] = []
+
+        targets = data_assets + systems
+        if not policies or not targets:
+            return rels
+
+        for policy in policies:
+            governed = random.sample(targets, k=min(random.randint(2, 6), len(targets)))
+            for target in governed:
+                rels.append(
+                    BaseRelationship(
+                        relationship_type=RelationshipType.GOVERNS,
+                        source_id=policy.id,
+                        target_id=target.id,
+                    )
+                )
+
+        return rels
+
+    def _assign_vulns_to_systems(self) -> list[BaseRelationship]:
+        vulns = self._ctx.get_entities(EntityType.VULNERABILITY)
+        systems = self._ctx.get_entities(EntityType.SYSTEM)
+        rels: list[BaseRelationship] = []
+
+        if not systems or not vulns:
+            return rels
+
+        for vuln in vulns:
+            affected = random.sample(systems, k=min(random.randint(1, 3), len(systems)))
+            vuln.affected_system_ids = [s.id for s in affected]
+            for system in affected:
+                rels.append(
+                    BaseRelationship(
+                        relationship_type=RelationshipType.AFFECTS,
+                        source_id=vuln.id,
+                        target_id=system.id,
+                    )
+                )
+
+        return rels
+
+    def _assign_threats_to_vulns(self) -> list[BaseRelationship]:
+        actors = self._ctx.get_entities(EntityType.THREAT_ACTOR)
+        vulns = self._ctx.get_entities(EntityType.VULNERABILITY)
+        rels: list[BaseRelationship] = []
+
+        if not actors or not vulns:
+            return rels
+
+        for actor in actors:
+            targeted_vulns = random.sample(vulns, k=min(random.randint(1, 4), len(vulns)))
+            for vuln in targeted_vulns:
+                rels.append(
+                    BaseRelationship(
+                        relationship_type=RelationshipType.EXPLOITS,
+                        source_id=actor.id,
+                        target_id=vuln.id,
+                    )
+                )
+
+        return rels
+
+    def _assign_vendors_to_systems(self) -> list[BaseRelationship]:
+        vendors = self._ctx.get_entities(EntityType.VENDOR)
+        systems = self._ctx.get_entities(EntityType.SYSTEM)
+        rels: list[BaseRelationship] = []
+
+        if not vendors or not systems:
+            return rels
+
+        for vendor in vendors:
+            supplied = random.sample(systems, k=min(random.randint(1, 3), len(systems)))
+            for system in supplied:
+                rels.append(
+                    BaseRelationship(
+                        relationship_type=RelationshipType.SUPPLIED_BY,
+                        source_id=system.id,
+                        target_id=vendor.id,
+                    )
+                )
+
+        return rels
+
+    def _assign_locations(self) -> list[BaseRelationship]:
+        locations = self._ctx.get_entities(EntityType.LOCATION)
+        departments = self._ctx.get_entities(EntityType.DEPARTMENT)
+        networks = self._ctx.get_entities(EntityType.NETWORK)
+        rels: list[BaseRelationship] = []
+
+        if not locations:
+            return rels
+
+        for dept in departments:
+            loc = random.choice(locations)
+            dept.location_id = loc.id
+            rels.append(
+                BaseRelationship(
+                    relationship_type=RelationshipType.LOCATED_AT,
+                    source_id=dept.id,
+                    target_id=loc.id,
+                )
+            )
+
+        for network in networks:
+            loc = random.choice(locations)
+            network.location_id = loc.id
+            rels.append(
+                BaseRelationship(
+                    relationship_type=RelationshipType.LOCATED_AT,
+                    source_id=network.id,
+                    target_id=loc.id,
+                )
+            )
+
+        return rels


### PR DESCRIPTION
## Summary
- `OrgProfile` base class + 3 pre-built profiles (tech company, healthcare, financial)
- 11 entity generators with realistic data via Faker
- `GeneratorRegistry` with decorator-based plugin registration
- `RelationshipWeaver` for org structure, network topology, security posture
- `SyntheticOrchestrator` coordinating dependency-ordered generation

## Test plan
- [ ] Generate tech company with 100 employees, verify entity counts
- [ ] Verify all relationship types are created
- [ ] Verify seed reproducibility
- [ ] Verify profile parameter ranges are respected