### PR TITLE
fix: single-source version via importlib.metadata

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,8 @@
 """Enterprise Knowledge Graph for cybersecurity, data, and AI research."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("hc-enterprise-kg")
+except PackageNotFoundError:
+    __version__ = "0.0.0"  # Fallback for editable installs without metadata


### PR DESCRIPTION
## Summary
- Replaces hardcoded `__version__ = "0.1.0"` with `importlib.metadata.version()`
- Version now always matches pyproject.toml
- Graceful fallback for editable installs without metadata

Closes #24