### PR TITLE
Add ingest, export, and analysis modules

### DIFF
--- a/src/hc_enterprise_kg/analysis/__init__.py
+++ b/src/hc_enterprise_kg/analysis/__init__.py
@@ -1,0 +1,1 @@
+"""Analysis and metrics for the knowledge graph."""

--- a/src/hc_enterprise_kg/analysis/metrics.py
+++ b/src/hc_enterprise_kg/analysis/metrics.py
@@ -1,0 +1,97 @@
+"""Graph metrics and analysis for the enterprise knowledge graph."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import networkx as nx
+
+from hc_enterprise_kg.graph.knowledge_graph import KnowledgeGraph
+
+
+def compute_centrality(kg: KnowledgeGraph) -> dict[str, float]:
+    """Compute degree centrality for all entities."""
+    g = kg.engine.get_native_graph()
+    return nx.degree_centrality(g)
+
+
+def compute_betweenness_centrality(kg: KnowledgeGraph) -> dict[str, float]:
+    """Compute betweenness centrality for all entities."""
+    g = kg.engine.get_native_graph()
+    return nx.betweenness_centrality(g)
+
+
+def compute_pagerank(kg: KnowledgeGraph) -> dict[str, float]:
+    """Compute PageRank for all entities."""
+    g = kg.engine.get_native_graph()
+    return nx.pagerank(g)
+
+
+def find_most_connected(kg: KnowledgeGraph, top_n: int = 10) -> list[tuple[str, int]]:
+    """Find the top N most connected entities by degree."""
+    g = kg.engine.get_native_graph()
+    degrees = sorted(g.degree(), key=lambda x: x[1], reverse=True)
+    return degrees[:top_n]
+
+
+def compute_clustering_coefficient(kg: KnowledgeGraph) -> float:
+    """Compute average clustering coefficient (undirected projection)."""
+    g = kg.engine.get_native_graph()
+    undirected = g.to_undirected()
+    return nx.average_clustering(undirected)
+
+
+def get_connected_components(kg: KnowledgeGraph) -> list[set[str]]:
+    """Get weakly connected components."""
+    g = kg.engine.get_native_graph()
+    return [c for c in nx.weakly_connected_components(g)]
+
+
+def compute_risk_score(kg: KnowledgeGraph, entity_id: str) -> dict[str, Any]:
+    """Compute a risk score for an entity based on graph topology.
+
+    Factors:
+    - Number of vulnerabilities affecting connected systems
+    - Criticality of connected systems
+    - Number of hops from internet-facing systems
+    - Data sensitivity of connected assets
+    """
+    from hc_enterprise_kg.domain.base import EntityType
+
+    entity = kg.get_entity(entity_id)
+    if not entity:
+        return {"entity_id": entity_id, "risk_score": 0.0, "error": "Entity not found"}
+
+    score = 0.0
+    factors: dict[str, Any] = {}
+
+    # Factor 1: Connected vulnerabilities
+    vuln_neighbors = kg.neighbors(entity_id, entity_type=EntityType.VULNERABILITY)
+    vuln_count = len(vuln_neighbors)
+    critical_vulns = sum(1 for v in vuln_neighbors if getattr(v, "severity", "") == "critical")
+    score += vuln_count * 10 + critical_vulns * 25
+    factors["vulnerabilities"] = vuln_count
+    factors["critical_vulnerabilities"] = critical_vulns
+
+    # Factor 2: Degree centrality (more connections = higher exposure)
+    g = kg.engine.get_native_graph()
+    if entity_id in g:
+        degree = g.degree(entity_id)
+        score += degree * 2
+        factors["degree"] = degree
+
+    # Factor 3: Internet exposure
+    system_neighbors = kg.neighbors(entity_id, entity_type=EntityType.SYSTEM)
+    internet_facing = sum(1 for s in system_neighbors if getattr(s, "is_internet_facing", False))
+    score += internet_facing * 20
+    factors["internet_facing_connections"] = internet_facing
+
+    # Normalize to 0-100
+    risk_score = min(100.0, score)
+
+    return {
+        "entity_id": entity_id,
+        "entity_name": entity.name,
+        "risk_score": round(risk_score, 1),
+        "factors": factors,
+    }

--- a/src/hc_enterprise_kg/analysis/queries.py
+++ b/src/hc_enterprise_kg/analysis/queries.py
@@ -1,0 +1,103 @@
+"""Pre-built query library for common enterprise KG analysis."""
+
+from __future__ import annotations
+
+from hc_enterprise_kg.domain.base import BaseEntity, EntityType, RelationshipType
+from hc_enterprise_kg.graph.knowledge_graph import KnowledgeGraph
+
+
+def find_attack_paths(
+    kg: KnowledgeGraph,
+    source_entity_id: str,
+    target_entity_id: str,
+) -> list[str] | None:
+    """Find the shortest attack path between two entities."""
+    return kg.shortest_path(source_entity_id, target_entity_id)
+
+
+def get_blast_radius(
+    kg: KnowledgeGraph,
+    entity_id: str,
+    max_depth: int = 3,
+) -> list[BaseEntity]:
+    """Get all entities reachable from the given entity within max_depth hops."""
+    visited: set[str] = set()
+    queue: list[tuple[str, int]] = [(entity_id, 0)]
+    result: list[BaseEntity] = []
+
+    while queue:
+        current_id, depth = queue.pop(0)
+        if current_id in visited or depth > max_depth:
+            continue
+        visited.add(current_id)
+
+        entity = kg.get_entity(current_id)
+        if entity and current_id != entity_id:
+            result.append(entity)
+
+        if depth < max_depth:
+            neighbors = kg.neighbors(current_id)
+            for neighbor in neighbors:
+                if neighbor.id not in visited:
+                    queue.append((neighbor.id, depth + 1))
+
+    return result
+
+
+def find_critical_systems(kg: KnowledgeGraph) -> list[BaseEntity]:
+    """Find all systems marked as critical."""
+    return kg.query().entities(EntityType.SYSTEM).where(criticality="critical").execute()
+
+
+def find_unpatched_vulnerabilities(kg: KnowledgeGraph) -> list[BaseEntity]:
+    """Find open vulnerabilities without patches."""
+    vulns = kg.list_entities(entity_type=EntityType.VULNERABILITY)
+    return [
+        v for v in vulns
+        if getattr(v, "status", "") == "open" and not getattr(v, "patch_available", True)
+    ]
+
+
+def find_internet_facing_systems(kg: KnowledgeGraph) -> list[BaseEntity]:
+    """Find all internet-facing systems."""
+    return kg.query().entities(EntityType.SYSTEM).where(is_internet_facing=True).execute()
+
+
+def find_privileged_users(kg: KnowledgeGraph) -> list[BaseEntity]:
+    """Find people with privileged roles."""
+    privileged_roles = kg.query().entities(EntityType.ROLE).where(is_privileged=True).execute()
+    privileged_people: list[BaseEntity] = []
+    seen: set[str] = set()
+
+    for role in privileged_roles:
+        people = kg.neighbors(
+            role.id,
+            direction="in",
+            relationship_type=RelationshipType.HAS_ROLE,
+            entity_type=EntityType.PERSON,
+        )
+        for person in people:
+            if person.id not in seen:
+                seen.add(person.id)
+                privileged_people.append(person)
+
+    return privileged_people
+
+
+def find_vendor_dependencies(kg: KnowledgeGraph, vendor_id: str) -> list[BaseEntity]:
+    """Find all systems that depend on a specific vendor."""
+    return kg.neighbors(
+        vendor_id,
+        direction="in",
+        relationship_type=RelationshipType.SUPPLIED_BY,
+        entity_type=EntityType.SYSTEM,
+    )
+
+
+def find_high_risk_data_assets(kg: KnowledgeGraph) -> list[BaseEntity]:
+    """Find data assets with restricted or confidential classification."""
+    assets = kg.list_entities(entity_type=EntityType.DATA_ASSET)
+    return [
+        a for a in assets
+        if getattr(a, "classification", "") in ("restricted", "confidential")
+    ]

--- a/src/hc_enterprise_kg/export/__init__.py
+++ b/src/hc_enterprise_kg/export/__init__.py
@@ -1,0 +1,7 @@
+"""Export module for the knowledge graph."""
+
+from hc_enterprise_kg.export.base import AbstractExporter
+from hc_enterprise_kg.export.graphml_export import GraphMLExporter
+from hc_enterprise_kg.export.json_export import JSONExporter
+
+__all__ = ["AbstractExporter", "GraphMLExporter", "JSONExporter"]

--- a/src/hc_enterprise_kg/export/base.py
+++ b/src/hc_enterprise_kg/export/base.py
@@ -1,0 +1,23 @@
+"""Base class for graph exporters."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+from hc_enterprise_kg.engine.abstract import AbstractGraphEngine
+
+
+class AbstractExporter(ABC):
+    """Base class for graph exporters."""
+
+    @abstractmethod
+    def export(self, engine: AbstractGraphEngine, output_path: Path, **kwargs: Any) -> None:
+        """Export the graph to the specified path."""
+        ...
+
+    @abstractmethod
+    def export_string(self, engine: AbstractGraphEngine, **kwargs: Any) -> str:
+        """Export the graph as a string."""
+        ...

--- a/src/hc_enterprise_kg/export/graphml_export.py
+++ b/src/hc_enterprise_kg/export/graphml_export.py
@@ -1,0 +1,58 @@
+"""GraphML exporter for the knowledge graph."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import networkx as nx
+
+from hc_enterprise_kg.engine.abstract import AbstractGraphEngine
+from hc_enterprise_kg.export.base import AbstractExporter
+
+
+class GraphMLExporter(AbstractExporter):
+    """Exports the knowledge graph as GraphML.
+
+    Uses NetworkX's built-in GraphML writer. Converts complex attributes
+    to strings for GraphML compatibility.
+    """
+
+    def export(self, engine: AbstractGraphEngine, output_path: Path, **kwargs: Any) -> None:
+        g = self._prepare_graph(engine)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        nx.write_graphml(g, str(output_path))
+
+    def export_string(self, engine: AbstractGraphEngine, **kwargs: Any) -> str:
+        import io
+
+        g = self._prepare_graph(engine)
+        buf = io.BytesIO()
+        nx.write_graphml(g, buf)
+        return buf.getvalue().decode("utf-8")
+
+    def _prepare_graph(self, engine: AbstractGraphEngine) -> nx.MultiDiGraph:
+        """Prepare a GraphML-compatible graph with string attributes."""
+        native = engine.get_native_graph()
+        g = native.copy()
+
+        # Convert complex attributes to strings for GraphML compatibility
+        for node_id, data in g.nodes(data=True):
+            for key, value in list(data.items()):
+                if isinstance(value, (list, dict)):
+                    data[key] = str(value)
+                elif isinstance(value, bool):
+                    data[key] = str(value).lower()
+                elif value is None:
+                    data[key] = ""
+
+        for u, v, key, data in g.edges(keys=True, data=True):
+            for k, value in list(data.items()):
+                if isinstance(value, (list, dict)):
+                    data[k] = str(value)
+                elif isinstance(value, bool):
+                    data[k] = str(value).lower()
+                elif value is None:
+                    data[k] = ""
+
+        return g

--- a/src/hc_enterprise_kg/export/json_export.py
+++ b/src/hc_enterprise_kg/export/json_export.py
@@ -1,0 +1,53 @@
+"""JSON exporter for the knowledge graph."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from hc_enterprise_kg.engine.abstract import AbstractGraphEngine
+from hc_enterprise_kg.export.base import AbstractExporter
+
+
+class JSONExporter(AbstractExporter):
+    """Exports the knowledge graph as JSON.
+
+    Output format:
+    {
+        "entities": [...],
+        "relationships": [...],
+        "statistics": {...}
+    }
+    """
+
+    def export(self, engine: AbstractGraphEngine, output_path: Path, **kwargs: Any) -> None:
+        content = self.export_string(engine, **kwargs)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(content)
+
+    def export_string(self, engine: AbstractGraphEngine, **kwargs: Any) -> str:
+        entities = engine.list_entities()
+        entity_dicts = []
+        for entity in entities:
+            d = entity.model_dump(mode="json")
+            entity_dicts.append(d)
+
+        # Collect all relationships
+        rel_dicts = []
+        seen_rel_ids: set[str] = set()
+        for entity in entities:
+            for direction in ("out", "in"):
+                for rel in engine.get_relationships(entity.id, direction=direction):
+                    if rel.id not in seen_rel_ids:
+                        seen_rel_ids.add(rel.id)
+                        rel_dicts.append(rel.model_dump(mode="json"))
+
+        data = {
+            "entities": entity_dicts,
+            "relationships": rel_dicts,
+            "statistics": engine.get_statistics(),
+        }
+
+        indent = kwargs.get("indent", 2)
+        return json.dumps(data, indent=indent, default=str)

--- a/src/hc_enterprise_kg/ingest/__init__.py
+++ b/src/hc_enterprise_kg/ingest/__init__.py
@@ -1,0 +1,7 @@
+"""Data ingestion for the knowledge graph."""
+
+from hc_enterprise_kg.ingest.base import AbstractIngestor, IngestResult
+from hc_enterprise_kg.ingest.csv_ingestor import CSVIngestor
+from hc_enterprise_kg.ingest.json_ingestor import JSONIngestor
+
+__all__ = ["AbstractIngestor", "CSVIngestor", "IngestResult", "JSONIngestor"]

--- a/src/hc_enterprise_kg/ingest/base.py
+++ b/src/hc_enterprise_kg/ingest/base.py
@@ -1,0 +1,42 @@
+"""Base classes for data ingestion."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from hc_enterprise_kg.domain.base import BaseEntity, BaseRelationship
+
+
+@dataclass
+class IngestResult:
+    """Result of an ingestion operation."""
+
+    entities: list[BaseEntity] = field(default_factory=list)
+    relationships: list[BaseRelationship] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def entity_count(self) -> int:
+        return len(self.entities)
+
+    @property
+    def relationship_count(self) -> int:
+        return len(self.relationships)
+
+
+class AbstractIngestor(ABC):
+    """Base class for all data ingestors."""
+
+    @abstractmethod
+    def ingest(self, source: Path | str, **kwargs: Any) -> IngestResult:
+        """Ingest data from the given source."""
+        ...
+
+    @abstractmethod
+    def can_handle(self, source: Path | str) -> bool:
+        """Return True if this ingestor can handle the given source."""
+        ...

--- a/src/hc_enterprise_kg/ingest/csv_ingestor.py
+++ b/src/hc_enterprise_kg/ingest/csv_ingestor.py
@@ -1,0 +1,79 @@
+"""CSV data ingestor."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.domain.registry import EntityRegistry
+from hc_enterprise_kg.ingest.base import AbstractIngestor, IngestResult
+from hc_enterprise_kg.ingest.mapping import SchemaMapping
+
+
+class CSVIngestor(AbstractIngestor):
+    """Ingests entities from CSV files using schema mappings."""
+
+    def can_handle(self, source: Path | str) -> bool:
+        path = Path(source) if isinstance(source, str) else source
+        return path.suffix.lower() == ".csv"
+
+    def ingest(
+        self,
+        source: Path | str,
+        mapping: SchemaMapping | None = None,
+        entity_type: EntityType | None = None,
+        **kwargs: Any,
+    ) -> IngestResult:
+        path = Path(source) if isinstance(source, str) else source
+        result = IngestResult()
+
+        if not path.exists():
+            result.errors.append(f"File not found: {path}")
+            return result
+
+        EntityRegistry.auto_discover()
+
+        with open(path, newline="") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        if not rows:
+            result.warnings.append("CSV file is empty")
+            return result
+
+        if mapping and mapping.entity_mappings:
+            for em in mapping.entity_mappings:
+                entity_class = EntityRegistry.get(em.target_entity_type)
+                for i, row in enumerate(rows):
+                    try:
+                        attrs: dict[str, Any] = {
+                            "entity_type": em.target_entity_type.value,
+                            "name": row.get(em.name_field, f"Row-{i}"),
+                        }
+                        for fm in em.field_mappings:
+                            if fm.source_field in row:
+                                attrs[fm.target_attribute] = row[fm.source_field]
+                        entity = entity_class.model_validate(attrs)
+                        result.entities.append(entity)
+                    except Exception as e:
+                        result.errors.append(f"Row {i}: {e}")
+        elif entity_type:
+            entity_class = EntityRegistry.get(entity_type)
+            columns = list(rows[0].keys())
+            name_col = columns[0]
+            for i, row in enumerate(rows):
+                try:
+                    attrs = {"entity_type": entity_type.value, "name": row.get(name_col, f"Row-{i}")}
+                    for col, val in row.items():
+                        if val and col != name_col:
+                            attrs[col] = val
+                    entity = entity_class.model_validate(attrs)
+                    result.entities.append(entity)
+                except Exception as e:
+                    result.errors.append(f"Row {i}: {e}")
+        else:
+            result.errors.append("No mapping or entity_type provided")
+
+        return result

--- a/src/hc_enterprise_kg/ingest/json_ingestor.py
+++ b/src/hc_enterprise_kg/ingest/json_ingestor.py
@@ -1,0 +1,63 @@
+"""JSON data ingestor."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from hc_enterprise_kg.domain.base import BaseRelationship, EntityType, RelationshipType
+from hc_enterprise_kg.domain.registry import EntityRegistry
+from hc_enterprise_kg.ingest.base import AbstractIngestor, IngestResult
+
+
+class JSONIngestor(AbstractIngestor):
+    """Ingests entities and relationships from JSON files.
+
+    Expected JSON format:
+    {
+        "entities": [{"entity_type": "person", "name": "...", ...}, ...],
+        "relationships": [{"relationship_type": "works_in", "source_id": "...", "target_id": "...", ...}, ...]
+    }
+    """
+
+    def can_handle(self, source: Path | str) -> bool:
+        path = Path(source) if isinstance(source, str) else source
+        return path.suffix.lower() == ".json"
+
+    def ingest(self, source: Path | str, **kwargs: Any) -> IngestResult:
+        path = Path(source) if isinstance(source, str) else source
+        result = IngestResult()
+
+        if not path.exists():
+            result.errors.append(f"File not found: {path}")
+            return result
+
+        EntityRegistry.auto_discover()
+
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except json.JSONDecodeError as e:
+            result.errors.append(f"Invalid JSON: {e}")
+            return result
+
+        # Parse entities
+        for i, raw in enumerate(data.get("entities", [])):
+            try:
+                entity_type = EntityType(raw["entity_type"])
+                entity_class = EntityRegistry.get(entity_type)
+                entity = entity_class.model_validate(raw)
+                result.entities.append(entity)
+            except Exception as e:
+                result.errors.append(f"Entity {i}: {e}")
+
+        # Parse relationships
+        for i, raw in enumerate(data.get("relationships", [])):
+            try:
+                rel = BaseRelationship.model_validate(raw)
+                result.relationships.append(rel)
+            except Exception as e:
+                result.errors.append(f"Relationship {i}: {e}")
+
+        return result

--- a/src/hc_enterprise_kg/ingest/mapping.py
+++ b/src/hc_enterprise_kg/ingest/mapping.py
@@ -1,0 +1,39 @@
+"""Schema mapping for data ingestion."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from hc_enterprise_kg.domain.base import EntityType, RelationshipType
+
+
+class FieldMapping(BaseModel):
+    """Maps a source field to an entity attribute."""
+
+    source_field: str
+    target_attribute: str
+    transform: str | None = None
+
+
+class EntityMapping(BaseModel):
+    """Maps a source record type to a domain entity type."""
+
+    source_type: str
+    target_entity_type: EntityType
+    field_mappings: list[FieldMapping]
+    name_field: str
+
+
+class RelationshipMapping(BaseModel):
+    """Maps source data to a relationship."""
+
+    source_field: str
+    target_field: str
+    relationship_type: RelationshipType
+
+
+class SchemaMapping(BaseModel):
+    """Complete mapping from a source schema to the KG domain model."""
+
+    entity_mappings: list[EntityMapping] = Field(default_factory=list)
+    relationship_mappings: list[RelationshipMapping] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
- **Ingest**: CSV/JSON ingestors with schema mapping, auto entity type detection
- **Export**: JSON + GraphML exporters, round-trip compatible
- **Analysis**: Pre-built queries (attack paths, blast radius, critical systems, unpatched vulns, privileged users, vendor deps) + graph metrics (centrality, PageRank, clustering, risk scoring)