### PR TITLE
Add full test suite, fixtures, and examples

### DIFF
--- a/examples/auto_kg_from_csv.py
+++ b/examples/auto_kg_from_csv.py
@@ -1,0 +1,92 @@
+"""Example: automatically construct a knowledge graph from CSV data."""
+
+import tempfile
+from pathlib import Path
+
+from hc_enterprise_kg.auto.extractors.csv_extractor import CSVExtractor
+from hc_enterprise_kg.auto.linkers.heuristic_linker import HeuristicLinker
+from hc_enterprise_kg.auto.pipeline import AutoKGPipeline
+from hc_enterprise_kg.auto.resolvers.dedup_resolver import DedupResolver
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.graph.knowledge_graph import KnowledgeGraph
+
+# Sample organizational data
+SAMPLE_DATA = """name,email,department,title,location
+Alice Smith,alice@acme.com,Engineering,Software Engineer,New York
+Bob Jones,bob@acme.com,Marketing,Marketing Manager,San Francisco
+Carol White,carol@acme.com,Engineering,Senior Engineer,New York
+Dave Brown,dave@acme.com,Finance,Financial Analyst,Chicago
+Eve Wilson,eve@acme.com,Human Resources,HR Director,San Francisco
+Frank Miller,frank@acme.com,Engineering,DevOps Engineer,New York
+Grace Lee,grace@acme.com,Sales,Account Executive,Chicago
+Alice Smith,alice.s@acme.com,Engineering,Lead Engineer,New York
+"""
+
+
+def main() -> None:
+    # Step 1: Create a knowledge graph
+    kg = KnowledgeGraph(backend="networkx", track_events=True)
+
+    # Step 2: Write sample CSV to a temp file
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        f.write(SAMPLE_DATA)
+        csv_path = f.name
+
+    print(f"CSV file: {csv_path}")
+
+    # Step 3: Configure and run the auto-KG pipeline
+    # Disable LLM and embeddings for this example (no API keys needed)
+    pipeline = AutoKGPipeline(
+        kg,
+        extractors=[CSVExtractor()],
+        linkers=[HeuristicLinker(name_match_threshold=85.0)],
+        resolver=DedupResolver(name_threshold=90.0),
+        use_llm=False,
+        use_embeddings=False,
+    )
+
+    print("\n=== Running Auto-KG Pipeline ===")
+    result = pipeline.run(csv_path)
+
+    # Step 4: Show pipeline results
+    print(f"\n=== Pipeline Results ===")
+    for key, value in sorted(result.stats.items()):
+        print(f"  {key}: {value}")
+
+    # Step 5: Explore the resulting graph
+    print(f"\n=== Graph Contents ===")
+    stats = kg.statistics
+    print(f"  Total entities: {stats['entity_count']}")
+    print(f"  Total relationships: {stats['relationship_count']}")
+
+    people = kg.query().entities(EntityType.PERSON).execute()
+    print(f"\n=== Extracted People ({len(people)}) ===")
+    for p in people:
+        email = getattr(p, "email", "N/A")
+        title = getattr(p, "title", "N/A")
+        print(f"  {p.name} - {title} ({email})")
+
+    # Step 6: Check if deduplication worked
+    # Alice Smith appears twice in the CSV — should be merged
+    alice_count = sum(1 for p in people if "Alice" in p.name)
+    print(f"\n=== Deduplication ===")
+    print(f"  Alice entries in CSV: 2")
+    print(f"  Alice entities in KG: {alice_count}")
+    if alice_count == 1:
+        print("  Deduplication successful!")
+
+    # Step 7: Export results
+    from hc_enterprise_kg.export.json_export import JSONExporter
+
+    exporter = JSONExporter()
+    json_str = exporter.export_string(kg.engine)
+    print(f"\n=== JSON Export ===")
+    print(f"  Output size: {len(json_str):,} characters")
+
+    # Clean up temp file
+    Path(csv_path).unlink()
+    print("\nDone!")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/quick_start.py
+++ b/examples/quick_start.py
@@ -1,0 +1,80 @@
+"""Quick start example: generate a synthetic enterprise KG and explore it."""
+
+from hc_enterprise_kg.domain.base import EntityType, RelationshipType
+from hc_enterprise_kg.graph.knowledge_graph import KnowledgeGraph
+from hc_enterprise_kg.synthetic.orchestrator import SyntheticOrchestrator
+from hc_enterprise_kg.synthetic.profiles.tech_company import mid_size_tech_company
+
+
+def main() -> None:
+    # Step 1: Create a knowledge graph
+    kg = KnowledgeGraph(backend="networkx", track_events=True)
+
+    # Step 2: Generate synthetic data from a tech company profile
+    profile = mid_size_tech_company(employee_count=100)
+    orchestrator = SyntheticOrchestrator(kg, profile, seed=42)
+    counts = orchestrator.generate()
+
+    print("=== Generation Complete ===")
+    for entity_type, count in sorted(counts.items()):
+        print(f"  {entity_type}: {count}")
+
+    # Step 3: Explore the graph
+    stats = kg.statistics
+    print(f"\n=== Graph Statistics ===")
+    print(f"  Entities: {stats['entity_count']}")
+    print(f"  Relationships: {stats['relationship_count']}")
+    print(f"  Entity types: {stats['entity_types']}")
+
+    # Step 4: Query the graph
+    people = kg.query().entities(EntityType.PERSON).execute()
+    print(f"\n=== People ({len(people)}) ===")
+    for p in people[:5]:
+        print(f"  {p.name} ({p.email})")
+    if len(people) > 5:
+        print(f"  ... and {len(people) - 5} more")
+
+    departments = kg.query().entities(EntityType.DEPARTMENT).execute()
+    print(f"\n=== Departments ({len(departments)}) ===")
+    for d in departments:
+        print(f"  {d.name}")
+
+    systems = kg.query().entities(EntityType.SYSTEM).execute()
+    print(f"\n=== Systems ({len(systems)}) ===")
+    for s in systems[:5]:
+        print(f"  {s.name} ({s.system_type})")
+    if len(systems) > 5:
+        print(f"  ... and {len(systems) - 5} more")
+
+    # Step 5: Traverse relationships
+    if people:
+        first_person = people[0]
+        neighbors = kg.neighbors(first_person.id)
+        print(f"\n=== Neighbors of {first_person.name} ===")
+        for n in neighbors:
+            print(f"  {n.entity_type.value}: {n.name}")
+
+    # Step 6: Export to JSON
+    from hc_enterprise_kg.export.json_export import JSONExporter
+
+    exporter = JSONExporter()
+    json_str = exporter.export_string(kg.engine)
+    print(f"\n=== JSON Export ===")
+    print(f"  Output size: {len(json_str):,} characters")
+
+    # Step 7: Check event log
+    print(f"\n=== Event Log ===")
+    print(f"  Total events: {len(kg.event_log)}")
+    if kg.event_log:
+        type_counts: dict[str, int] = {}
+        for event in kg.event_log:
+            t = event.mutation_type.value
+            type_counts[t] = type_counts.get(t, 0) + 1
+        for t, c in sorted(type_counts.items()):
+            print(f"  {t}: {c}")
+
+    print("\nDone!")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,116 @@
+"""Shared pytest fixtures for the enterprise knowledge graph tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from hc_enterprise_kg.domain.base import BaseRelationship, EntityType, RelationshipType
+from hc_enterprise_kg.domain.entities.department import Department
+from hc_enterprise_kg.domain.entities.person import Person
+from hc_enterprise_kg.domain.entities.system import System
+from hc_enterprise_kg.domain.registry import EntityRegistry
+from hc_enterprise_kg.engine.factory import GraphEngineFactory
+from hc_enterprise_kg.engine.networkx_engine import NetworkXGraphEngine
+from hc_enterprise_kg.graph.knowledge_graph import KnowledgeGraph
+
+
+@pytest.fixture(autouse=True)
+def _auto_discover() -> None:
+    """Auto-discover entity types and engine backends before each test."""
+    EntityRegistry.auto_discover()
+    GraphEngineFactory.auto_discover()
+
+
+@pytest.fixture
+def engine() -> NetworkXGraphEngine:
+    """Create a fresh NetworkX engine."""
+    return NetworkXGraphEngine()
+
+
+@pytest.fixture
+def kg() -> KnowledgeGraph:
+    """Create a fresh KnowledgeGraph."""
+    return KnowledgeGraph(backend="networkx", track_events=True)
+
+
+@pytest.fixture
+def sample_person() -> Person:
+    """Create a sample Person entity."""
+    return Person(
+        id="person-1",
+        first_name="Alice",
+        last_name="Smith",
+        name="Alice Smith",
+        email="alice.smith@acme.com",
+        title="Software Engineer",
+        employee_id="EMP-001",
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def sample_department() -> Department:
+    """Create a sample Department entity."""
+    return Department(
+        id="dept-1",
+        name="Engineering",
+        description="Engineering department",
+        code="ENG",
+        headcount=50,
+    )
+
+
+@pytest.fixture
+def sample_system() -> System:
+    """Create a sample System entity."""
+    return System(
+        id="sys-1",
+        name="Web Application",
+        system_type="application",
+        hostname="webapp-001",
+        ip_address="10.0.1.100",
+        os="Linux",
+        criticality="high",
+        is_internet_facing=True,
+    )
+
+
+@pytest.fixture
+def sample_relationship() -> BaseRelationship:
+    """Create a sample relationship."""
+    return BaseRelationship(
+        id="rel-1",
+        relationship_type=RelationshipType.WORKS_IN,
+        source_id="person-1",
+        target_id="dept-1",
+    )
+
+
+@pytest.fixture
+def populated_kg(
+    kg: KnowledgeGraph,
+    sample_person: Person,
+    sample_department: Department,
+    sample_system: System,
+) -> KnowledgeGraph:
+    """Create a KG with sample entities and relationships."""
+    kg.add_entity(sample_person)
+    kg.add_entity(sample_department)
+    kg.add_entity(sample_system)
+
+    kg.add_relationship(
+        BaseRelationship(
+            relationship_type=RelationshipType.WORKS_IN,
+            source_id=sample_person.id,
+            target_id=sample_department.id,
+        )
+    )
+    kg.add_relationship(
+        BaseRelationship(
+            relationship_type=RelationshipType.RESPONSIBLE_FOR,
+            source_id=sample_department.id,
+            target_id=sample_system.id,
+        )
+    )
+
+    return kg

--- a/tests/fixtures/sample_entities.json
+++ b/tests/fixtures/sample_entities.json
@@ -1,0 +1,69 @@
+{
+  "entities": [
+    {
+      "id": "person-alice",
+      "entity_type": "person",
+      "name": "Alice Smith",
+      "first_name": "Alice",
+      "last_name": "Smith",
+      "email": "alice@acme.com",
+      "title": "Software Engineer",
+      "is_active": true
+    },
+    {
+      "id": "dept-eng",
+      "entity_type": "department",
+      "name": "Engineering",
+      "description": "Software engineering department",
+      "code": "ENG",
+      "headcount": 25
+    },
+    {
+      "id": "sys-webapp",
+      "entity_type": "system",
+      "name": "Web Application",
+      "system_type": "application",
+      "hostname": "webapp-001",
+      "ip_address": "10.0.1.100",
+      "os": "Linux",
+      "criticality": "high",
+      "is_internet_facing": true
+    },
+    {
+      "id": "net-corp",
+      "entity_type": "network",
+      "name": "Corporate LAN",
+      "network_type": "lan",
+      "cidr": "10.0.0.0/16"
+    },
+    {
+      "id": "vuln-001",
+      "entity_type": "vulnerability",
+      "name": "CVE-2024-1234",
+      "severity": "critical",
+      "description": "Remote code execution in web framework"
+    }
+  ],
+  "relationships": [
+    {
+      "relationship_type": "works_in",
+      "source_id": "person-alice",
+      "target_id": "dept-eng"
+    },
+    {
+      "relationship_type": "responsible_for",
+      "source_id": "dept-eng",
+      "target_id": "sys-webapp"
+    },
+    {
+      "relationship_type": "connects_to",
+      "source_id": "sys-webapp",
+      "target_id": "net-corp"
+    },
+    {
+      "relationship_type": "affects",
+      "source_id": "vuln-001",
+      "target_id": "sys-webapp"
+    }
+  ]
+}

--- a/tests/fixtures/sample_org.csv
+++ b/tests/fixtures/sample_org.csv
@@ -1,0 +1,11 @@
+name,email,department,title,location
+Alice Smith,alice@acme.com,Engineering,Software Engineer,New York
+Bob Jones,bob@acme.com,Marketing,Marketing Manager,San Francisco
+Carol White,carol@acme.com,Engineering,Senior Engineer,New York
+Dave Brown,dave@acme.com,Finance,Financial Analyst,Chicago
+Eve Wilson,eve@acme.com,Human Resources,HR Director,San Francisco
+Frank Miller,frank@acme.com,Engineering,DevOps Engineer,New York
+Grace Lee,grace@acme.com,Sales,Account Executive,Chicago
+Hank Taylor,hank@acme.com,IT,System Administrator,New York
+Iris Chen,iris@acme.com,Security,Security Analyst,San Francisco
+Jack Davis,jack@acme.com,Engineering,Tech Lead,New York

--- a/tests/fixtures/sample_text.txt
+++ b/tests/fixtures/sample_text.txt
@@ -1,0 +1,25 @@
+Enterprise Security Assessment Report
+======================================
+
+Contact: alice@acme.com, bob@acme.com
+
+Network Infrastructure:
+- Corporate LAN: 10.0.0.0/16
+- DMZ: 172.16.0.0/24
+- Server: webapp-001.acme.com (10.0.1.100)
+- Server: db-001.acme.com (10.0.1.200)
+- Server: mail-001.acme.com (10.0.2.50)
+
+Vulnerabilities Identified:
+- CVE-2024-1234: Critical RCE in web framework affecting webapp-001
+- CVE-2024-5678: Medium privilege escalation in database server
+- CVE-2023-9999: Low information disclosure in mail server
+
+Threat Actors:
+- APT-42 has been observed targeting similar infrastructure
+- Ransomware group "DarkSide" may exploit CVE-2024-1234
+
+Key Personnel:
+- Alice Smith (alice@acme.com) - Security Lead
+- Bob Jones (bob@acme.com) - Network Admin
+- Carol White (carol@acme.com) - CISO

--- a/tests/integration/test_auto_pipeline.py
+++ b/tests/integration/test_auto_pipeline.py
@@ -1,0 +1,116 @@
+"""Integration tests for the automatic KG construction pipeline."""
+
+import tempfile
+from pathlib import Path
+
+from hc_enterprise_kg.auto.extractors.csv_extractor import CSVExtractor
+from hc_enterprise_kg.auto.extractors.rule_based import RuleBasedExtractor
+from hc_enterprise_kg.auto.linkers.heuristic_linker import HeuristicLinker
+from hc_enterprise_kg.auto.pipeline import AutoKGPipeline
+from hc_enterprise_kg.auto.resolvers.dedup_resolver import DedupResolver
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.graph.knowledge_graph import KnowledgeGraph
+
+SAMPLE_CSV = """name,email,department,title
+Alice Smith,alice@acme.com,Engineering,Software Engineer
+Bob Jones,bob@acme.com,Marketing,Marketing Manager
+Carol White,carol@acme.com,Engineering,Senior Engineer
+"""
+
+
+class TestAutoPipelineIntegration:
+    def test_csv_to_kg_pipeline(self):
+        kg = KnowledgeGraph()
+
+        # Write CSV to temp file
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write(SAMPLE_CSV)
+            csv_path = f.name
+
+        pipeline = AutoKGPipeline(
+            kg,
+            extractors=[CSVExtractor()],
+            linkers=[HeuristicLinker()],
+            resolver=DedupResolver(),
+            use_llm=False,
+            use_embeddings=False,
+        )
+        result = pipeline.run(csv_path)
+
+        assert result.stats["status"] == "complete"
+        assert result.stats["entities_extracted"] >= 3
+        assert result.stats["entities_loaded"] >= 3
+
+        # Clean up
+        Path(csv_path).unlink()
+
+    def test_csv_string_pipeline(self):
+        kg = KnowledgeGraph()
+        pipeline = AutoKGPipeline(
+            kg,
+            extractors=[CSVExtractor()],
+            linkers=[],
+            resolver=DedupResolver(),
+            use_llm=False,
+            use_embeddings=False,
+        )
+        result = pipeline.run(SAMPLE_CSV)
+
+        assert result.stats["status"] == "complete"
+        assert result.stats["entities_loaded"] >= 3
+
+    def test_rule_based_extraction_from_text(self):
+        kg = KnowledgeGraph()
+        text = """
+        Contact alice@acme.com or bob@test.org for help.
+        Server 10.0.1.50 has vulnerability CVE-2024-1234.
+        """
+        pipeline = AutoKGPipeline(
+            kg,
+            extractors=[RuleBasedExtractor()],
+            linkers=[],
+            resolver=DedupResolver(),
+            use_llm=False,
+            use_embeddings=False,
+        )
+        result = pipeline.run(text)
+
+        assert result.stats["status"] == "complete"
+        assert result.stats["entities_extracted"] >= 2
+
+    def test_dedup_in_pipeline(self):
+        kg = KnowledgeGraph()
+        csv_content = """name,email,department,title
+Alice Smith,alice@acme.com,Engineering,Engineer
+Alice Smith,,Engineering,Senior Engineer
+"""
+        pipeline = AutoKGPipeline(
+            kg,
+            extractors=[CSVExtractor()],
+            linkers=[],
+            resolver=DedupResolver(name_threshold=90.0),
+            use_llm=False,
+            use_embeddings=False,
+        )
+        result = pipeline.run(csv_content)
+
+        assert result.stats["status"] == "complete"
+        # Two rows extracted, but should merge into one
+        assert result.stats["entities_extracted"] == 2
+        assert result.stats["duplicates_merged"] >= 1
+
+    def test_pipeline_loads_into_queryable_kg(self):
+        kg = KnowledgeGraph()
+        pipeline = AutoKGPipeline(
+            kg,
+            extractors=[CSVExtractor()],
+            linkers=[HeuristicLinker()],
+            resolver=DedupResolver(),
+            use_llm=False,
+            use_embeddings=False,
+        )
+        pipeline.run(SAMPLE_CSV)
+
+        # Should be able to query entities after pipeline
+        people = kg.query().entities(EntityType.PERSON).execute()
+        assert len(people) >= 3

--- a/tests/integration/test_knowledge_graph.py
+++ b/tests/integration/test_knowledge_graph.py
@@ -1,0 +1,139 @@
+"""Integration tests for the KnowledgeGraph lifecycle."""
+
+from hc_enterprise_kg.domain.base import BaseRelationship, EntityType, RelationshipType
+from hc_enterprise_kg.domain.entities.department import Department
+from hc_enterprise_kg.domain.entities.person import Person
+from hc_enterprise_kg.domain.entities.system import System
+from hc_enterprise_kg.domain.temporal import MutationType
+from hc_enterprise_kg.graph.knowledge_graph import KnowledgeGraph
+
+
+class TestKnowledgeGraphLifecycle:
+    def test_add_query_remove_entity(self, kg: KnowledgeGraph):
+        person = Person(
+            id="p1", first_name="Alice", last_name="Smith",
+            name="Alice Smith", email="a@b.com",
+        )
+        kg.add_entity(person)
+        assert kg.get_entity("p1") is not None
+        assert kg.get_entity("p1").name == "Alice Smith"
+
+        # Query
+        results = kg.query().entities(EntityType.PERSON).execute()
+        assert len(results) == 1
+
+        # Remove
+        kg.remove_entity("p1")
+        assert kg.get_entity("p1") is None
+
+    def test_add_and_traverse_relationships(self, kg: KnowledgeGraph):
+        person = Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com")
+        dept = Department(id="d1", name="Engineering")
+        system = System(id="s1", name="WebApp", system_type="app")
+
+        kg.add_entity(person)
+        kg.add_entity(dept)
+        kg.add_entity(system)
+
+        kg.add_relationship(BaseRelationship(
+            relationship_type=RelationshipType.WORKS_IN,
+            source_id="p1", target_id="d1",
+        ))
+        kg.add_relationship(BaseRelationship(
+            relationship_type=RelationshipType.RESPONSIBLE_FOR,
+            source_id="d1", target_id="s1",
+        ))
+
+        # Neighbors
+        neighbors = kg.neighbors("d1")
+        neighbor_ids = {n.id for n in neighbors}
+        assert "p1" in neighbor_ids
+        assert "s1" in neighbor_ids
+
+        # Shortest path
+        path = kg.shortest_path("p1", "s1")
+        assert path is not None
+        assert "p1" in path
+        assert "s1" in path
+
+    def test_event_tracking(self, kg: KnowledgeGraph):
+        person = Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com")
+        kg.add_entity(person)
+        kg.update_entity("p1", title="Manager")
+        kg.remove_entity("p1")
+
+        log = kg.event_log
+        types = [e.mutation_type for e in log]
+        assert MutationType.CREATE in types
+        assert MutationType.UPDATE in types
+        assert MutationType.DELETE in types
+
+    def test_event_subscription(self, kg: KnowledgeGraph):
+        events_received = []
+
+        def handler(event):
+            events_received.append(event)
+
+        kg.subscribe(handler, MutationType.CREATE)
+        person = Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com")
+        kg.add_entity(person)
+
+        assert len(events_received) == 1
+        assert events_received[0].mutation_type == MutationType.CREATE
+
+    def test_bulk_operations(self, kg: KnowledgeGraph):
+        people = [
+            Person(id=f"p{i}", first_name=f"P{i}", last_name="T", name=f"P{i} T", email=f"p{i}@t.com")
+            for i in range(10)
+        ]
+        kg.add_entities_bulk(people)
+        assert kg.statistics["entity_count"] == 10
+
+        rels = [
+            BaseRelationship(
+                relationship_type=RelationshipType.REPORTS_TO,
+                source_id=f"p{i}", target_id="p0",
+            )
+            for i in range(1, 10)
+        ]
+        kg.add_relationships_bulk(rels)
+        assert kg.statistics["relationship_count"] == 9
+
+    def test_statistics(self, populated_kg: KnowledgeGraph):
+        stats = populated_kg.statistics
+        assert stats["entity_count"] == 3
+        assert stats["relationship_count"] == 2
+        assert "entity_types" in stats
+
+    def test_query_with_filters(self, kg: KnowledgeGraph):
+        kg.add_entity(Person(
+            id="p1", first_name="Alice", last_name="Smith",
+            name="Alice Smith", email="a@b.com", is_active=True,
+        ))
+        kg.add_entity(Person(
+            id="p2", first_name="Bob", last_name="Jones",
+            name="Bob Jones", email="b@c.com", is_active=False,
+        ))
+
+        active = kg.query().entities(EntityType.PERSON).where(is_active=True).execute()
+        assert len(active) == 1
+        assert active[0].id == "p1"
+
+    def test_list_entities_with_limit_offset(self, kg: KnowledgeGraph):
+        for i in range(5):
+            kg.add_entity(Person(
+                id=f"p{i}", first_name=f"P{i}", last_name="T",
+                name=f"P{i} T", email=f"p{i}@t.com",
+            ))
+        page = kg.list_entities(limit=2, offset=0)
+        assert len(page) == 2
+
+        page2 = kg.list_entities(limit=2, offset=2)
+        assert len(page2) == 2
+
+    def test_relationship_direction_filtering(self, populated_kg: KnowledgeGraph):
+        out_rels = populated_kg.get_relationships("person-1", direction="out")
+        assert len(out_rels) >= 1
+
+        in_rels = populated_kg.get_relationships("dept-1", direction="in")
+        assert len(in_rels) >= 1

--- a/tests/integration/test_synthetic_pipeline.py
+++ b/tests/integration/test_synthetic_pipeline.py
@@ -1,0 +1,93 @@
+"""Integration tests for the synthetic generation pipeline."""
+
+from hc_enterprise_kg.domain.base import EntityType, RelationshipType
+from hc_enterprise_kg.graph.knowledge_graph import KnowledgeGraph
+from hc_enterprise_kg.synthetic.orchestrator import SyntheticOrchestrator
+from hc_enterprise_kg.synthetic.profiles.tech_company import mid_size_tech_company
+from hc_enterprise_kg.synthetic.profiles.healthcare_org import healthcare_org
+from hc_enterprise_kg.synthetic.profiles.financial_org import financial_org
+
+
+class TestSyntheticPipeline:
+    def test_tech_company_generation(self):
+        kg = KnowledgeGraph()
+        profile = mid_size_tech_company(50)
+        orchestrator = SyntheticOrchestrator(kg, profile, seed=42)
+        counts = orchestrator.generate()
+
+        assert counts["person"] == 50
+        assert counts.get("department", 0) > 0
+        assert counts.get("system", 0) > 0
+        assert counts.get("_relationships", 0) > 0
+
+        stats = kg.statistics
+        assert stats["entity_count"] > 50  # People + other entities
+
+    def test_healthcare_org_generation(self):
+        kg = KnowledgeGraph()
+        profile = healthcare_org(30)
+        orchestrator = SyntheticOrchestrator(kg, profile, seed=42)
+        counts = orchestrator.generate()
+
+        assert counts["person"] == 30
+        assert counts.get("_relationships", 0) > 0
+
+    def test_financial_org_generation(self):
+        kg = KnowledgeGraph()
+        profile = financial_org(30)
+        orchestrator = SyntheticOrchestrator(kg, profile, seed=42)
+        counts = orchestrator.generate()
+
+        assert counts["person"] == 30
+        assert counts.get("_relationships", 0) > 0
+
+    def test_generation_with_query(self):
+        kg = KnowledgeGraph()
+        profile = mid_size_tech_company(20)
+        orchestrator = SyntheticOrchestrator(kg, profile, seed=42)
+        orchestrator.generate()
+
+        people = kg.query().entities(EntityType.PERSON).execute()
+        assert len(people) == 20
+
+        departments = kg.query().entities(EntityType.DEPARTMENT).execute()
+        assert len(departments) > 0
+
+    def test_generation_with_export(self):
+        import json
+
+        kg = KnowledgeGraph()
+        profile = mid_size_tech_company(15)
+        orchestrator = SyntheticOrchestrator(kg, profile, seed=42)
+        orchestrator.generate()
+
+        from hc_enterprise_kg.export.json_export import JSONExporter
+        exporter = JSONExporter()
+        result = exporter.export_string(kg.engine)
+        data = json.loads(result)
+
+        assert len(data["entities"]) > 15
+        assert len(data["relationships"]) > 0
+        assert data["statistics"]["entity_count"] == len(data["entities"])
+
+    def test_event_log_recorded(self):
+        kg = KnowledgeGraph(track_events=True)
+        profile = mid_size_tech_company(10)
+        orchestrator = SyntheticOrchestrator(kg, profile, seed=42)
+        orchestrator.generate()
+
+        assert len(kg.event_log) > 0
+
+    def test_seed_reproducibility(self):
+        kg1 = KnowledgeGraph()
+        profile1 = mid_size_tech_company(20)
+        orch1 = SyntheticOrchestrator(kg1, profile1, seed=123)
+        counts1 = orch1.generate()
+
+        kg2 = KnowledgeGraph()
+        profile2 = mid_size_tech_company(20)
+        orch2 = SyntheticOrchestrator(kg2, profile2, seed=123)
+        counts2 = orch2.generate()
+
+        assert counts1 == counts2
+        assert kg1.statistics["entity_count"] == kg2.statistics["entity_count"]

--- a/tests/unit/auto/test_extractors.py
+++ b/tests/unit/auto/test_extractors.py
@@ -1,0 +1,46 @@
+"""Tests for auto extractors."""
+
+from hc_enterprise_kg.auto.extractors.rule_based import RuleBasedExtractor
+from hc_enterprise_kg.domain.base import EntityType
+
+
+class TestRuleBasedExtractor:
+    def test_extract_emails(self):
+        text = "Contact alice@example.com and bob@acme.com for details."
+        extractor = RuleBasedExtractor()
+        result = extractor.extract(text)
+        emails = [e for e in result.entities if e.entity_type == EntityType.PERSON]
+        assert len(emails) == 2
+
+    def test_extract_ips(self):
+        text = "Server at 10.0.1.50 is down. Check 192.168.1.1 as well."
+        extractor = RuleBasedExtractor()
+        result = extractor.extract(text)
+        systems = [e for e in result.entities if e.entity_type == EntityType.SYSTEM]
+        assert len(systems) == 2
+
+    def test_extract_cves(self):
+        text = "Affected by CVE-2024-12345 and CVE-2023-98765."
+        extractor = RuleBasedExtractor()
+        result = extractor.extract(text)
+        vulns = [e for e in result.entities if e.entity_type == EntityType.VULNERABILITY]
+        assert len(vulns) == 2
+        assert any(v.cve_id == "CVE-2024-12345" for v in vulns)
+
+    def test_no_duplicates(self):
+        text = "Contact alice@example.com. Repeat: alice@example.com"
+        extractor = RuleBasedExtractor()
+        result = extractor.extract(text)
+        assert len(result.entities) == 1
+
+    def test_can_handle(self):
+        extractor = RuleBasedExtractor()
+        assert extractor.can_handle("some text") is True
+        assert extractor.can_handle("") is False
+        assert extractor.can_handle(123) is False
+
+    def test_confidence_set(self):
+        text = "Contact alice@example.com"
+        extractor = RuleBasedExtractor()
+        result = extractor.extract(text)
+        assert result.entities[0].metadata.get("_confidence") is not None

--- a/tests/unit/auto/test_linkers.py
+++ b/tests/unit/auto/test_linkers.py
@@ -1,0 +1,103 @@
+"""Tests for entity linkers."""
+
+from unittest.mock import MagicMock, patch
+
+from hc_enterprise_kg.auto.linkers.heuristic_linker import HeuristicLinker
+from hc_enterprise_kg.domain.base import EntityType, RelationshipType
+from hc_enterprise_kg.domain.entities.department import Department
+from hc_enterprise_kg.domain.entities.person import Person
+from hc_enterprise_kg.domain.entities.system import System
+
+
+class TestHeuristicLinker:
+    def test_fk_detection_links_person_to_department(self):
+        dept = Department(id="d1", name="Engineering")
+        person = Person(
+            id="p1",
+            first_name="Alice",
+            last_name="Smith",
+            name="Alice Smith",
+            email="a@b.com",
+            department_id="d1",
+        )
+        linker = HeuristicLinker()
+        result = linker.link([person, dept])
+        assert len(result.relationships) >= 1
+        fk_rels = [r for r in result.relationships if r.properties.get("_link_method") == "fk_detection"]
+        assert len(fk_rels) == 1
+        assert fk_rels[0].source_id == "p1"
+        assert fk_rels[0].target_id == "d1"
+
+    def test_no_links_for_unrelated_entities(self):
+        dept = Department(id="d1", name="Engineering")
+        sys = System(id="s1", name="WebApp", system_type="application")
+        linker = HeuristicLinker(name_match_threshold=99.0)
+        result = linker.link([dept, sys])
+        # No FK attrs linking these, names don't match
+        assert len(result.relationships) == 0
+
+    def test_name_matching_links_similar_names(self):
+        # Person named "Engineering" should fuzzy-match Department "Engineering"
+        person = Person(
+            id="p1", first_name="Engineering", last_name="Team",
+            name="Engineering Team", email="eng@test.com",
+        )
+        dept = Department(id="d1", name="Engineering Team")
+        linker = HeuristicLinker(name_match_threshold=80.0)
+        result = linker.link([person, dept])
+        name_rels = [r for r in result.relationships if r.properties.get("_link_method") == "name_matching"]
+        assert len(name_rels) >= 1
+
+    def test_high_threshold_prevents_links(self):
+        person = Person(
+            id="p1", first_name="Alice", last_name="Smith",
+            name="Alice Smith", email="a@b.com",
+        )
+        dept = Department(id="d1", name="Engineering")
+        linker = HeuristicLinker(name_match_threshold=99.0)
+        result = linker.link([person, dept])
+        name_rels = [r for r in result.relationships if r.properties.get("_link_method") == "name_matching"]
+        assert len(name_rels) == 0
+
+    def test_linking_result_has_method(self):
+        linker = HeuristicLinker()
+        result = linker.link([])
+        assert result.link_method == "heuristic"
+
+    def test_relationships_have_confidence(self):
+        dept = Department(id="d1", name="Engineering")
+        person = Person(
+            id="p1", first_name="Alice", last_name="Smith",
+            name="Alice Smith", email="a@b.com",
+            department_id="d1",
+        )
+        linker = HeuristicLinker()
+        result = linker.link([person, dept])
+        for rel in result.relationships:
+            assert 0.0 <= rel.confidence <= 1.0
+
+
+class TestEmbeddingLinker:
+    def test_embedding_linker_returns_result_with_few_entities(self):
+        from hc_enterprise_kg.auto.linkers.embedding_linker import EmbeddingLinker
+
+        linker = EmbeddingLinker(similarity_threshold=0.7)
+        # Less than 2 entities => no linking
+        person = Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com")
+        result = linker.link([person])
+        assert result.link_method == "embedding"
+        assert len(result.relationships) == 0
+
+    def test_embedding_linker_missing_library(self):
+        from hc_enterprise_kg.auto.linkers.embedding_linker import EmbeddingLinker
+
+        linker = EmbeddingLinker()
+        linker._model = None  # Reset
+
+        person = Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com")
+        dept = Department(id="d1", name="Engineering")
+
+        # Mock the import to fail
+        with patch.object(linker, "_load_model", side_effect=ImportError("no module")):
+            result = linker.link([person, dept])
+            assert len(result.errors) >= 1

--- a/tests/unit/auto/test_pipeline.py
+++ b/tests/unit/auto/test_pipeline.py
@@ -1,0 +1,142 @@
+"""Tests for the AutoKGPipeline."""
+
+from unittest.mock import MagicMock
+
+from hc_enterprise_kg.auto.base import ExtractionResult, LinkingResult, ResolutionResult
+from hc_enterprise_kg.auto.pipeline import AutoKGPipeline
+from hc_enterprise_kg.domain.base import BaseRelationship, EntityType, RelationshipType
+from hc_enterprise_kg.domain.entities.department import Department
+from hc_enterprise_kg.domain.entities.person import Person
+from hc_enterprise_kg.graph.knowledge_graph import KnowledgeGraph
+
+
+class TestAutoKGPipeline:
+    def test_pipeline_with_no_entities_extracted(self, kg: KnowledgeGraph):
+        mock_extractor = MagicMock()
+        mock_extractor.can_handle.return_value = True
+        mock_extractor.extract.return_value = ExtractionResult(source="test")
+
+        pipeline = AutoKGPipeline(
+            kg,
+            extractors=[mock_extractor],
+            linkers=[],
+            use_llm=False,
+            use_embeddings=False,
+        )
+        result = pipeline.run("test data")
+        assert result.stats.get("status") == "no_entities_extracted"
+
+    def test_pipeline_extracts_and_loads_entities(self, kg: KnowledgeGraph):
+        person = Person(
+            id="p1", first_name="Alice", last_name="Smith",
+            name="Alice Smith", email="a@b.com",
+        )
+
+        mock_extractor = MagicMock()
+        mock_extractor.can_handle.return_value = True
+        mock_extractor.extract.return_value = ExtractionResult(
+            entities=[person], source="test"
+        )
+
+        mock_linker = MagicMock()
+        mock_linker.link.return_value = LinkingResult(link_method="mock")
+
+        mock_resolver = MagicMock()
+        mock_resolver.resolve.return_value = ResolutionResult(entities=[person])
+
+        pipeline = AutoKGPipeline(
+            kg,
+            extractors=[mock_extractor],
+            linkers=[mock_linker],
+            resolver=mock_resolver,
+            use_llm=False,
+            use_embeddings=False,
+        )
+        result = pipeline.run("test data")
+
+        assert result.stats["status"] == "complete"
+        assert result.stats["entities_extracted"] == 1
+        assert result.stats["entities_loaded"] == 1
+        assert kg.get_entity("p1") is not None
+
+    def test_pipeline_links_relationships(self, kg: KnowledgeGraph):
+        person = Person(
+            id="p1", first_name="Alice", last_name="Smith",
+            name="Alice Smith", email="a@b.com",
+        )
+        dept = Department(id="d1", name="Engineering")
+
+        mock_extractor = MagicMock()
+        mock_extractor.can_handle.return_value = True
+        mock_extractor.extract.return_value = ExtractionResult(
+            entities=[person, dept], source="test"
+        )
+
+        rel = BaseRelationship(
+            relationship_type=RelationshipType.WORKS_IN,
+            source_id="p1", target_id="d1",
+        )
+        mock_linker = MagicMock()
+        mock_linker.link.return_value = LinkingResult(
+            relationships=[rel], link_method="mock"
+        )
+
+        mock_resolver = MagicMock()
+        mock_resolver.resolve.return_value = ResolutionResult(
+            entities=[person, dept]
+        )
+
+        pipeline = AutoKGPipeline(
+            kg,
+            extractors=[mock_extractor],
+            linkers=[mock_linker],
+            resolver=mock_resolver,
+        )
+        result = pipeline.run("test")
+
+        assert result.stats["relationships_loaded"] >= 1
+
+    def test_pipeline_dedup_merges_entities(self, kg: KnowledgeGraph):
+        p1 = Person(id="p1", first_name="Alice", last_name="Smith", name="Alice Smith", email="a@b.com")
+        p2 = Person(id="p2", first_name="Alice", last_name="Smith", name="Alice Smith", email="")
+
+        mock_extractor = MagicMock()
+        mock_extractor.can_handle.return_value = True
+        mock_extractor.extract.return_value = ExtractionResult(
+            entities=[p1, p2], source="test"
+        )
+
+        mock_linker = MagicMock()
+        mock_linker.link.return_value = LinkingResult(link_method="mock")
+
+        mock_resolver = MagicMock()
+        mock_resolver.resolve.return_value = ResolutionResult(
+            entities=[p1],
+            merged_entity_ids=[("p1", "p2")],
+        )
+
+        pipeline = AutoKGPipeline(
+            kg,
+            extractors=[mock_extractor],
+            linkers=[mock_linker],
+            resolver=mock_resolver,
+        )
+        result = pipeline.run("test")
+
+        assert result.stats["duplicates_merged"] == 1
+        assert result.stats["entities_after_dedup"] == 1
+
+    def test_pipeline_skips_extractor_that_cannot_handle(self, kg: KnowledgeGraph):
+        mock_extractor = MagicMock()
+        mock_extractor.can_handle.return_value = False
+
+        pipeline = AutoKGPipeline(
+            kg,
+            extractors=[mock_extractor],
+            linkers=[],
+            use_llm=False,
+            use_embeddings=False,
+        )
+        result = pipeline.run("test")
+        mock_extractor.extract.assert_not_called()
+        assert result.stats.get("status") == "no_entities_extracted"

--- a/tests/unit/auto/test_resolvers.py
+++ b/tests/unit/auto/test_resolvers.py
@@ -1,0 +1,47 @@
+"""Tests for entity resolvers."""
+
+from hc_enterprise_kg.auto.resolvers.dedup_resolver import DedupResolver
+from hc_enterprise_kg.domain.entities.person import Person
+
+
+class TestDedupResolver:
+    def test_no_duplicates(self):
+        entities = [
+            Person(id="p1", first_name="Alice", last_name="Smith", name="Alice Smith", email="a@b.com"),
+            Person(id="p2", first_name="Bob", last_name="Jones", name="Bob Jones", email="b@c.com"),
+        ]
+        resolver = DedupResolver()
+        result = resolver.resolve(entities)
+        assert len(result.entities) == 2
+        assert len(result.merged_entity_ids) == 0
+
+    def test_exact_name_duplicate(self):
+        entities = [
+            Person(id="p1", first_name="Alice", last_name="Smith", name="Alice Smith", email="a@b.com"),
+            Person(id="p2", first_name="Alice", last_name="Smith", name="Alice Smith", email=""),
+        ]
+        resolver = DedupResolver(name_threshold=90.0)
+        result = resolver.resolve(entities)
+        assert len(result.entities) == 1
+        assert len(result.merged_entity_ids) == 1
+
+    def test_merge_fills_empty_fields(self):
+        entities = [
+            Person(id="p1", first_name="Alice", last_name="Smith", name="Alice Smith", email="alice@test.com", title=""),
+            Person(id="p2", first_name="Alice", last_name="Smith", name="Alice Smith", email="", title="Engineer"),
+        ]
+        resolver = DedupResolver(name_threshold=90.0)
+        result = resolver.resolve(entities)
+        merged = result.entities[0]
+        assert merged.email == "alice@test.com"  # From winner
+        assert merged.title == "Engineer"  # Filled from loser
+
+    def test_different_types_not_merged(self):
+        from hc_enterprise_kg.domain.entities.department import Department
+        entities = [
+            Person(id="p1", first_name="Engineering", last_name="", name="Engineering", email="eng@test.com"),
+            Department(id="d1", name="Engineering"),
+        ]
+        resolver = DedupResolver(name_threshold=90.0)
+        result = resolver.resolve(entities)
+        assert len(result.entities) == 2

--- a/tests/unit/domain/test_base.py
+++ b/tests/unit/domain/test_base.py
@@ -1,0 +1,64 @@
+"""Tests for domain base types."""
+
+from hc_enterprise_kg.domain.base import (
+    BaseEntity,
+    BaseRelationship,
+    EntityType,
+    RelationshipType,
+)
+from hc_enterprise_kg.domain.entities.person import Person
+
+
+class TestBaseEntity:
+    def test_person_creation(self, sample_person):
+        assert sample_person.name == "Alice Smith"
+        assert sample_person.entity_type == EntityType.PERSON
+        assert sample_person.first_name == "Alice"
+
+    def test_entity_has_id(self):
+        person = Person(first_name="Bob", last_name="Jones", name="Bob Jones", email="bob@test.com")
+        assert person.id is not None
+        assert len(person.id) > 0
+
+    def test_entity_has_timestamps(self):
+        person = Person(first_name="Bob", last_name="Jones", name="Bob Jones", email="bob@test.com")
+        assert person.created_at is not None
+        assert person.updated_at is not None
+        assert person.version == 1
+
+    def test_entity_serialization(self, sample_person):
+        data = sample_person.model_dump()
+        assert data["first_name"] == "Alice"
+        assert data["entity_type"] == EntityType.PERSON
+
+    def test_entity_deserialization(self, sample_person):
+        data = sample_person.model_dump()
+        restored = Person.model_validate(data)
+        assert restored.name == sample_person.name
+        assert restored.id == sample_person.id
+
+    def test_entity_extra_fields(self):
+        person = Person(
+            first_name="Bob",
+            last_name="Jones",
+            name="Bob Jones",
+            email="bob@test.com",
+            custom_field="custom_value",
+        )
+        assert person.custom_field == "custom_value"
+
+
+class TestBaseRelationship:
+    def test_relationship_creation(self, sample_relationship):
+        assert sample_relationship.relationship_type == RelationshipType.WORKS_IN
+        assert sample_relationship.source_id == "person-1"
+        assert sample_relationship.target_id == "dept-1"
+
+    def test_relationship_defaults(self, sample_relationship):
+        assert sample_relationship.weight == 1.0
+        assert sample_relationship.confidence == 1.0
+
+    def test_relationship_serialization(self, sample_relationship):
+        data = sample_relationship.model_dump()
+        restored = BaseRelationship.model_validate(data)
+        assert restored.source_id == sample_relationship.source_id

--- a/tests/unit/domain/test_entities.py
+++ b/tests/unit/domain/test_entities.py
@@ -1,0 +1,92 @@
+"""Tests for all entity types."""
+
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.domain.entities import (
+    AnyEntity,
+    DataAsset,
+    Department,
+    Incident,
+    Location,
+    Network,
+    Person,
+    Policy,
+    Role,
+    System,
+    ThreatActor,
+    Vendor,
+    Vulnerability,
+)
+
+
+class TestAllEntityTypes:
+    """Verify each entity type can be created with minimal fields."""
+
+    def test_person(self):
+        e = Person(first_name="A", last_name="B", name="A B", email="a@b.com")
+        assert e.entity_type == EntityType.PERSON
+
+    def test_department(self):
+        e = Department(name="Engineering")
+        assert e.entity_type == EntityType.DEPARTMENT
+
+    def test_role(self):
+        e = Role(name="Engineer")
+        assert e.entity_type == EntityType.ROLE
+
+    def test_system(self):
+        e = System(name="Web Server")
+        assert e.entity_type == EntityType.SYSTEM
+
+    def test_network(self):
+        e = Network(name="Corporate LAN")
+        assert e.entity_type == EntityType.NETWORK
+
+    def test_data_asset(self):
+        e = DataAsset(name="Customer DB")
+        assert e.entity_type == EntityType.DATA_ASSET
+
+    def test_policy(self):
+        e = Policy(name="Access Control")
+        assert e.entity_type == EntityType.POLICY
+
+    def test_vendor(self):
+        e = Vendor(name="Acme Corp")
+        assert e.entity_type == EntityType.VENDOR
+
+    def test_location(self):
+        e = Location(name="HQ")
+        assert e.entity_type == EntityType.LOCATION
+
+    def test_vulnerability(self):
+        e = Vulnerability(name="CVE-2024-12345")
+        assert e.entity_type == EntityType.VULNERABILITY
+
+    def test_threat_actor(self):
+        e = ThreatActor(name="APT-1")
+        assert e.entity_type == EntityType.THREAT_ACTOR
+
+    def test_incident(self):
+        e = Incident(name="Data Breach 2024")
+        assert e.entity_type == EntityType.INCIDENT
+
+
+class TestDiscriminatedUnion:
+    def test_person_roundtrip(self):
+        person = Person(first_name="A", last_name="B", name="A B", email="a@b.com")
+        data = person.model_dump()
+        data["entity_type"] = "person"
+        from pydantic import TypeAdapter
+        adapter = TypeAdapter(AnyEntity)
+        restored = adapter.validate_python(data)
+        assert isinstance(restored, Person)
+        assert restored.first_name == "A"
+
+    def test_system_roundtrip(self):
+        system = System(name="Server", hostname="srv-01")
+        data = system.model_dump()
+        data["entity_type"] = "system"
+        from pydantic import TypeAdapter
+        adapter = TypeAdapter(AnyEntity)
+        restored = adapter.validate_python(data)
+        assert isinstance(restored, System)
+        assert restored.hostname == "srv-01"

--- a/tests/unit/domain/test_registry.py
+++ b/tests/unit/domain/test_registry.py
@@ -1,0 +1,28 @@
+"""Tests for EntityRegistry."""
+
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.domain.entities.person import Person
+from hc_enterprise_kg.domain.registry import EntityRegistry
+
+
+class TestEntityRegistry:
+    def test_auto_discover(self):
+        EntityRegistry.auto_discover()
+        assert EntityRegistry.is_registered(EntityType.PERSON)
+        assert EntityRegistry.is_registered(EntityType.SYSTEM)
+        assert len(EntityRegistry.all_types()) == 12
+
+    def test_get_registered_type(self):
+        EntityRegistry.auto_discover()
+        cls = EntityRegistry.get(EntityType.PERSON)
+        assert cls is Person
+
+    def test_get_unregistered_raises(self):
+        EntityRegistry.clear()
+        try:
+            EntityRegistry.get(EntityType.PERSON)
+            assert False, "Should have raised KeyError"
+        except KeyError:
+            pass
+        # Re-register for other tests
+        EntityRegistry.auto_discover()

--- a/tests/unit/domain/test_temporal.py
+++ b/tests/unit/domain/test_temporal.py
@@ -1,0 +1,21 @@
+"""Tests for temporal event types."""
+
+from hc_enterprise_kg.domain.temporal import GraphEvent, MutationType
+
+
+class TestGraphEvent:
+    def test_event_creation(self):
+        event = GraphEvent(
+            mutation_type=MutationType.CREATE,
+            entity_type="person",
+            entity_id="p-1",
+        )
+        assert event.mutation_type == MutationType.CREATE
+        assert event.entity_type == "person"
+        assert event.timestamp is not None
+        assert event.id is not None
+
+    def test_all_mutation_types(self):
+        for mt in MutationType:
+            event = GraphEvent(mutation_type=mt)
+            assert event.mutation_type == mt

--- a/tests/unit/engine/test_contract.py
+++ b/tests/unit/engine/test_contract.py
@@ -1,0 +1,173 @@
+"""Engine contract tests — reusable for any backend implementation."""
+
+import pytest
+
+from hc_enterprise_kg.domain.base import BaseRelationship, EntityType, RelationshipType
+from hc_enterprise_kg.domain.entities.department import Department
+from hc_enterprise_kg.domain.entities.person import Person
+from hc_enterprise_kg.domain.entities.system import System
+from hc_enterprise_kg.engine.abstract import AbstractGraphEngine
+from hc_enterprise_kg.engine.networkx_engine import NetworkXGraphEngine
+
+
+class GraphEngineContractTests:
+    """Contract tests that any AbstractGraphEngine implementation must pass."""
+
+    @pytest.fixture
+    def engine(self) -> AbstractGraphEngine:
+        raise NotImplementedError
+
+    def test_add_and_get_entity(self, engine):
+        person = Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com")
+        eid = engine.add_entity(person)
+        assert eid == "p1"
+
+        retrieved = engine.get_entity("p1")
+        assert retrieved is not None
+        assert retrieved.name == "A B"
+
+    def test_get_nonexistent_entity(self, engine):
+        assert engine.get_entity("nonexistent") is None
+
+    def test_update_entity(self, engine):
+        person = Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com")
+        engine.add_entity(person)
+
+        updated = engine.update_entity("p1", {"title": "Senior Engineer"})
+        assert updated is not None
+
+    def test_remove_entity(self, engine):
+        person = Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com")
+        engine.add_entity(person)
+
+        assert engine.remove_entity("p1") is True
+        assert engine.get_entity("p1") is None
+
+    def test_remove_nonexistent(self, engine):
+        assert engine.remove_entity("nonexistent") is False
+
+    def test_list_entities(self, engine):
+        engine.add_entity(Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com"))
+        engine.add_entity(Department(id="d1", name="Eng"))
+
+        all_entities = engine.list_entities()
+        assert len(all_entities) == 2
+
+        people = engine.list_entities(entity_type=EntityType.PERSON)
+        assert len(people) == 1
+
+    def test_entity_count(self, engine):
+        assert engine.entity_count() == 0
+        engine.add_entity(Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com"))
+        assert engine.entity_count() == 1
+        assert engine.entity_count(EntityType.PERSON) == 1
+        assert engine.entity_count(EntityType.SYSTEM) == 0
+
+    def test_add_relationship(self, engine):
+        engine.add_entity(Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com"))
+        engine.add_entity(Department(id="d1", name="Eng"))
+
+        rel = BaseRelationship(
+            id="r1",
+            relationship_type=RelationshipType.WORKS_IN,
+            source_id="p1",
+            target_id="d1",
+        )
+        rid = engine.add_relationship(rel)
+        assert rid == "r1"
+
+    def test_add_relationship_missing_source(self, engine):
+        engine.add_entity(Department(id="d1", name="Eng"))
+        rel = BaseRelationship(
+            relationship_type=RelationshipType.WORKS_IN, source_id="nonexistent", target_id="d1"
+        )
+        with pytest.raises(KeyError):
+            engine.add_relationship(rel)
+
+    def test_get_relationship(self, engine):
+        engine.add_entity(Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com"))
+        engine.add_entity(Department(id="d1", name="Eng"))
+        engine.add_relationship(
+            BaseRelationship(id="r1", relationship_type=RelationshipType.WORKS_IN, source_id="p1", target_id="d1")
+        )
+
+        rel = engine.get_relationship("r1")
+        assert rel is not None
+        assert rel.source_id == "p1"
+
+    def test_remove_relationship(self, engine):
+        engine.add_entity(Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com"))
+        engine.add_entity(Department(id="d1", name="Eng"))
+        engine.add_relationship(
+            BaseRelationship(id="r1", relationship_type=RelationshipType.WORKS_IN, source_id="p1", target_id="d1")
+        )
+
+        assert engine.remove_relationship("r1") is True
+        assert engine.get_relationship("r1") is None
+
+    def test_neighbors(self, engine):
+        engine.add_entity(Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com"))
+        engine.add_entity(Department(id="d1", name="Eng"))
+        engine.add_relationship(
+            BaseRelationship(relationship_type=RelationshipType.WORKS_IN, source_id="p1", target_id="d1")
+        )
+
+        neighbors = engine.neighbors("p1", direction="out")
+        assert len(neighbors) == 1
+        assert neighbors[0].id == "d1"
+
+    def test_shortest_path(self, engine):
+        engine.add_entity(Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com"))
+        engine.add_entity(Department(id="d1", name="Eng"))
+        engine.add_entity(System(id="s1", name="Web App"))
+        engine.add_relationship(
+            BaseRelationship(relationship_type=RelationshipType.WORKS_IN, source_id="p1", target_id="d1")
+        )
+        engine.add_relationship(
+            BaseRelationship(relationship_type=RelationshipType.RESPONSIBLE_FOR, source_id="d1", target_id="s1")
+        )
+
+        path = engine.shortest_path("p1", "s1")
+        assert path == ["p1", "d1", "s1"]
+
+    def test_shortest_path_no_path(self, engine):
+        engine.add_entity(Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com"))
+        engine.add_entity(System(id="s1", name="Web App"))
+        assert engine.shortest_path("p1", "s1") is None
+
+    def test_bulk_add(self, engine):
+        people = [
+            Person(id=f"p{i}", first_name=f"F{i}", last_name=f"L{i}", name=f"F{i} L{i}", email=f"p{i}@test.com")
+            for i in range(10)
+        ]
+        ids = engine.add_entities_bulk(people)
+        assert len(ids) == 10
+        assert engine.entity_count() == 10
+
+    def test_statistics(self, engine):
+        engine.add_entity(Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com"))
+        stats = engine.get_statistics()
+        assert stats["total_entities"] == 1
+        assert stats["total_relationships"] == 0
+
+    def test_clear(self, engine):
+        engine.add_entity(Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com"))
+        engine.clear()
+        assert engine.entity_count() == 0
+
+    def test_remove_entity_removes_relationships(self, engine):
+        engine.add_entity(Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com"))
+        engine.add_entity(Department(id="d1", name="Eng"))
+        engine.add_relationship(
+            BaseRelationship(id="r1", relationship_type=RelationshipType.WORKS_IN, source_id="p1", target_id="d1")
+        )
+        engine.remove_entity("p1")
+        assert engine.relationship_count() == 0
+
+
+class TestNetworkXEngine(GraphEngineContractTests):
+    """Runs the full engine contract test suite against NetworkX backend."""
+
+    @pytest.fixture
+    def engine(self) -> AbstractGraphEngine:
+        return NetworkXGraphEngine()

--- a/tests/unit/engine/test_query.py
+++ b/tests/unit/engine/test_query.py
@@ -1,0 +1,53 @@
+"""Tests for QueryBuilder."""
+
+from hc_enterprise_kg.domain.base import BaseRelationship, EntityType, RelationshipType
+from hc_enterprise_kg.domain.entities.department import Department
+from hc_enterprise_kg.domain.entities.person import Person
+from hc_enterprise_kg.engine.networkx_engine import NetworkXGraphEngine
+from hc_enterprise_kg.engine.query import QueryBuilder
+
+
+class TestQueryBuilder:
+    def test_query_by_type(self, engine):
+        engine.add_entity(Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com"))
+        engine.add_entity(Department(id="d1", name="Eng"))
+
+        results = QueryBuilder(engine).entities(EntityType.PERSON).execute()
+        assert len(results) == 1
+        assert results[0].id == "p1"
+
+    def test_query_with_filter(self, engine):
+        engine.add_entity(Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com", is_active=True))
+        engine.add_entity(Person(id="p2", first_name="C", last_name="D", name="C D", email="c@d.com", is_active=False))
+
+        results = QueryBuilder(engine).entities(EntityType.PERSON).where(is_active=True).execute()
+        assert len(results) == 1
+
+    def test_query_with_limit(self, engine):
+        for i in range(10):
+            engine.add_entity(Person(id=f"p{i}", first_name=f"F{i}", last_name=f"L{i}", name=f"F{i}", email=f"{i}@t.com"))
+
+        results = QueryBuilder(engine).entities(EntityType.PERSON).limit(3).execute()
+        assert len(results) == 3
+
+    def test_query_connected_to(self, engine):
+        engine.add_entity(Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com"))
+        engine.add_entity(Person(id="p2", first_name="C", last_name="D", name="C D", email="c@d.com"))
+        engine.add_entity(Department(id="d1", name="Eng"))
+        engine.add_relationship(BaseRelationship(relationship_type=RelationshipType.WORKS_IN, source_id="p1", target_id="d1"))
+
+        results = (
+            QueryBuilder(engine)
+            .entities(EntityType.PERSON)
+            .connected_to("d1", via=RelationshipType.WORKS_IN, direction="in")
+            .execute()
+        )
+        assert len(results) == 1
+        assert results[0].id == "p1"
+
+    def test_query_count(self, engine):
+        engine.add_entity(Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com"))
+        engine.add_entity(Person(id="p2", first_name="C", last_name="D", name="C D", email="c@d.com"))
+
+        count = QueryBuilder(engine).entities(EntityType.PERSON).count()
+        assert count == 2

--- a/tests/unit/export/test_exporters.py
+++ b/tests/unit/export/test_exporters.py
@@ -1,0 +1,102 @@
+"""Tests for JSON and GraphML exporters."""
+
+import json
+import tempfile
+from pathlib import Path
+
+from hc_enterprise_kg.domain.base import BaseRelationship, RelationshipType
+from hc_enterprise_kg.domain.entities.department import Department
+from hc_enterprise_kg.domain.entities.person import Person
+from hc_enterprise_kg.engine.networkx_engine import NetworkXGraphEngine
+from hc_enterprise_kg.export.graphml_export import GraphMLExporter
+from hc_enterprise_kg.export.json_export import JSONExporter
+
+
+def _build_engine() -> NetworkXGraphEngine:
+    engine = NetworkXGraphEngine()
+    person = Person(
+        id="p1", first_name="Alice", last_name="Smith",
+        name="Alice Smith", email="a@b.com",
+    )
+    dept = Department(id="d1", name="Engineering")
+    engine.add_entity(person)
+    engine.add_entity(dept)
+    engine.add_relationship(
+        BaseRelationship(
+            relationship_type=RelationshipType.WORKS_IN,
+            source_id="p1", target_id="d1",
+        )
+    )
+    return engine
+
+
+class TestJSONExporter:
+    def test_export_string_returns_valid_json(self):
+        engine = _build_engine()
+        exporter = JSONExporter()
+        result = exporter.export_string(engine)
+        data = json.loads(result)
+        assert "entities" in data
+        assert "relationships" in data
+        assert "statistics" in data
+        assert len(data["entities"]) == 2
+        assert len(data["relationships"]) == 1
+
+    def test_export_to_file(self):
+        engine = _build_engine()
+        exporter = JSONExporter()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "output.json"
+            exporter.export(engine, path)
+            assert path.exists()
+            data = json.loads(path.read_text())
+            assert len(data["entities"]) == 2
+
+    def test_export_statistics_include_counts(self):
+        engine = _build_engine()
+        exporter = JSONExporter()
+        result = exporter.export_string(engine)
+        data = json.loads(result)
+        stats = data["statistics"]
+        assert stats["entity_count"] == 2
+        assert stats["relationship_count"] == 1
+
+    def test_export_with_custom_indent(self):
+        engine = _build_engine()
+        exporter = JSONExporter()
+        result = exporter.export_string(engine, indent=4)
+        # 4-space indent means lines start with 4 spaces
+        assert "    " in result
+
+
+class TestGraphMLExporter:
+    def test_export_string_returns_xml(self):
+        engine = _build_engine()
+        exporter = GraphMLExporter()
+        result = exporter.export_string(engine)
+        assert "<?xml" in result or "<graphml" in result
+
+    def test_export_to_file(self):
+        engine = _build_engine()
+        exporter = GraphMLExporter()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "output.graphml"
+            exporter.export(engine, path)
+            assert path.exists()
+            content = path.read_text()
+            assert "graphml" in content
+
+    def test_export_contains_nodes_and_edges(self):
+        engine = _build_engine()
+        exporter = GraphMLExporter()
+        result = exporter.export_string(engine)
+        assert "p1" in result
+        assert "d1" in result
+        assert "<edge" in result
+
+    def test_complex_attributes_converted_to_strings(self):
+        engine = _build_engine()
+        exporter = GraphMLExporter()
+        # Should not raise even with complex attrs
+        result = exporter.export_string(engine)
+        assert isinstance(result, str)

--- a/tests/unit/synthetic/test_generators.py
+++ b/tests/unit/synthetic/test_generators.py
@@ -1,0 +1,60 @@
+"""Tests for entity generators."""
+
+from hc_enterprise_kg.domain.base import EntityType
+from hc_enterprise_kg.synthetic.base import GenerationContext, GeneratorRegistry
+from hc_enterprise_kg.synthetic.profiles.tech_company import mid_size_tech_company
+
+# Import to trigger registration
+import hc_enterprise_kg.synthetic.generators  # noqa: F401
+
+
+class TestGenerators:
+    def _make_context(self, employees=50):
+        profile = mid_size_tech_company(employees)
+        return GenerationContext(profile=profile, seed=42)
+
+    def test_people_generator(self):
+        ctx = self._make_context()
+        gen = GeneratorRegistry.get(EntityType.PERSON)()
+        people = gen.generate(50, ctx)
+        assert len(people) == 50
+        assert all(p.entity_type == EntityType.PERSON for p in people)
+        assert all(p.email for p in people)
+
+    def test_department_generator(self):
+        ctx = self._make_context()
+        gen = GeneratorRegistry.get(EntityType.DEPARTMENT)()
+        depts = gen.generate(len(ctx.profile.department_specs), ctx)
+        assert len(depts) == len(ctx.profile.department_specs)
+
+    def test_system_generator(self):
+        ctx = self._make_context()
+        gen = GeneratorRegistry.get(EntityType.SYSTEM)()
+        systems = gen.generate(20, ctx)
+        assert len(systems) == 20
+        assert all(s.entity_type == EntityType.SYSTEM for s in systems)
+
+    def test_vulnerability_generator(self):
+        ctx = self._make_context()
+        gen = GeneratorRegistry.get(EntityType.VULNERABILITY)()
+        vulns = gen.generate(5, ctx)
+        assert len(vulns) == 5
+        assert all(v.cve_id for v in vulns)
+
+    def test_seed_reproducibility(self):
+        ctx1 = self._make_context()
+        ctx2 = self._make_context()
+        gen = GeneratorRegistry.get(EntityType.PERSON)()
+        people1 = gen.generate(10, ctx1)
+        people2 = gen.generate(10, ctx2)
+        assert [p.name for p in people1] == [p.name for p in people2]
+
+    def test_all_generators_registered(self):
+        expected = {
+            EntityType.PERSON, EntityType.DEPARTMENT, EntityType.ROLE,
+            EntityType.SYSTEM, EntityType.NETWORK, EntityType.DATA_ASSET,
+            EntityType.POLICY, EntityType.VENDOR, EntityType.LOCATION,
+            EntityType.VULNERABILITY, EntityType.THREAT_ACTOR, EntityType.INCIDENT,
+        }
+        registered = set(GeneratorRegistry.all().keys())
+        assert expected.issubset(registered)

--- a/tests/unit/synthetic/test_orchestrator.py
+++ b/tests/unit/synthetic/test_orchestrator.py
@@ -1,0 +1,37 @@
+"""Tests for SyntheticOrchestrator."""
+
+from hc_enterprise_kg.graph.knowledge_graph import KnowledgeGraph
+from hc_enterprise_kg.synthetic.orchestrator import SyntheticOrchestrator
+from hc_enterprise_kg.synthetic.profiles.tech_company import mid_size_tech_company
+
+
+class TestSyntheticOrchestrator:
+    def test_generate_small_org(self):
+        kg = KnowledgeGraph()
+        profile = mid_size_tech_company(50)
+        orchestrator = SyntheticOrchestrator(kg, profile, seed=42)
+        counts = orchestrator.generate()
+
+        assert counts["person"] == 50
+        assert counts["department"] == 10
+        assert counts["_relationships"] > 0
+        assert kg.statistics["total_entities"] > 50
+        assert kg.statistics["total_relationships"] > 0
+
+    def test_generate_with_seed_reproducible(self):
+        kg1 = KnowledgeGraph()
+        kg2 = KnowledgeGraph()
+        profile = mid_size_tech_company(20)
+
+        SyntheticOrchestrator(kg1, profile, seed=42).generate()
+        SyntheticOrchestrator(kg2, profile, seed=42).generate()
+
+        assert kg1.statistics["total_entities"] == kg2.statistics["total_entities"]
+        assert kg1.statistics["total_relationships"] == kg2.statistics["total_relationships"]
+
+    def test_event_log_populated(self):
+        kg = KnowledgeGraph(track_events=True)
+        profile = mid_size_tech_company(10)
+        SyntheticOrchestrator(kg, profile, seed=42).generate()
+
+        assert len(kg.event_log) > 0

--- a/tests/unit/synthetic/test_profiles.py
+++ b/tests/unit/synthetic/test_profiles.py
@@ -1,0 +1,31 @@
+"""Tests for organization profiles."""
+
+from hc_enterprise_kg.synthetic.profiles.financial_org import financial_org
+from hc_enterprise_kg.synthetic.profiles.healthcare_org import healthcare_org
+from hc_enterprise_kg.synthetic.profiles.tech_company import mid_size_tech_company
+
+
+class TestProfiles:
+    def test_tech_profile(self):
+        profile = mid_size_tech_company(500)
+        assert profile.employee_count == 500
+        assert profile.industry == "technology"
+        assert len(profile.department_specs) == 10
+        fractions = sum(s.headcount_fraction for s in profile.department_specs)
+        assert 0.99 <= fractions <= 1.01
+
+    def test_healthcare_profile(self):
+        profile = healthcare_org(2000)
+        assert profile.employee_count == 2000
+        assert profile.industry == "healthcare"
+        assert len(profile.department_specs) == 10
+
+    def test_financial_profile(self):
+        profile = financial_org(1000)
+        assert profile.employee_count == 1000
+        assert profile.industry == "financial_services"
+        assert len(profile.department_specs) == 11
+
+    def test_profile_custom_employee_count(self):
+        profile = mid_size_tech_company(100)
+        assert profile.employee_count == 100

--- a/tests/unit/synthetic/test_relationships.py
+++ b/tests/unit/synthetic/test_relationships.py
@@ -1,0 +1,116 @@
+"""Tests for RelationshipWeaver."""
+
+import random
+
+from hc_enterprise_kg.domain.base import EntityType, RelationshipType
+from hc_enterprise_kg.domain.entities.department import Department
+from hc_enterprise_kg.domain.entities.location import Location
+from hc_enterprise_kg.domain.entities.network import Network
+from hc_enterprise_kg.domain.entities.person import Person
+from hc_enterprise_kg.domain.entities.system import System
+from hc_enterprise_kg.domain.entities.vulnerability import Vulnerability
+from hc_enterprise_kg.synthetic.base import GenerationContext
+from hc_enterprise_kg.synthetic.profiles.tech_company import mid_size_tech_company
+from hc_enterprise_kg.synthetic.relationships import RelationshipWeaver
+
+
+def _build_context(num_people: int = 10, seed: int = 42) -> GenerationContext:
+    profile = mid_size_tech_company(num_people)
+    ctx = GenerationContext(profile=profile, seed=seed)
+
+    # Generate minimal entities
+    people = [
+        Person(id=f"p{i}", first_name=f"Person{i}", last_name="Test", name=f"Person{i} Test", email=f"p{i}@t.com")
+        for i in range(num_people)
+    ]
+    departments = [
+        Department(id=f"d{i}", name=spec.name)
+        for i, spec in enumerate(profile.department_specs)
+    ]
+    systems = [
+        System(id=f"s{i}", name=f"System{i}", system_type="application")
+        for i in range(5)
+    ]
+    networks = [
+        Network(id=f"n{i}", name=f"Network{i}", network_type="lan", cidr="10.0.0.0/24")
+        for i in range(3)
+    ]
+    locations = [
+        Location(id=f"l{i}", name=f"Location{i}", city=f"City{i}", country="US")
+        for i in range(2)
+    ]
+    vulns = [
+        Vulnerability(id=f"v{i}", name=f"CVE-2024-000{i}", severity="high")
+        for i in range(2)
+    ]
+
+    ctx.store(EntityType.PERSON, people)
+    ctx.store(EntityType.DEPARTMENT, departments)
+    ctx.store(EntityType.SYSTEM, systems)
+    ctx.store(EntityType.NETWORK, networks)
+    ctx.store(EntityType.LOCATION, locations)
+    ctx.store(EntityType.VULNERABILITY, vulns)
+
+    return ctx
+
+
+class TestRelationshipWeaver:
+    def test_weave_all_produces_relationships(self):
+        ctx = _build_context()
+        weaver = RelationshipWeaver(ctx)
+        rels = weaver.weave_all()
+        assert len(rels) > 0
+
+    def test_people_assigned_to_departments(self):
+        ctx = _build_context()
+        weaver = RelationshipWeaver(ctx)
+        rels = weaver.weave_all()
+        works_in = [r for r in rels if r.relationship_type == RelationshipType.WORKS_IN]
+        assert len(works_in) > 0
+
+    def test_systems_assigned_to_networks(self):
+        ctx = _build_context()
+        weaver = RelationshipWeaver(ctx)
+        rels = weaver.weave_all()
+        connects = [r for r in rels if r.relationship_type == RelationshipType.CONNECTS_TO]
+        assert len(connects) > 0
+
+    def test_locations_assigned(self):
+        ctx = _build_context()
+        weaver = RelationshipWeaver(ctx)
+        rels = weaver.weave_all()
+        located = [r for r in rels if r.relationship_type == RelationshipType.LOCATED_AT]
+        assert len(located) > 0
+
+    def test_management_chains_created(self):
+        ctx = _build_context(num_people=20)
+        weaver = RelationshipWeaver(ctx)
+        rels = weaver.weave_all()
+        reports_to = [r for r in rels if r.relationship_type == RelationshipType.REPORTS_TO]
+        manages = [r for r in rels if r.relationship_type == RelationshipType.MANAGES]
+        assert len(reports_to) > 0
+        assert len(manages) > 0
+
+    def test_vulns_assigned_to_systems(self):
+        ctx = _build_context()
+        weaver = RelationshipWeaver(ctx)
+        rels = weaver.weave_all()
+        affects = [r for r in rels if r.relationship_type == RelationshipType.AFFECTS]
+        assert len(affects) > 0
+
+    def test_empty_entity_lists_produce_no_relationships(self):
+        profile = mid_size_tech_company(10)
+        ctx = GenerationContext(profile=profile, seed=42)
+        # Don't store any entities
+        weaver = RelationshipWeaver(ctx)
+        rels = weaver.weave_all()
+        assert len(rels) == 0
+
+    def test_seed_reproducibility(self):
+        ctx1 = _build_context(seed=99)
+        rels1 = RelationshipWeaver(ctx1).weave_all()
+
+        ctx2 = _build_context(seed=99)
+        rels2 = RelationshipWeaver(ctx2).weave_all()
+
+        assert len(rels1) == len(rels2)


### PR DESCRIPTION
## Summary
- 16 unit test files covering domain model, engine contracts, query builder, synthetic generators/profiles/orchestrator/relationships, auto-KG extractors/linkers/resolvers/pipeline, and JSON/GraphML exporters
- 3 integration test files for KnowledgeGraph lifecycle, synthetic generation pipeline, and auto-KG CSV-to-KG pipeline
- Test fixtures: sample CSV, JSON entities, and unstructured text for extraction
- 2 example scripts: `quick_start.py` (synthetic generation) and `auto_kg_from_csv.py` (auto-KG construction)

## Test plan
- [ ] `poetry install` to install all dependencies
- [ ] `make test` to run the full suite
- [ ] `python examples/quick_start.py` to verify synthetic generation
- [ ] `python examples/auto_kg_from_csv.py` to verify auto-KG pipeline