### PR TITLE
Add automatic KG construction pipeline

### DIFF
--- a/src/hc_enterprise_kg/auto/__init__.py
+++ b/src/hc_enterprise_kg/auto/__init__.py
@@ -1,0 +1,12 @@
+"""Automatic knowledge graph construction pipeline."""
+
+from hc_enterprise_kg.auto.base import ExtractionResult, LinkingResult, PipelineResult, ResolutionResult
+from hc_enterprise_kg.auto.pipeline import AutoKGPipeline
+
+__all__ = [
+    "AutoKGPipeline",
+    "ExtractionResult",
+    "LinkingResult",
+    "PipelineResult",
+    "ResolutionResult",
+]

--- a/src/hc_enterprise_kg/auto/base.py
+++ b/src/hc_enterprise_kg/auto/base.py
@@ -1,0 +1,59 @@
+"""Base classes for the automatic KG construction pipeline."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from hc_enterprise_kg.domain.base import BaseEntity, BaseRelationship
+
+
+class PipelineStage(str, Enum):
+    """Stages in the auto KG pipeline."""
+
+    EXTRACT = "extract"
+    LINK = "link"
+    RESOLVE = "resolve"
+    SCORE = "score"
+
+
+@dataclass
+class ExtractionResult:
+    """Result of an extraction stage."""
+
+    entities: list[BaseEntity] = field(default_factory=list)
+    relationships: list[BaseRelationship] = field(default_factory=list)
+    source: str = ""
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class LinkingResult:
+    """Result of a linking stage."""
+
+    relationships: list[BaseRelationship] = field(default_factory=list)
+    link_method: str = ""
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ResolutionResult:
+    """Result of a resolution/dedup stage."""
+
+    merged_entity_ids: list[tuple[str, str]] = field(default_factory=list)  # (kept_id, removed_id)
+    entities: list[BaseEntity] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class PipelineResult:
+    """Overall result of the auto KG pipeline."""
+
+    entities: list[BaseEntity] = field(default_factory=list)
+    relationships: list[BaseRelationship] = field(default_factory=list)
+    extraction_results: list[ExtractionResult] = field(default_factory=list)
+    linking_results: list[LinkingResult] = field(default_factory=list)
+    resolution_result: ResolutionResult | None = None
+    stats: dict[str, Any] = field(default_factory=dict)

--- a/src/hc_enterprise_kg/auto/confidence.py
+++ b/src/hc_enterprise_kg/auto/confidence.py
@@ -1,0 +1,56 @@
+"""Confidence scoring for auto-extracted entities and relationships."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ConfidenceSource(str, Enum):
+    """Source of extraction that determines base confidence."""
+
+    RULE_BASED = "rule_based"
+    CSV_STRUCTURED = "csv_structured"
+    LLM_EXTRACTION = "llm_extraction"
+    HEURISTIC_LINK = "heuristic_link"
+    EMBEDDING_LINK = "embedding_link"
+    USER_PROVIDED = "user_provided"
+
+
+# Base confidence scores by source type
+BASE_CONFIDENCE: dict[ConfidenceSource, float] = {
+    ConfidenceSource.USER_PROVIDED: 1.0,
+    ConfidenceSource.RULE_BASED: 0.95,
+    ConfidenceSource.CSV_STRUCTURED: 0.90,
+    ConfidenceSource.LLM_EXTRACTION: 0.70,
+    ConfidenceSource.HEURISTIC_LINK: 0.75,
+    ConfidenceSource.EMBEDDING_LINK: 0.60,
+}
+
+
+def compute_confidence(
+    source: ConfidenceSource,
+    similarity_score: float | None = None,
+    field_completeness: float = 1.0,
+) -> float:
+    """Compute a confidence score for an extracted entity or relationship.
+
+    Args:
+        source: The extraction method used.
+        similarity_score: Optional similarity score (0-1) from embedding/fuzzy matching.
+        field_completeness: Fraction of expected fields that are populated (0-1).
+
+    Returns:
+        Confidence score between 0.0 and 1.0.
+    """
+    base = BASE_CONFIDENCE.get(source, 0.5)
+
+    if similarity_score is not None:
+        # Blend base confidence with similarity score
+        score = 0.5 * base + 0.5 * similarity_score
+    else:
+        score = base
+
+    # Penalize incomplete entities
+    score *= max(0.5, field_completeness)
+
+    return round(min(1.0, max(0.0, score)), 3)

--- a/src/hc_enterprise_kg/auto/extractors/base.py
+++ b/src/hc_enterprise_kg/auto/extractors/base.py
@@ -1,0 +1,22 @@
+"""Abstract base for entity extractors."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from hc_enterprise_kg.auto.base import ExtractionResult
+
+
+class AbstractExtractor(ABC):
+    """Base class for all entity extractors in the auto KG pipeline."""
+
+    @abstractmethod
+    def extract(self, data: Any, **kwargs: Any) -> ExtractionResult:
+        """Extract entities and relationships from the given data."""
+        ...
+
+    @abstractmethod
+    def can_handle(self, data: Any) -> bool:
+        """Return True if this extractor can process the given data."""
+        ...

--- a/src/hc_enterprise_kg/auto/extractors/csv_extractor.py
+++ b/src/hc_enterprise_kg/auto/extractors/csv_extractor.py
@@ -1,0 +1,110 @@
+"""CSV-based entity extraction using schema inference."""
+
+from __future__ import annotations
+
+import csv
+import io
+import uuid
+from pathlib import Path
+from typing import Any
+
+from hc_enterprise_kg.auto.base import ExtractionResult
+from hc_enterprise_kg.auto.confidence import ConfidenceSource, compute_confidence
+from hc_enterprise_kg.auto.extractors.base import AbstractExtractor
+from hc_enterprise_kg.auto.schema_inference import infer_entity_type, infer_name_field
+from hc_enterprise_kg.domain.base import BaseEntity, EntityType
+from hc_enterprise_kg.domain.registry import EntityRegistry
+
+
+class CSVExtractor(AbstractExtractor):
+    """Extracts entities from CSV data using schema inference or explicit mapping.
+
+    If entity_type is not provided, attempts to infer it from column names.
+    """
+
+    def can_handle(self, data: Any) -> bool:
+        if isinstance(data, (str, Path)):
+            path = Path(data) if isinstance(data, str) else data
+            return path.suffix.lower() == ".csv" or (isinstance(data, str) and "," in data)
+        return False
+
+    def extract(
+        self,
+        data: Any,
+        entity_type: EntityType | None = None,
+        name_field: str | None = None,
+        field_mapping: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> ExtractionResult:
+        """Extract entities from CSV data.
+
+        Args:
+            data: CSV file path or CSV string content.
+            entity_type: Explicit entity type. If None, infers from columns.
+            name_field: Column to use as entity name. If None, infers.
+            field_mapping: Optional mapping of CSV columns to entity attributes.
+        """
+        rows = self._read_csv(data)
+        if not rows:
+            return ExtractionResult(source="csv", errors=["No data rows found"])
+
+        columns = list(rows[0].keys())
+
+        # Infer entity type if not provided
+        if entity_type is None:
+            entity_type = infer_entity_type(columns)
+            if entity_type is None:
+                return ExtractionResult(
+                    source="csv",
+                    errors=[f"Could not infer entity type from columns: {columns}"],
+                )
+
+        # Infer name field if not provided
+        if name_field is None:
+            name_field = infer_name_field(columns)
+
+        confidence = compute_confidence(ConfidenceSource.CSV_STRUCTURED)
+        entities: list[BaseEntity] = []
+        errors: list[str] = []
+
+        EntityRegistry.auto_discover()
+
+        for i, row in enumerate(rows):
+            try:
+                # Build entity attributes
+                attrs: dict[str, Any] = {
+                    "entity_type": entity_type.value,
+                    "name": row.get(name_field, f"Entity-{i}") if name_field else f"Entity-{i}",
+                    "metadata": {"_confidence": confidence, "_source": "csv", "_row": i},
+                }
+
+                # Apply field mapping or pass through
+                if field_mapping:
+                    for csv_col, entity_attr in field_mapping.items():
+                        if csv_col in row and row[csv_col]:
+                            attrs[entity_attr] = row[csv_col]
+                else:
+                    for col, val in row.items():
+                        if val and col != name_field:
+                            attrs[col] = val
+
+                entity_class = EntityRegistry.get(entity_type)
+                entity = entity_class.model_validate(attrs)
+                entities.append(entity)
+            except Exception as e:
+                errors.append(f"Row {i}: {e}")
+
+        return ExtractionResult(entities=entities, source="csv", errors=errors)
+
+    def _read_csv(self, data: Any) -> list[dict[str, str]]:
+        """Read CSV from file path or string."""
+        if isinstance(data, (str, Path)):
+            path = Path(data)
+            if path.exists() and path.is_file():
+                with open(path, newline="") as f:
+                    return list(csv.DictReader(f))
+
+        if isinstance(data, str) and "," in data:
+            return list(csv.DictReader(io.StringIO(data)))
+
+        return []

--- a/src/hc_enterprise_kg/auto/extractors/llm_extractor.py
+++ b/src/hc_enterprise_kg/auto/extractors/llm_extractor.py
@@ -1,0 +1,152 @@
+"""LLM-based entity and relationship extraction."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+from hc_enterprise_kg.auto.base import ExtractionResult
+from hc_enterprise_kg.auto.confidence import ConfidenceSource, compute_confidence
+from hc_enterprise_kg.auto.extractors.base import AbstractExtractor
+from hc_enterprise_kg.domain.base import (
+    BaseEntity,
+    BaseRelationship,
+    EntityType,
+    RelationshipType,
+)
+from hc_enterprise_kg.domain.registry import EntityRegistry
+
+EXTRACTION_PROMPT = """You are an entity and relationship extractor for an enterprise knowledge graph.
+
+Given the following text, extract all entities and relationships you can find.
+
+Entity types: person, department, role, system, network, data_asset, policy, vendor, location, vulnerability, threat_actor, incident
+
+Relationship types: works_in, manages, reports_to, has_role, member_of, hosts, connects_to, depends_on, stores, runs_on, governs, exploits, targets, mitigates, affects, provides_service, located_at, supplied_by, responsible_for
+
+Return a JSON object with this exact structure:
+{
+  "entities": [
+    {"entity_type": "person", "name": "John Doe", "attributes": {"email": "john@example.com", "title": "Engineer"}},
+    ...
+  ],
+  "relationships": [
+    {"type": "works_in", "source_name": "John Doe", "target_name": "Engineering"},
+    ...
+  ]
+}
+
+Only include entities and relationships you are confident about. Do not hallucinate.
+
+TEXT:
+"""
+
+
+class LLMExtractor(AbstractExtractor):
+    """Extracts entities and relationships from unstructured text using an LLM.
+
+    Uses litellm for provider-agnostic API calls (supports OpenAI, Anthropic, local models).
+    """
+
+    def __init__(self, model: str = "gpt-4o-mini", temperature: float = 0.0) -> None:
+        self._model = model
+        self._temperature = temperature
+
+    def can_handle(self, data: Any) -> bool:
+        return isinstance(data, str) and len(data) > 50
+
+    def extract(self, data: Any, **kwargs: Any) -> ExtractionResult:
+        if not isinstance(data, str):
+            return ExtractionResult(source="llm", errors=["Data must be a string"])
+
+        try:
+            from litellm import completion
+        except ImportError:
+            return ExtractionResult(
+                source="llm",
+                errors=["litellm is required for LLM extraction. Install with: pip install litellm"],
+            )
+
+        EntityRegistry.auto_discover()
+
+        try:
+            response = completion(
+                model=self._model,
+                messages=[
+                    {"role": "system", "content": "You extract structured entities from text. Always respond with valid JSON."},
+                    {"role": "user", "content": EXTRACTION_PROMPT + data},
+                ],
+                temperature=self._temperature,
+                response_format={"type": "json_object"},
+            )
+
+            content = response.choices[0].message.content
+            if not content:
+                return ExtractionResult(source="llm", errors=["Empty LLM response"])
+
+            parsed = json.loads(content)
+            return self._parse_llm_response(parsed)
+
+        except Exception as e:
+            return ExtractionResult(source="llm", errors=[f"LLM extraction failed: {e}"])
+
+    def _parse_llm_response(self, parsed: dict[str, Any]) -> ExtractionResult:
+        """Parse LLM JSON response into domain entities and relationships."""
+        entities: list[BaseEntity] = []
+        relationships: list[BaseRelationship] = []
+        errors: list[str] = []
+        confidence = compute_confidence(ConfidenceSource.LLM_EXTRACTION)
+        name_to_id: dict[str, str] = {}
+
+        for raw_entity in parsed.get("entities", []):
+            try:
+                entity_type_str = raw_entity.get("entity_type", "")
+                entity_type = EntityType(entity_type_str)
+                name = raw_entity.get("name", "Unknown")
+                attrs = raw_entity.get("attributes", {})
+
+                entity_id = str(uuid.uuid4())
+                name_to_id[name] = entity_id
+
+                entity_data = {
+                    "id": entity_id,
+                    "entity_type": entity_type.value,
+                    "name": name,
+                    "metadata": {"_confidence": confidence, "_source": "llm"},
+                    **attrs,
+                }
+
+                entity_class = EntityRegistry.get(entity_type)
+                entity = entity_class.model_validate(entity_data)
+                entities.append(entity)
+            except Exception as e:
+                errors.append(f"Entity parse error: {e}")
+
+        for raw_rel in parsed.get("relationships", []):
+            try:
+                rel_type = RelationshipType(raw_rel.get("type", ""))
+                source_name = raw_rel.get("source_name", "")
+                target_name = raw_rel.get("target_name", "")
+
+                source_id = name_to_id.get(source_name)
+                target_id = name_to_id.get(target_name)
+
+                if source_id and target_id:
+                    relationships.append(
+                        BaseRelationship(
+                            relationship_type=rel_type,
+                            source_id=source_id,
+                            target_id=target_id,
+                            confidence=confidence,
+                        )
+                    )
+            except Exception as e:
+                errors.append(f"Relationship parse error: {e}")
+
+        return ExtractionResult(
+            entities=entities,
+            relationships=relationships,
+            source="llm",
+            errors=errors,
+        )

--- a/src/hc_enterprise_kg/auto/extractors/rule_based.py
+++ b/src/hc_enterprise_kg/auto/extractors/rule_based.py
@@ -1,0 +1,111 @@
+"""Rule-based entity extraction using regex patterns."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any
+
+from hc_enterprise_kg.auto.base import ExtractionResult
+from hc_enterprise_kg.auto.confidence import ConfidenceSource, compute_confidence
+from hc_enterprise_kg.auto.extractors.base import AbstractExtractor
+from hc_enterprise_kg.domain.base import BaseEntity, EntityType
+from hc_enterprise_kg.domain.entities.person import Person
+from hc_enterprise_kg.domain.entities.system import System
+from hc_enterprise_kg.domain.entities.vulnerability import Vulnerability
+
+# Compiled patterns for entity detection
+PATTERNS = {
+    "email": re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"),
+    "ipv4": re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b"),
+    "cve": re.compile(r"\bCVE-\d{4}-\d{4,7}\b"),
+    "hostname": re.compile(r"\b[a-z][a-z0-9-]*\.(local|internal|corp|com|net|org)\b", re.IGNORECASE),
+    "cidr": re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}/\d{1,2}\b"),
+}
+
+
+class RuleBasedExtractor(AbstractExtractor):
+    """Extracts entities from text using regex patterns.
+
+    Detects: email addresses (→ Person), IP addresses (→ System),
+    CVE IDs (→ Vulnerability), hostnames (→ System), CIDR ranges (→ Network).
+    """
+
+    def can_handle(self, data: Any) -> bool:
+        return isinstance(data, str) and len(data) > 0
+
+    def extract(self, data: Any, **kwargs: Any) -> ExtractionResult:
+        if not isinstance(data, str):
+            return ExtractionResult(source="rule_based", errors=["Data must be a string"])
+
+        text = data
+        entities: list[BaseEntity] = []
+        seen: set[str] = set()
+        confidence = compute_confidence(ConfidenceSource.RULE_BASED)
+
+        # Extract emails → Person entities
+        for match in PATTERNS["email"].finditer(text):
+            email = match.group()
+            if email in seen:
+                continue
+            seen.add(email)
+            local = email.split("@")[0]
+            parts = re.split(r"[._-]", local)
+            first = parts[0].title() if parts else "Unknown"
+            last = parts[1].title() if len(parts) > 1 else ""
+
+            entities.append(
+                Person(
+                    name=f"{first} {last}".strip(),
+                    first_name=first,
+                    last_name=last,
+                    email=email,
+                    metadata={"_confidence": confidence, "_source": "rule_based"},
+                )
+            )
+
+        # Extract IPs → System entities
+        for match in PATTERNS["ipv4"].finditer(text):
+            ip = match.group()
+            if ip in seen:
+                continue
+            seen.add(ip)
+            entities.append(
+                System(
+                    name=f"System at {ip}",
+                    ip_address=ip,
+                    system_type="unknown",
+                    metadata={"_confidence": confidence, "_source": "rule_based"},
+                )
+            )
+
+        # Extract CVEs → Vulnerability entities
+        for match in PATTERNS["cve"].finditer(text):
+            cve = match.group()
+            if cve in seen:
+                continue
+            seen.add(cve)
+            entities.append(
+                Vulnerability(
+                    name=cve,
+                    cve_id=cve,
+                    metadata={"_confidence": confidence, "_source": "rule_based"},
+                )
+            )
+
+        # Extract hostnames → System entities
+        for match in PATTERNS["hostname"].finditer(text):
+            hostname = match.group()
+            if hostname in seen:
+                continue
+            seen.add(hostname)
+            entities.append(
+                System(
+                    name=hostname,
+                    hostname=hostname,
+                    system_type="unknown",
+                    metadata={"_confidence": confidence, "_source": "rule_based"},
+                )
+            )
+
+        return ExtractionResult(entities=entities, source="rule_based")

--- a/src/hc_enterprise_kg/auto/linkers/base.py
+++ b/src/hc_enterprise_kg/auto/linkers/base.py
@@ -1,0 +1,17 @@
+"""Abstract base for entity linkers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from hc_enterprise_kg.auto.base import LinkingResult
+from hc_enterprise_kg.domain.base import BaseEntity
+
+
+class AbstractLinker(ABC):
+    """Base class for entity linkers that discover relationships."""
+
+    @abstractmethod
+    def link(self, entities: list[BaseEntity]) -> LinkingResult:
+        """Discover and propose relationships between entities."""
+        ...

--- a/src/hc_enterprise_kg/auto/linkers/embedding_linker.py
+++ b/src/hc_enterprise_kg/auto/linkers/embedding_linker.py
@@ -1,0 +1,99 @@
+"""Embedding-based entity linker using sentence-transformers for similarity."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hc_enterprise_kg.auto.base import LinkingResult
+from hc_enterprise_kg.auto.confidence import ConfidenceSource, compute_confidence
+from hc_enterprise_kg.auto.linkers.base import AbstractLinker
+from hc_enterprise_kg.domain.base import BaseEntity, BaseRelationship, RelationshipType
+
+
+class EmbeddingLinker(AbstractLinker):
+    """Links entities by computing embedding similarity on their descriptions.
+
+    Uses sentence-transformers to embed entity name + description, then
+    finds pairs above a cosine similarity threshold and proposes relationships.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "all-MiniLM-L6-v2",
+        similarity_threshold: float = 0.7,
+        relationship_type: RelationshipType = RelationshipType.DEPENDS_ON,
+    ) -> None:
+        self._model_name = model_name
+        self._threshold = similarity_threshold
+        self._rel_type = relationship_type
+        self._model: Any = None
+
+    def _load_model(self) -> Any:
+        if self._model is None:
+            try:
+                from sentence_transformers import SentenceTransformer
+                self._model = SentenceTransformer(self._model_name)
+            except ImportError:
+                raise ImportError(
+                    "sentence-transformers is required for embedding linking. "
+                    "Install with: pip install sentence-transformers"
+                )
+        return self._model
+
+    def link(self, entities: list[BaseEntity]) -> LinkingResult:
+        if len(entities) < 2:
+            return LinkingResult(link_method="embedding")
+
+        try:
+            model = self._load_model()
+        except ImportError as e:
+            return LinkingResult(link_method="embedding", errors=[str(e)])
+
+        # Build text representations
+        texts = [f"{e.name}: {e.description}" for e in entities]
+
+        try:
+            import numpy as np
+
+            # Encode all entities
+            embeddings = model.encode(texts, convert_to_numpy=True, show_progress_bar=False)
+
+            # Normalize for cosine similarity
+            norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+            norms = np.where(norms == 0, 1, norms)
+            normalized = embeddings / norms
+
+            # Compute pairwise cosine similarity
+            similarity_matrix = normalized @ normalized.T
+
+            relationships: list[BaseRelationship] = []
+
+            for i in range(len(entities)):
+                for j in range(i + 1, len(entities)):
+                    sim = float(similarity_matrix[i, j])
+                    if sim >= self._threshold:
+                        # Don't link entities of the same type by default
+                        if entities[i].entity_type == entities[j].entity_type:
+                            continue
+
+                        confidence = compute_confidence(
+                            ConfidenceSource.EMBEDDING_LINK,
+                            similarity_score=sim,
+                        )
+                        relationships.append(
+                            BaseRelationship(
+                                relationship_type=self._rel_type,
+                                source_id=entities[i].id,
+                                target_id=entities[j].id,
+                                confidence=confidence,
+                                properties={
+                                    "_link_method": "embedding_similarity",
+                                    "_similarity_score": round(sim, 4),
+                                },
+                            )
+                        )
+
+            return LinkingResult(relationships=relationships, link_method="embedding")
+
+        except Exception as e:
+            return LinkingResult(link_method="embedding", errors=[f"Embedding linking failed: {e}"])

--- a/src/hc_enterprise_kg/auto/linkers/heuristic_linker.py
+++ b/src/hc_enterprise_kg/auto/linkers/heuristic_linker.py
@@ -1,0 +1,127 @@
+"""Heuristic-based entity linker using fuzzy name matching and FK detection."""
+
+from __future__ import annotations
+
+from rapidfuzz import fuzz
+
+from hc_enterprise_kg.auto.base import LinkingResult
+from hc_enterprise_kg.auto.confidence import ConfidenceSource, compute_confidence
+from hc_enterprise_kg.auto.linkers.base import AbstractLinker
+from hc_enterprise_kg.domain.base import BaseEntity, BaseRelationship, EntityType, RelationshipType
+
+# Heuristic rules for which entity types can be linked
+LINKABLE_PAIRS: list[tuple[EntityType, EntityType, RelationshipType]] = [
+    (EntityType.PERSON, EntityType.DEPARTMENT, RelationshipType.WORKS_IN),
+    (EntityType.SYSTEM, EntityType.NETWORK, RelationshipType.CONNECTS_TO),
+    (EntityType.SYSTEM, EntityType.VENDOR, RelationshipType.SUPPLIED_BY),
+    (EntityType.DATA_ASSET, EntityType.SYSTEM, RelationshipType.STORES),
+    (EntityType.POLICY, EntityType.SYSTEM, RelationshipType.GOVERNS),
+    (EntityType.VULNERABILITY, EntityType.SYSTEM, RelationshipType.AFFECTS),
+    (EntityType.DEPARTMENT, EntityType.LOCATION, RelationshipType.LOCATED_AT),
+]
+
+# Attribute pairs that indicate FK-like relationships
+FK_ATTRIBUTES: list[tuple[str, EntityType]] = [
+    ("department_id", EntityType.DEPARTMENT),
+    ("system_id", EntityType.SYSTEM),
+    ("network_id", EntityType.NETWORK),
+    ("vendor_id", EntityType.VENDOR),
+    ("location_id", EntityType.LOCATION),
+    ("owner_id", EntityType.PERSON),
+    ("head_id", EntityType.PERSON),
+    ("threat_actor_id", EntityType.THREAT_ACTOR),
+]
+
+
+class HeuristicLinker(AbstractLinker):
+    """Links entities using fuzzy name matching and FK attribute detection.
+
+    Two strategies:
+    1. FK detection: If entity A has a `department_id` attribute matching
+       entity B's id, create a relationship.
+    2. Name matching: If entity names match above a threshold using fuzzy
+       string matching, propose a relationship.
+    """
+
+    def __init__(self, name_match_threshold: float = 85.0) -> None:
+        self._threshold = name_match_threshold
+
+    def link(self, entities: list[BaseEntity]) -> LinkingResult:
+        relationships: list[BaseRelationship] = []
+        errors: list[str] = []
+
+        # Index entities by type and by id
+        by_type: dict[EntityType, list[BaseEntity]] = {}
+        by_id: dict[str, BaseEntity] = {}
+        for entity in entities:
+            by_type.setdefault(entity.entity_type, []).append(entity)
+            by_id[entity.id] = entity
+
+        # Strategy 1: FK attribute detection
+        for entity in entities:
+            for attr_name, target_type in FK_ATTRIBUTES:
+                fk_value = getattr(entity, attr_name, None)
+                if fk_value and fk_value in by_id:
+                    target = by_id[fk_value]
+                    rel_type = self._infer_relationship_type(entity.entity_type, target.entity_type)
+                    if rel_type:
+                        confidence = compute_confidence(ConfidenceSource.HEURISTIC_LINK)
+                        relationships.append(
+                            BaseRelationship(
+                                relationship_type=rel_type,
+                                source_id=entity.id,
+                                target_id=target.id,
+                                confidence=confidence,
+                                properties={"_link_method": "fk_detection"},
+                            )
+                        )
+
+        # Strategy 2: Name-based matching for linkable pairs
+        for src_type, tgt_type, rel_type in LINKABLE_PAIRS:
+            sources = by_type.get(src_type, [])
+            targets = by_type.get(tgt_type, [])
+
+            if not sources or not targets:
+                continue
+
+            for src in sources:
+                for tgt in targets:
+                    score = fuzz.token_sort_ratio(src.name, tgt.name)
+                    if score >= self._threshold:
+                        confidence = compute_confidence(
+                            ConfidenceSource.HEURISTIC_LINK,
+                            similarity_score=score / 100.0,
+                        )
+                        relationships.append(
+                            BaseRelationship(
+                                relationship_type=rel_type,
+                                source_id=src.id,
+                                target_id=tgt.id,
+                                confidence=confidence,
+                                properties={
+                                    "_link_method": "name_matching",
+                                    "_match_score": score,
+                                },
+                            )
+                        )
+
+        return LinkingResult(
+            relationships=relationships,
+            link_method="heuristic",
+            errors=errors,
+        )
+
+    def _infer_relationship_type(
+        self, source_type: EntityType, target_type: EntityType
+    ) -> RelationshipType | None:
+        for src_t, tgt_t, rel_t in LINKABLE_PAIRS:
+            if source_type == src_t and target_type == tgt_t:
+                return rel_t
+        # Fallback generic mappings
+        fk_rel_map: dict[tuple[EntityType, EntityType], RelationshipType] = {
+            (EntityType.PERSON, EntityType.DEPARTMENT): RelationshipType.WORKS_IN,
+            (EntityType.PERSON, EntityType.PERSON): RelationshipType.REPORTS_TO,
+            (EntityType.DEPARTMENT, EntityType.PERSON): RelationshipType.MANAGES,
+            (EntityType.DEPARTMENT, EntityType.LOCATION): RelationshipType.LOCATED_AT,
+        }
+        return fk_rel_map.get((source_type, target_type))

--- a/src/hc_enterprise_kg/auto/pipeline.py
+++ b/src/hc_enterprise_kg/auto/pipeline.py
@@ -1,0 +1,171 @@
+"""AutoKGPipeline: orchestrates extract → link → resolve → score pipeline."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hc_enterprise_kg.auto.base import PipelineResult
+from hc_enterprise_kg.auto.extractors.base import AbstractExtractor
+from hc_enterprise_kg.auto.extractors.csv_extractor import CSVExtractor
+from hc_enterprise_kg.auto.extractors.llm_extractor import LLMExtractor
+from hc_enterprise_kg.auto.extractors.rule_based import RuleBasedExtractor
+from hc_enterprise_kg.auto.linkers.base import AbstractLinker
+from hc_enterprise_kg.auto.linkers.embedding_linker import EmbeddingLinker
+from hc_enterprise_kg.auto.linkers.heuristic_linker import HeuristicLinker
+from hc_enterprise_kg.auto.resolvers.base import AbstractResolver
+from hc_enterprise_kg.auto.resolvers.dedup_resolver import DedupResolver
+from hc_enterprise_kg.domain.base import BaseEntity, BaseRelationship
+from hc_enterprise_kg.graph.knowledge_graph import KnowledgeGraph
+
+
+class AutoKGPipeline:
+    """Orchestrates the automatic KG construction pipeline.
+
+    Configurable pipeline that chains:
+    1. Extraction: Convert raw data into entities and relationships
+    2. Linking: Discover additional relationships between extracted entities
+    3. Resolution: Merge/deduplicate overlapping entities
+    4. Load: Insert the final entities and relationships into the KG
+
+    Usage:
+        kg = KnowledgeGraph()
+        pipeline = AutoKGPipeline(kg)
+        result = pipeline.run("path/to/data.csv")
+
+        # Or with custom configuration:
+        pipeline = AutoKGPipeline(
+            kg,
+            extractors=[RuleBasedExtractor(), CSVExtractor()],
+            linkers=[HeuristicLinker()],
+            resolver=DedupResolver(),
+            use_llm=False,
+            use_embeddings=False,
+        )
+    """
+
+    def __init__(
+        self,
+        knowledge_graph: KnowledgeGraph,
+        extractors: list[AbstractExtractor] | None = None,
+        linkers: list[AbstractLinker] | None = None,
+        resolver: AbstractResolver | None = None,
+        use_llm: bool = True,
+        use_embeddings: bool = True,
+        llm_model: str = "gpt-4o-mini",
+    ) -> None:
+        self._kg = knowledge_graph
+
+        # Configure extractors
+        if extractors is not None:
+            self._extractors = extractors
+        else:
+            self._extractors: list[AbstractExtractor] = [
+                RuleBasedExtractor(),
+                CSVExtractor(),
+            ]
+            if use_llm:
+                self._extractors.append(LLMExtractor(model=llm_model))
+
+        # Configure linkers
+        if linkers is not None:
+            self._linkers = linkers
+        else:
+            self._linkers: list[AbstractLinker] = [HeuristicLinker()]
+            if use_embeddings:
+                self._linkers.append(EmbeddingLinker())
+
+        # Configure resolver
+        self._resolver = resolver or DedupResolver()
+
+    def run(self, data: Any, **kwargs: Any) -> PipelineResult:
+        """Run the full auto-KG pipeline on the given data.
+
+        Args:
+            data: Input data (file path, string text, or CSV content).
+            **kwargs: Extra arguments passed to extractors.
+
+        Returns:
+            PipelineResult with all extracted entities, relationships, and stats.
+        """
+        result = PipelineResult()
+        all_entities: list[BaseEntity] = []
+        all_relationships: list[BaseRelationship] = []
+
+        # Stage 1: Extraction
+        for extractor in self._extractors:
+            if extractor.can_handle(data):
+                extraction = extractor.extract(data, **kwargs)
+                result.extraction_results.append(extraction)
+                all_entities.extend(extraction.entities)
+                all_relationships.extend(extraction.relationships)
+
+        if not all_entities:
+            result.stats["status"] = "no_entities_extracted"
+            return result
+
+        # Stage 2: Linking
+        for linker in self._linkers:
+            try:
+                linking = linker.link(all_entities)
+                result.linking_results.append(linking)
+                all_relationships.extend(linking.relationships)
+            except Exception as e:
+                result.linking_results.append(
+                    type(linking)(link_method="error", errors=[str(e)])  # type: ignore[name-defined]
+                )
+
+        # Stage 3: Resolution
+        resolution = self._resolver.resolve(all_entities)
+        result.resolution_result = resolution
+
+        # Use resolved entities (deduplicated)
+        final_entities = resolution.entities if resolution.entities else all_entities
+
+        # Update relationships to point to merged entity IDs
+        id_remap = {removed: kept for kept, removed in resolution.merged_entity_ids}
+        final_relationships: list[BaseRelationship] = []
+        for rel in all_relationships:
+            src = id_remap.get(rel.source_id, rel.source_id)
+            tgt = id_remap.get(rel.target_id, rel.target_id)
+            if src != rel.source_id or tgt != rel.target_id:
+                rel = BaseRelationship(
+                    relationship_type=rel.relationship_type,
+                    source_id=src,
+                    target_id=tgt,
+                    confidence=rel.confidence,
+                    properties=rel.properties,
+                )
+            final_relationships.append(rel)
+
+        # Stage 4: Load into KG
+        entity_ids_in_kg = set()
+        for entity in final_entities:
+            try:
+                self._kg.add_entity(entity)
+                entity_ids_in_kg.add(entity.id)
+            except Exception:
+                pass  # Skip entities that fail validation
+
+        loaded_rels = 0
+        for rel in final_relationships:
+            if rel.source_id in entity_ids_in_kg and rel.target_id in entity_ids_in_kg:
+                try:
+                    self._kg.add_relationship(rel)
+                    loaded_rels += 1
+                except Exception:
+                    pass
+
+        result.entities = final_entities
+        result.relationships = final_relationships
+        result.stats = {
+            "entities_extracted": len(all_entities),
+            "entities_after_dedup": len(final_entities),
+            "duplicates_merged": len(resolution.merged_entity_ids),
+            "relationships_discovered": len(all_relationships),
+            "relationships_after_remap": len(final_relationships),
+            "entities_loaded": len(entity_ids_in_kg),
+            "relationships_loaded": loaded_rels,
+            "status": "complete",
+        }
+
+        return result

--- a/src/hc_enterprise_kg/auto/resolvers/base.py
+++ b/src/hc_enterprise_kg/auto/resolvers/base.py
@@ -1,0 +1,17 @@
+"""Abstract base for entity resolvers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from hc_enterprise_kg.auto.base import ResolutionResult
+from hc_enterprise_kg.domain.base import BaseEntity
+
+
+class AbstractResolver(ABC):
+    """Base class for entity resolvers that merge/deduplicate entities."""
+
+    @abstractmethod
+    def resolve(self, entities: list[BaseEntity]) -> ResolutionResult:
+        """Identify and merge duplicate entities."""
+        ...

--- a/src/hc_enterprise_kg/auto/resolvers/dedup_resolver.py
+++ b/src/hc_enterprise_kg/auto/resolvers/dedup_resolver.py
@@ -1,0 +1,119 @@
+"""Deduplication resolver: merges overlapping entities."""
+
+from __future__ import annotations
+
+from rapidfuzz import fuzz
+
+from hc_enterprise_kg.auto.base import ResolutionResult
+from hc_enterprise_kg.auto.resolvers.base import AbstractResolver
+from hc_enterprise_kg.domain.base import BaseEntity
+
+
+class DedupResolver(AbstractResolver):
+    """Identifies and merges duplicate entities based on name similarity.
+
+    When duplicates are found, the entity with higher confidence (from metadata)
+    is kept and the other is merged into it. If confidence is equal, the
+    entity with more populated fields wins.
+    """
+
+    def __init__(self, name_threshold: float = 90.0) -> None:
+        self._threshold = name_threshold
+
+    def resolve(self, entities: list[BaseEntity]) -> ResolutionResult:
+        if len(entities) < 2:
+            return ResolutionResult(entities=list(entities))
+
+        # Group entities by type for comparison
+        by_type: dict[str, list[BaseEntity]] = {}
+        for entity in entities:
+            by_type.setdefault(entity.entity_type.value, []).append(entity)
+
+        merged_ids: list[tuple[str, str]] = []
+        final_entities: list[BaseEntity] = []
+        removed_ids: set[str] = set()
+
+        for entity_type, group in by_type.items():
+            # Compare all pairs within the same type
+            keep: dict[str, BaseEntity] = {}
+            for entity in group:
+                if entity.id in removed_ids:
+                    continue
+
+                # Check against already-kept entities
+                found_match = False
+                for kept_id, kept_entity in list(keep.items()):
+                    score = fuzz.token_sort_ratio(entity.name, kept_entity.name)
+                    if score >= self._threshold:
+                        # Merge: keep the higher-confidence one
+                        winner, loser = self._pick_winner(kept_entity, entity)
+                        merged = self._merge_entities(winner, loser)
+                        keep[winner.id] = merged
+                        merged_ids.append((winner.id, loser.id))
+                        removed_ids.add(loser.id)
+                        found_match = True
+                        break
+
+                if not found_match:
+                    keep[entity.id] = entity
+
+            final_entities.extend(keep.values())
+
+        return ResolutionResult(
+            merged_entity_ids=merged_ids,
+            entities=final_entities,
+        )
+
+    def _pick_winner(
+        self, a: BaseEntity, b: BaseEntity
+    ) -> tuple[BaseEntity, BaseEntity]:
+        """Pick the entity with higher confidence or more fields populated."""
+        conf_a = a.metadata.get("_confidence", 0.5)
+        conf_b = b.metadata.get("_confidence", 0.5)
+        if conf_a >= conf_b:
+            return a, b
+        return b, a
+
+    def _merge_entities(self, winner: BaseEntity, loser: BaseEntity) -> BaseEntity:
+        """Merge loser's fields into winner where winner has empty/default values."""
+        winner_data = winner.model_dump()
+        loser_data = loser.model_dump()
+
+        for key, loser_val in loser_data.items():
+            if key in ("id", "entity_type", "created_at", "updated_at", "version"):
+                continue
+            winner_val = winner_data.get(key)
+            # Fill empty fields from loser
+            if self._is_empty(winner_val) and not self._is_empty(loser_val):
+                winner_data[key] = loser_val
+
+        # Merge tags
+        winner_tags = set(winner_data.get("tags", []))
+        loser_tags = set(loser_data.get("tags", []))
+        winner_data["tags"] = list(winner_tags | loser_tags)
+
+        # Merge metadata
+        winner_meta = winner_data.get("metadata", {})
+        loser_meta = loser_data.get("metadata", {})
+        for k, v in loser_meta.items():
+            if k not in winner_meta:
+                winner_meta[k] = v
+        winner_data["metadata"] = winner_meta
+        winner_data["metadata"]["_merged_from"] = loser.id
+
+        from hc_enterprise_kg.domain.registry import EntityRegistry
+
+        EntityRegistry.auto_discover()
+        entity_class = EntityRegistry.get(winner.entity_type)
+        return entity_class.model_validate(winner_data)
+
+    def _is_empty(self, value: object) -> bool:
+        if value is None:
+            return True
+        if isinstance(value, str) and value == "":
+            return True
+        if isinstance(value, list) and len(value) == 0:
+            return True
+        if isinstance(value, dict) and len(value) == 0:
+            return True
+        return False

--- a/src/hc_enterprise_kg/auto/schema_inference.py
+++ b/src/hc_enterprise_kg/auto/schema_inference.py
@@ -1,0 +1,100 @@
+"""Schema inference: automatically detect entity types and relationships from raw data."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from hc_enterprise_kg.domain.base import EntityType
+
+# Patterns that hint at entity types based on column names or values
+COLUMN_PATTERNS: dict[EntityType, list[str]] = {
+    EntityType.PERSON: [
+        r"(?i)(first.?name|last.?name|employee|email|hire.?date|title|staff)",
+    ],
+    EntityType.DEPARTMENT: [
+        r"(?i)(department|dept|division|business.?unit|team)",
+    ],
+    EntityType.SYSTEM: [
+        r"(?i)(hostname|ip.?address|server|system|application|service|os|port)",
+    ],
+    EntityType.NETWORK: [
+        r"(?i)(cidr|subnet|vlan|network|gateway|dns)",
+    ],
+    EntityType.VULNERABILITY: [
+        r"(?i)(cve|cvss|vulnerability|vuln|exploit|severity)",
+    ],
+    EntityType.VENDOR: [
+        r"(?i)(vendor|supplier|provider|contractor|sla)",
+    ],
+    EntityType.DATA_ASSET: [
+        r"(?i)(data.?asset|database|dataset|classification|retention|encryption)",
+    ],
+    EntityType.POLICY: [
+        r"(?i)(policy|control|framework|compliance|regulation)",
+    ],
+    EntityType.LOCATION: [
+        r"(?i)(location|address|city|state|country|zip|facility|site)",
+    ],
+    EntityType.THREAT_ACTOR: [
+        r"(?i)(threat.?actor|apt|adversary|attacker|campaign)",
+    ],
+    EntityType.INCIDENT: [
+        r"(?i)(incident|breach|alert|detection|response|forensic)",
+    ],
+}
+
+# Patterns for detecting relationships from column names
+RELATIONSHIP_COLUMN_PATTERNS = [
+    (r"(?i)(department.?id|dept.?id)", "entity_to_department"),
+    (r"(?i)(manager.?id|reports.?to|supervisor)", "person_to_manager"),
+    (r"(?i)(system.?id|host.?id|server.?id)", "entity_to_system"),
+    (r"(?i)(network.?id|subnet.?id|vlan.?id)", "entity_to_network"),
+    (r"(?i)(vendor.?id|supplier.?id)", "entity_to_vendor"),
+    (r"(?i)(location.?id|site.?id)", "entity_to_location"),
+    (r"(?i)(owner.?id|assigned.?to)", "entity_to_person"),
+]
+
+
+def infer_entity_type(columns: list[str]) -> EntityType | None:
+    """Infer the most likely entity type from a list of column names.
+
+    Returns the entity type with the most pattern matches, or None if
+    no strong match is found.
+    """
+    scores: dict[EntityType, int] = {}
+    for entity_type, patterns in COLUMN_PATTERNS.items():
+        score = 0
+        for pattern in patterns:
+            for col in columns:
+                if re.search(pattern, col):
+                    score += 1
+        if score > 0:
+            scores[entity_type] = score
+
+    if not scores:
+        return None
+    return max(scores, key=scores.get)  # type: ignore[arg-type]
+
+
+def infer_relationships(columns: list[str]) -> list[tuple[str, str]]:
+    """Detect potential relationship columns from column names.
+
+    Returns list of (column_name, relationship_hint) tuples.
+    """
+    results: list[tuple[str, str]] = []
+    for pattern, hint in RELATIONSHIP_COLUMN_PATTERNS:
+        for col in columns:
+            if re.search(pattern, col):
+                results.append((col, hint))
+    return results
+
+
+def infer_name_field(columns: list[str]) -> str | None:
+    """Guess which column is the entity name field."""
+    name_patterns = [r"(?i)^name$", r"(?i)(full.?name|display.?name)", r"(?i)(title|label|hostname)"]
+    for pattern in name_patterns:
+        for col in columns:
+            if re.search(pattern, col):
+                return col
+    return columns[0] if columns else None


### PR DESCRIPTION
## Summary
- `AutoKGPipeline` orchestrator: extract → link → resolve → load
- **Extractors**: rule-based (regex for IPs/emails/CVEs), CSV (schema inference), LLM (via litellm)
- **Linkers**: heuristic (fuzzy matching + FK detection), embedding (sentence-transformers cosine similarity)
- **Resolvers**: dedup (merge overlapping entities, confidence-based winner selection)
- Confidence scoring with source-based base scores
- Schema inference for auto-detecting entity types from column names

## Test plan
- [ ] Rule-based extraction finds IPs, emails, CVEs from text
- [ ] CSV extraction infers entity types from column names
- [ ] Heuristic linker creates FK-based and name-matched relationships
- [ ] Dedup resolver merges entities above name similarity threshold
- [ ] Full pipeline: text → entities → relationships → KG