### PR TITLE
Align ID prefix comments with generators

### DIFF
--- a/src/domain/entities/control.py
+++ b/src/domain/entities/control.py
@@ -178,7 +178,7 @@ class Control(BaseEntity):
     entity_type: Literal[EntityType.CONTROL] = EntityType.CONTROL
 
     # --- Identity & classification ---
-    control_id: str = ""  # Format: CL-XXXXX
+    control_id: str = ""  # Format: CTL-XXXXX
     control_type: str = ""  # Preventive, Detective, Corrective, Deterrent, Compensating
     control_category: str = ""  # Technical, Administrative, Physical
     control_class: str = ""  # Automated, Semi-Automated, Manual

--- a/src/domain/entities/regulation.py
+++ b/src/domain/entities/regulation.py
@@ -119,7 +119,7 @@ class Regulation(BaseEntity):
     entity_type: Literal[EntityType.REGULATION] = EntityType.REGULATION
 
     # --- Identity ---
-    regulation_id: str = ""  # Format: RG-XXXXX
+    regulation_id: str = ""  # Format: REG-XXXXX
     short_name: str = ""  # e.g., "GDPR"
     regulation_type: str = ""  # Law/Statute, Regulation/Rule, Executive Order, etc.
     regulation_category: str = ""  # Data Privacy, Financial Reporting, Cybersecurity, etc.

--- a/src/domain/entities/risk.py
+++ b/src/domain/entities/risk.py
@@ -165,7 +165,7 @@ class Risk(BaseEntity):
     entity_type: Literal[EntityType.RISK] = EntityType.RISK
 
     # --- Identity & classification ---
-    risk_id: str = ""  # Format: RS-XXXXX
+    risk_id: str = ""  # Format: RSK-XXXXX
     risk_category: str = ""  # Cybersecurity, Data Privacy, Strategic, Financial, etc.
     risk_subcategory: str = ""
     risk_source: str = ""  # Internal, External, Third Party, Regulatory, etc.

--- a/src/domain/entities/threat.py
+++ b/src/domain/entities/threat.py
@@ -100,7 +100,7 @@ class Threat(BaseEntity):
     entity_type: Literal[EntityType.THREAT] = EntityType.THREAT
 
     # --- Identity & classification ---
-    threat_id: str = ""  # Format: TH-XXXXX
+    threat_id: str = ""  # Format: THR-XXXXX
     threat_group: str = ""  # Natural Threat, Man-Made Intentional/Unintentional/Systemic, etc.
     threat_category: str = ""  # Environmental/Weather, Cyber — External Actor, etc.
     threat_source_type: str = ""  # Nation State, Organized Criminal, Hacktivist, etc.


### PR DESCRIPTION
## Summary
- Updated schema comments for regulation, control, risk, and threat entity ID fields
- Comments now match generator output: `REG-`, `CTL-`, `RSK-`, `THR-` (was `RG-`, `CL-`, `RS-`, `TH-`)

## Test plan
- [x] Comment-only change — no behavior change
- [x] Verified against generator output in `src/synthetic/generators/enterprise.py`

Closes #35