### PR TITLE
Fix integration issues and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# hc-enterprise-kg
+
+Enterprise Knowledge Graph for cybersecurity, data, and AI research.
+
+## Install
+
+```bash
+poetry install
+```
+
+## Usage
+
+```bash
+# Generate a synthetic org KG
+hckg generate org --profile tech --employees 100 --seed 42
+
+# Inspect the graph
+hckg inspect
+
+# Export
+hckg export --format json --output graph.json
+```
+
+## Development
+
+```bash
+make test       # Run tests
+make lint       # Lint
+make typecheck  # Type check
+make all        # All of the above
+```

--- a/examples/auto_kg_from_csv.py
+++ b/examples/auto_kg_from_csv.py
@@ -11,15 +11,15 @@ from hc_enterprise_kg.domain.base import EntityType
 from hc_enterprise_kg.graph.knowledge_graph import KnowledgeGraph
 
 # Sample organizational data
-SAMPLE_DATA = """name,email,department,title,location
-Alice Smith,alice@acme.com,Engineering,Software Engineer,New York
-Bob Jones,bob@acme.com,Marketing,Marketing Manager,San Francisco
-Carol White,carol@acme.com,Engineering,Senior Engineer,New York
-Dave Brown,dave@acme.com,Finance,Financial Analyst,Chicago
-Eve Wilson,eve@acme.com,Human Resources,HR Director,San Francisco
-Frank Miller,frank@acme.com,Engineering,DevOps Engineer,New York
-Grace Lee,grace@acme.com,Sales,Account Executive,Chicago
-Alice Smith,alice.s@acme.com,Engineering,Lead Engineer,New York
+SAMPLE_DATA = """name,first_name,last_name,email,department,title,location
+Alice Smith,Alice,Smith,alice@acme.com,Engineering,Software Engineer,New York
+Bob Jones,Bob,Jones,bob@acme.com,Marketing,Marketing Manager,San Francisco
+Carol White,Carol,White,carol@acme.com,Engineering,Senior Engineer,New York
+Dave Brown,Dave,Brown,dave@acme.com,Finance,Financial Analyst,Chicago
+Eve Wilson,Eve,Wilson,eve@acme.com,Human Resources,HR Director,San Francisco
+Frank Miller,Frank,Miller,frank@acme.com,Engineering,DevOps Engineer,New York
+Grace Lee,Grace,Lee,grace@acme.com,Sales,Account Executive,Chicago
+Alice Smith,Alice,Smith,alice.s@acme.com,Engineering,Lead Engineer,New York
 """
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ dependencies = [
     "click>=8.1",
     "pyyaml>=6.0",
     "litellm>=1.0",
-    "sentence-transformers>=2.2",
     "rapidfuzz>=3.0",
 ]
 
 [project.optional-dependencies]
+embeddings = ["sentence-transformers>=2.2"]
 neo4j = ["neo4j>=5.0"]
 viz = ["matplotlib>=3.8", "pyvis>=0.3"]
 dev = [

--- a/src/hc_enterprise_kg/auto/extractors/rule_based.py
+++ b/src/hc_enterprise_kg/auto/extractors/rule_based.py
@@ -49,6 +49,7 @@ class RuleBasedExtractor(AbstractExtractor):
             if email in seen:
                 continue
             seen.add(email)
+            seen.add(email.split("@")[1])  # Prevent domain from matching as hostname
             local = email.split("@")[0]
             parts = re.split(r"[._-]", local)
             first = parts[0].title() if parts else "Unknown"

--- a/src/hc_enterprise_kg/engine/networkx_engine.py
+++ b/src/hc_enterprise_kg/engine/networkx_engine.py
@@ -251,10 +251,10 @@ class NetworkXGraphEngine(AbstractGraphEngine):
             rel_type_counts[t] = rel_type_counts.get(t, 0) + 1
 
         return {
-            "total_entities": g.number_of_nodes(),
-            "total_relationships": g.number_of_edges(),
-            "entity_type_counts": type_counts,
-            "relationship_type_counts": rel_type_counts,
+            "entity_count": g.number_of_nodes(),
+            "relationship_count": g.number_of_edges(),
+            "entity_types": type_counts,
+            "relationship_types": rel_type_counts,
             "density": nx.density(g),
             "is_weakly_connected": (
                 nx.is_weakly_connected(g) if g.number_of_nodes() > 0 else True

--- a/src/hc_enterprise_kg/export/graphml_export.py
+++ b/src/hc_enterprise_kg/export/graphml_export.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -41,6 +42,8 @@ class GraphMLExporter(AbstractExporter):
             for key, value in list(data.items()):
                 if isinstance(value, (list, dict)):
                     data[key] = str(value)
+                elif isinstance(value, datetime):
+                    data[key] = value.isoformat()
                 elif isinstance(value, bool):
                     data[key] = str(value).lower()
                 elif value is None:
@@ -50,6 +53,8 @@ class GraphMLExporter(AbstractExporter):
             for k, value in list(data.items()):
                 if isinstance(value, (list, dict)):
                     data[k] = str(value)
+                elif isinstance(value, datetime):
+                    data[k] = value.isoformat()
                 elif isinstance(value, bool):
                     data[k] = str(value).lower()
                 elif value is None:

--- a/src/hc_enterprise_kg/synthetic/base.py
+++ b/src/hc_enterprise_kg/synthetic/base.py
@@ -30,6 +30,7 @@ class GenerationContext:
         self.faker = Faker()
         if seed is not None:
             Faker.seed(seed)
+            self.faker.unique.clear()
             import random
 
             random.seed(seed)

--- a/tests/fixtures/sample_org.csv
+++ b/tests/fixtures/sample_org.csv
@@ -1,11 +1,11 @@
-name,email,department,title,location
-Alice Smith,alice@acme.com,Engineering,Software Engineer,New York
-Bob Jones,bob@acme.com,Marketing,Marketing Manager,San Francisco
-Carol White,carol@acme.com,Engineering,Senior Engineer,New York
-Dave Brown,dave@acme.com,Finance,Financial Analyst,Chicago
-Eve Wilson,eve@acme.com,Human Resources,HR Director,San Francisco
-Frank Miller,frank@acme.com,Engineering,DevOps Engineer,New York
-Grace Lee,grace@acme.com,Sales,Account Executive,Chicago
-Hank Taylor,hank@acme.com,IT,System Administrator,New York
-Iris Chen,iris@acme.com,Security,Security Analyst,San Francisco
-Jack Davis,jack@acme.com,Engineering,Tech Lead,New York
+name,first_name,last_name,email,department,title,location
+Alice Smith,Alice,Smith,alice@acme.com,Engineering,Software Engineer,New York
+Bob Jones,Bob,Jones,bob@acme.com,Marketing,Marketing Manager,San Francisco
+Carol White,Carol,White,carol@acme.com,Engineering,Senior Engineer,New York
+Dave Brown,Dave,Brown,dave@acme.com,Finance,Financial Analyst,Chicago
+Eve Wilson,Eve,Wilson,eve@acme.com,Human Resources,HR Director,San Francisco
+Frank Miller,Frank,Miller,frank@acme.com,Engineering,DevOps Engineer,New York
+Grace Lee,Grace,Lee,grace@acme.com,Sales,Account Executive,Chicago
+Hank Taylor,Hank,Taylor,hank@acme.com,IT,System Administrator,New York
+Iris Chen,Iris,Chen,iris@acme.com,Security,Security Analyst,San Francisco
+Jack Davis,Jack,Davis,jack@acme.com,Engineering,Tech Lead,New York

--- a/tests/integration/test_auto_pipeline.py
+++ b/tests/integration/test_auto_pipeline.py
@@ -11,10 +11,10 @@ from hc_enterprise_kg.auto.resolvers.dedup_resolver import DedupResolver
 from hc_enterprise_kg.domain.base import EntityType
 from hc_enterprise_kg.graph.knowledge_graph import KnowledgeGraph
 
-SAMPLE_CSV = """name,email,department,title
-Alice Smith,alice@acme.com,Engineering,Software Engineer
-Bob Jones,bob@acme.com,Marketing,Marketing Manager
-Carol White,carol@acme.com,Engineering,Senior Engineer
+SAMPLE_CSV = """name,first_name,last_name,email,department,title
+Alice Smith,Alice,Smith,alice@acme.com,Engineering,Software Engineer
+Bob Jones,Bob,Jones,bob@acme.com,Marketing,Marketing Manager
+Carol White,Carol,White,carol@acme.com,Engineering,Senior Engineer
 """
 
 
@@ -80,9 +80,9 @@ class TestAutoPipelineIntegration:
 
     def test_dedup_in_pipeline(self):
         kg = KnowledgeGraph()
-        csv_content = """name,email,department,title
-Alice Smith,alice@acme.com,Engineering,Engineer
-Alice Smith,,Engineering,Senior Engineer
+        csv_content = """name,first_name,last_name,email,department,title
+Alice Smith,Alice,Smith,alice@acme.com,Engineering,Engineer
+Alice Smith,Alice,Smith,alice.smith@acme.com,Engineering,Senior Engineer
 """
         pipeline = AutoKGPipeline(
             kg,

--- a/tests/unit/engine/test_contract.py
+++ b/tests/unit/engine/test_contract.py
@@ -147,8 +147,8 @@ class GraphEngineContractTests:
     def test_statistics(self, engine):
         engine.add_entity(Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com"))
         stats = engine.get_statistics()
-        assert stats["total_entities"] == 1
-        assert stats["total_relationships"] == 0
+        assert stats["entity_count"] == 1
+        assert stats["relationship_count"] == 0
 
     def test_clear(self, engine):
         engine.add_entity(Person(id="p1", first_name="A", last_name="B", name="A B", email="a@b.com"))

--- a/tests/unit/synthetic/test_generators.py
+++ b/tests/unit/synthetic/test_generators.py
@@ -42,11 +42,13 @@ class TestGenerators:
         assert all(v.cve_id for v in vulns)
 
     def test_seed_reproducibility(self):
-        ctx1 = self._make_context()
-        ctx2 = self._make_context()
-        gen = GeneratorRegistry.get(EntityType.PERSON)()
-        people1 = gen.generate(10, ctx1)
-        people2 = gen.generate(10, ctx2)
+        # Each context re-seeds Faker globally, so we need fresh generators
+        ctx1 = GenerationContext(profile=mid_size_tech_company(50), seed=42)
+        people1 = GeneratorRegistry.get(EntityType.PERSON)().generate(10, ctx1)
+
+        ctx2 = GenerationContext(profile=mid_size_tech_company(50), seed=42)
+        people2 = GeneratorRegistry.get(EntityType.PERSON)().generate(10, ctx2)
+
         assert [p.name for p in people1] == [p.name for p in people2]
 
     def test_all_generators_registered(self):

--- a/tests/unit/synthetic/test_orchestrator.py
+++ b/tests/unit/synthetic/test_orchestrator.py
@@ -15,8 +15,8 @@ class TestSyntheticOrchestrator:
         assert counts["person"] == 50
         assert counts["department"] == 10
         assert counts["_relationships"] > 0
-        assert kg.statistics["total_entities"] > 50
-        assert kg.statistics["total_relationships"] > 0
+        assert kg.statistics["entity_count"] > 50
+        assert kg.statistics["relationship_count"] > 0
 
     def test_generate_with_seed_reproducible(self):
         kg1 = KnowledgeGraph()
@@ -26,8 +26,8 @@ class TestSyntheticOrchestrator:
         SyntheticOrchestrator(kg1, profile, seed=42).generate()
         SyntheticOrchestrator(kg2, profile, seed=42).generate()
 
-        assert kg1.statistics["total_entities"] == kg2.statistics["total_entities"]
-        assert kg1.statistics["total_relationships"] == kg2.statistics["total_relationships"]
+        assert kg1.statistics["entity_count"] == kg2.statistics["entity_count"]
+        assert kg1.statistics["relationship_count"] == kg2.statistics["relationship_count"]
 
     def test_event_log_populated(self):
         kg = KnowledgeGraph(track_events=True)


### PR DESCRIPTION
## Summary
- Fix engine statistics key names (`entity_count`, `relationship_count`, `entity_types`) for consistency
- Handle `datetime` serialization in GraphML exporter (prevents `NetworkXError`)
- Prevent email domains from being re-extracted as hostname entities in rule-based extractor
- Clear Faker unique state on seed reset for reliable generator reproducibility
- Make `sentence-transformers` optional (PyTorch lacks Python 3.14 wheels)
- Update CSV fixtures with `first_name`/`last_name` columns for Person model compatibility
- Add `README.md`

## Test plan
- [x] All 124 tests pass (`poetry run pytest tests/ -q`)
- [x] `python examples/quick_start.py` runs successfully
- [x] `python examples/auto_kg_from_csv.py` runs successfully with dedup working