### PR TITLE
Add zero-config demo command, improve CLI UX, rewrite README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ Thumbs.db
 *.db
 *.sqlite3
 exports/
+
+# Generated KG outputs
+graph.json
+graph.graphml
+result.json

--- a/src/cli/auto_cmd.py
+++ b/src/cli/auto_cmd.py
@@ -16,7 +16,8 @@ def auto() -> None:
 
 
 @auto.command()
-@click.argument("source", type=click.Path(exists=True))
+@click.argument("source", type=click.Path(exists=True), required=False, default=None)
+@click.option("--demo", is_flag=True, help="Run with dynamically generated sample data (no file needed).")
 @click.option("--use-llm/--no-llm", default=False, help="Enable LLM-based extraction.")
 @click.option("--use-embeddings/--no-embeddings", default=False, help="Enable embedding-based linking.")
 @click.option("--llm-model", default="gpt-4o-mini", help="LLM model to use.")
@@ -24,14 +25,29 @@ def auto() -> None:
 @click.pass_context
 def build(
     ctx: click.Context,
-    source: str,
+    source: str | None,
+    demo: bool,
     use_llm: bool,
     use_embeddings: bool,
     llm_model: str,
     output: str | None,
 ) -> None:
-    """Build a KG automatically from a data source."""
+    """Build a KG automatically from a data source.
+
+    \b
+    Examples:
+        hckg auto build data.csv --output result.json
+        hckg auto build --demo --output result.json
+    """
     from auto.pipeline import AutoKGPipeline
+
+    if source is None and not demo:
+        raise click.UsageError(
+            "Provide a SOURCE file, or use --demo to run with generated sample data.\n\n"
+            "Examples:\n"
+            "  hckg auto build data.csv --output result.json\n"
+            "  hckg auto build --demo --output result.json"
+        )
 
     backend = ctx.obj.get("backend", "networkx") if ctx.obj else "networkx"
     kg = KnowledgeGraph(backend=backend)
@@ -43,13 +59,22 @@ def build(
         llm_model=llm_model,
     )
 
-    source_path = Path(source)
-    if source_path.suffix == ".csv":
-        data = source
+    if demo:
+        import tempfile
+        csv_content = _generate_demo_csv()
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False, prefix="hckg_demo_")
+        tmp.write(csv_content)
+        tmp.close()
+        data = tmp.name
+        click.echo("Running auto-KG pipeline on dynamically generated sample data...")
     else:
-        data = source_path.read_text()
+        source_path = Path(source)  # type: ignore[arg-type]
+        if source_path.suffix == ".csv":
+            data = source  # type: ignore[assignment]
+        else:
+            data = source_path.read_text()
+        click.echo(f"Running auto-KG pipeline on {source}...")
 
-    click.echo(f"Running auto-KG pipeline on {source}...")
     result = pipeline.run(data)
 
     click.echo("\nPipeline results:")
@@ -60,6 +85,38 @@ def build(
         from export.json_export import JSONExporter
         JSONExporter().export(kg.engine, Path(output))
         click.echo(f"\nExported to {output}")
+
+
+def _generate_demo_csv() -> str:
+    """Dynamically generate a sample CSV using Faker."""
+    from faker import Faker
+
+    fake = Faker()
+    Faker.seed(42)
+
+    departments = ["Engineering", "Marketing", "Sales", "Finance", "HR", "Security", "IT Operations"]
+    titles = {
+        "Engineering": ["Software Engineer", "Senior Engineer", "Tech Lead", "DevOps Engineer"],
+        "Marketing": ["Marketing Manager", "Content Strategist", "Growth Analyst"],
+        "Sales": ["Account Executive", "Sales Director", "Business Development Rep"],
+        "Finance": ["Financial Analyst", "Controller", "Accountant"],
+        "HR": ["HR Director", "Recruiter", "HR Specialist"],
+        "Security": ["Security Analyst", "CISO", "Penetration Tester"],
+        "IT Operations": ["System Administrator", "Network Engineer", "DBA"],
+    }
+    locations = ["New York", "San Francisco", "Chicago", "Austin", "Seattle"]
+
+    lines = ["name,first_name,last_name,email,department,title,location"]
+    for _ in range(25):
+        first = fake.first_name()
+        last = fake.last_name()
+        dept = fake.random_element(departments)
+        title = fake.random_element(titles[dept])
+        location = fake.random_element(locations)
+        email = f"{first.lower()}.{last.lower()}@{fake.company().lower().replace(' ', '').replace(',', '')}.com"
+        lines.append(f"{first} {last},{first},{last},{email},{dept},{title},{location}")
+
+    return "\n".join(lines)
 
 
 @auto.command()

--- a/src/cli/demo_cmd.py
+++ b/src/cli/demo_cmd.py
@@ -1,0 +1,70 @@
+"""One-command demo: generates a KG, exports it, and prints a summary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+
+@click.command()
+@click.option("--profile", type=click.Choice(["tech", "healthcare", "financial"]), default="tech", help="Organization profile.")
+@click.option("--employees", type=int, default=100, help="Number of employees.")
+@click.option("--seed", type=int, default=42, help="Random seed.")
+@click.option("--output", type=click.Path(), default="graph.json", help="Output file path.")
+@click.option("--format", "fmt", type=click.Choice(["json", "graphml"]), default="json", help="Output format.")
+def demo(profile: str, employees: int, seed: int, output: str, fmt: str) -> None:
+    """Generate a full enterprise KG, export it, and print a summary.
+
+    \b
+    Just run:
+        hckg demo
+
+    That's it. You'll get a graph.json with a complete enterprise knowledge graph.
+    """
+    from graph.knowledge_graph import KnowledgeGraph
+    from synthetic.orchestrator import SyntheticOrchestrator
+
+    # Load profile
+    if profile == "tech":
+        from synthetic.profiles.tech_company import mid_size_tech_company
+        org_profile = mid_size_tech_company(employees)
+    elif profile == "healthcare":
+        from synthetic.profiles.healthcare_org import healthcare_org
+        org_profile = healthcare_org(employees)
+    elif profile == "financial":
+        from synthetic.profiles.financial_org import financial_org
+        org_profile = financial_org(employees)
+    else:
+        raise click.BadParameter(f"Unknown profile: {profile}")
+
+    kg = KnowledgeGraph()
+    orchestrator = SyntheticOrchestrator(kg, org_profile, seed=seed)
+
+    click.echo(f"Generating {org_profile.name} ({employees} employees, seed={seed})...")
+    counts = orchestrator.generate()
+
+    # Export
+    output_path = Path(output)
+    if fmt == "graphml":
+        from export.graphml_export import GraphMLExporter
+        GraphMLExporter().export(kg.engine, output_path)
+    else:
+        from export.json_export import JSONExporter
+        JSONExporter().export(kg.engine, output_path)
+
+    # Print summary
+    stats = kg.statistics
+    click.echo("")
+    click.echo("Entity breakdown:")
+    for etype, ecount in sorted(stats["entity_types"].items()):
+        click.echo(f"  {etype:20s} {ecount:>6d}")
+
+    click.echo("")
+    click.echo(f"Total entities:      {stats['entity_count']}")
+    click.echo(f"Total relationships: {stats['relationship_count']}")
+    click.echo(f"Output:              {output_path.resolve()}")
+    click.echo("")
+    click.echo("Next steps:")
+    click.echo(f"  hckg inspect {output}")
+    click.echo(f"  hckg export --source {output} --format graphml --output graph.graphml")

--- a/src/cli/generate.py
+++ b/src/cli/generate.py
@@ -24,9 +24,9 @@ def generate() -> None:
 )
 @click.option("--employees", type=int, default=500, help="Number of employees.")
 @click.option("--seed", type=int, default=None, help="Random seed for reproducibility.")
-@click.option("--output", type=click.Path(), default=None, help="Export to JSON file.")
+@click.option("--output", type=click.Path(), default="graph.json", show_default=True, help="Export to JSON file.")
 @click.pass_context
-def org(ctx: click.Context, profile: str, employees: int, seed: int | None, output: str | None) -> None:
+def org(ctx: click.Context, profile: str, employees: int, seed: int | None, output: str) -> None:
     """Generate a full organizational knowledge graph."""
     from synthetic.orchestrator import SyntheticOrchestrator
 
@@ -58,7 +58,6 @@ def org(ctx: click.Context, profile: str, employees: int, seed: int | None, outp
     click.echo(f"\nTotal entities: {stats['entity_count']}")
     click.echo(f"Total relationships: {stats['relationship_count']}")
 
-    if output:
-        from export.json_export import JSONExporter
-        JSONExporter().export(kg.engine, Path(output))
-        click.echo(f"\nExported to {output}")
+    from export.json_export import JSONExporter
+    JSONExporter().export(kg.engine, Path(output))
+    click.echo(f"\nExported to {output}")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -18,11 +18,13 @@ def cli(ctx: click.Context, backend: str) -> None:
 
 
 # Import and register subcommand groups
+from cli.demo_cmd import demo  # noqa: E402
 from cli.generate import generate  # noqa: E402
 from cli.auto_cmd import auto  # noqa: E402
 from cli.export_cmd import export_cmd  # noqa: E402
 from cli.inspect_cmd import inspect_cmd  # noqa: E402
 
+cli.add_command(demo)
 cli.add_command(generate)
 cli.add_command(auto)
 cli.add_command(export_cmd, name="export")


### PR DESCRIPTION
## Summary

- **`hckg demo`** — new zero-config command that generates a full enterprise KG, exports to `graph.json`, and prints a summary with next steps. One command, no arguments needed.
- **`generate org`** now always exports to `graph.json` by default (previously silently discarded the graph if `--output` wasn't specified)
- **`auto build --demo`** — dynamically generates sample CSV data using Faker instead of requiring a static file
- **Better error messages** — `auto build` with no arguments shows usage examples instead of a raw Click error
- **Comprehensive README rewrite** — prerequisites, Poetry setup, shell alias, entity type table, full CLI reference with option tables, Python API examples (querying, analysis, security queries, export), org profile comparison, optional deps, and troubleshooting for every known setup issue
- **`.gitignore`** — generated output files (`graph.json`, `result.json`, `graph.graphml`) excluded from repo

## Test plan

- [x] All 124 tests pass
- [x] `hckg demo` produces `graph.json` with correct entity/relationship counts
- [x] `hckg inspect graph.json` works on the demo output
- [x] `hckg generate org` auto-exports without `--output` flag
- [x] `hckg auto build --demo --output result.json` generates and processes dynamic CSV
- [x] `hckg auto build` with no args shows helpful error with examples