### PR TITLE
Move blast_radius BFS to engine layer

### DIFF
--- a/src/graph/knowledge_graph.py
+++ b/src/graph/knowledge_graph.py
@@ -134,6 +134,12 @@ class KnowledgeGraph:
     def shortest_path(self, source_id: str, target_id: str) -> list[str] | None:
         return self._engine.shortest_path(source_id, target_id)
 
+    def blast_radius(
+        self, entity_id: str, max_depth: int = 3
+    ) -> dict[int, list[BaseEntity]]:
+        """Compute entities reachable within N hops (blast radius analysis)."""
+        return self._engine.blast_radius(entity_id, max_depth)
+
     # --- Query ---
 
     def query(self) -> QueryBuilder:


### PR DESCRIPTION
## Summary
- Adds `blast_radius()` as a concrete method on `AbstractGraphEngine` with default BFS implementation
- Exposes via `KnowledgeGraph.blast_radius()` facade
- Simplifies MCP `get_blast_radius` tool to thin delegate — removes `deque` import from tools.py

## Test plan
- [x] 63 affected tests passing (engine, MCP, integration)
- [x] ruff clean
- [x] Blast radius results unchanged (same BFS algorithm, relocated)

Closes #33