### PR TITLE
Documentation overhaul: CLAUDE.md, README, CHANGELOG, CONTRIBUTING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,40 +4,148 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.17.0] - 2026-02-20
 
 ### Added
+- **CSVIngestor transforms** — `FieldMapping.transform` now applied during ingestion (lowercase, uppercase, strip, int, float, bool)
+- **CSVIngestor relationship mappings** — `SchemaMapping.relationship_mappings` processed after entity ingestion
+- **JSONIngestor.ingest_string()** — In-memory JSON ingestion with shared core logic
+- **25 new ingestor tests**
 
-- **`hckg serve` command** — Unified server with two modes: REST API (default, Flask) for any HTTP client, and `--stdio` for Claude Desktop's MCP pipe. Works with ChatGPT, OpenAI, LangChain, curl, or any LLM client
-- **OpenAI-compatible endpoints** — `GET /openai/tools` returns function-calling tool definitions; `POST /openai/call` dispatches tool invocations for agent frameworks
-- **GraphRAG endpoint** — `POST /ask` accepts natural-language questions and returns relevant graph context via the retrieval pipeline
-- **`hckg install` command** — Register hc-enterprise-kg with LLM clients: `hckg install claude`, `hckg install status`, `hckg install remove claude`. Auto-detects config paths on macOS/Windows/Linux
-- **GraphRAG retrieval pipeline** — Keyword extraction, fuzzy entity matching, type detection, neighbor expansion, relevance scoring, and LLM-ready context formatting (`src/rag/`)
-- **MCP server** — 10 tools for Claude Desktop integration (`src/mcp_server/`)
-- **`hckg visualize` command** — Interactive HTML graph visualization powered by pyvis
-- **`--clean` flag on `hckg demo`** — Remove previous output files before regenerating
-- **94 new tests** — REST API (32), install CLI (8), serve CLI (3), MCP server tools (17), GraphRAG (16), visualize (18)
+## [0.16.0] - 2026-02-20
 
 ### Changed
+- **MCP server modularization** — Split monolithic server.py into `state.py`, `helpers.py`, `tools.py`, `server.py`
+- **Blast radius to engine layer** — Moved BFS from MCP tool to `AbstractGraphEngine.blast_radius()`
+- **Safe update_entity** — Copy-validate-write pattern prevents in-place corruption; invalid updates raise `ValueError`
+- **ID prefix comments** — Aligned schema comments with generator output (REG-/CTL-/RSK-/THR-)
 
-- **Refined project vision and objectives** — Focused on rapid organizational modelling, scenario analysis, and enabling data & AI leadership (CDAIO). Positioned as a speed-to-insight tool for directionally correct analysis and low-hanging fruit identification
-- **Updated README** with Vision & Objectives section covering the problem space, approach, CDAIO enablement, and the rationale for knowledge graph-based modelling
-- **Updated project metadata** — Refined description, keywords, and GitHub topics to reflect organizational modelling, data & AI governance, and scenario analysis focus
-- **Updated `hckg demo` output** to include `hckg visualize` in next steps
+### Fixed
+- `datetime.utcnow()` deprecation in `update_entity` (now uses `datetime.now(UTC)`)
+
+## [0.15.0] - 2026-02-20
+
+### Fixed
+- **MCP auto-reload** — Server detects graph file changes via mtime checking, transparently reloads on every tool call
+- **RoleGenerator** — Now executes; roles generated for all departments (was returning count 0)
+- **Version sync** — `__version__` uses `importlib.metadata` for single-source truth
+- **Deserialization logging** — `_deserialize_entity/relationship` now logs errors instead of silently swallowing them
+
+### Removed
+- **stubs.py** — Empty file removed; all entity stubs replaced by full implementations
+
+## [0.14.0] - 2026-02-19
+
+### Added
+- **Enterprise synthetic generators** for all 18 L01-L11 entity types
+- **10 cross-layer relationship weaving methods** connecting entities across layers
+- **Enterprise integration tests** for full 30-type synthetic pipeline
+- **Extended sample_entities.json** with all enterprise entity types
+
+## [0.13.0] - 2026-02-19
+
+### Added
+- **Initiative entity** — Full implementation replacing last stub (~80 attributes)
+- **Initiative test suite** — 14 tests
+
+## [0.12.0] - 2026-02-19
+
+### Added
+- **Extended Vendor entity** with contract, compliance, and risk attributes
+- **Contract entity** — Vendor contracts with SLAs, financial terms, compliance
+- **Test suite** for extended Vendor and Contract entities
+
+## [0.11.0] - 2026-02-19
+
+### Added
+- **MarketSegment entity** — Target markets with demographics and sizing
+- **Customer entity** — Customer accounts with revenue, satisfaction, lifecycle
+- **Test suite** for MarketSegment and Customer entities
+
+## [0.10.0] - 2026-02-19
+
+### Added
+- **ProductPortfolio entity** — Product groupings with strategy and lifecycle
+- **Product entity** — Individual products with pricing, compliance, and metrics
+- **Test suite** for ProductPortfolio and Product entities
+
+## [0.9.0] - 2026-02-19
+
+### Added
+- **Site entity** (~91 attributes) — Physical facilities with address, capacity, compliance
+- **Geography entity** (~20 attributes) — Geographic regions and territories
+- **Jurisdiction entity** (~18 attributes) — Regulatory jurisdictions
+- **Locations test suite** — 18 tests
+
+## [0.8.0] - 2026-02-19
+
+### Added
+- **BusinessCapability entity** (~90 attributes) — L1/L2/L3 capability hierarchy with maturity assessment
+- **Business capabilities test suite** — 12 tests
+
+## [0.7.0] - 2026-02-19
+
+### Added
+- **Extended Person entity** (~64 attributes) — Security clearance, emergency contact, career progression
+- **Extended Role entity** (~65 attributes) — Permissions, compliance requirements, succession planning
+- **People & roles test suite** — 20 tests
+
+## [0.6.0] - 2026-02-19
+
+### Added
+- **OrganizationalUnit entity** (~100 attributes) — Business units, divisions, subsidiaries
+- **Organization test suite**
+
+## [0.5.0] - 2026-02-19
+
+### Added
+- **Extended DataAsset entity** — Expanded with governance, lineage, and quality attributes
+- **DataDomain entity** — Logical data groupings with ownership
+- **DataFlow entity** — Data movement between systems
+- **Data assets test suite**
+
+## [0.4.0] - 2026-02-19
+
+### Added
+- **Extended System entity** (~119 attributes) — Full enterprise system modeling
+- **Integration entity** (~30 attributes) — System-to-system integrations
+- **Technology test suite**
+
+## [0.3.0] - 2026-02-19
+
+### Added
+- **Regulation entity** — Laws and standards with compliance tracking
+- **Control entity** — Security/compliance controls (SCF-aligned)
+- **Risk entity** — Enterprise risks with scoring and treatment
+- **Threat entity** — Threat catalog entries (MITRE ATT&CK-aligned)
+- **Extended Policy entity** — Added compliance mapping and enforcement
+- **Compliance test suite**
+
+## [0.2.0] - 2026-02-19
+
+### Added
+- **Enterprise ontology foundation** — Expanded EntityType and RelationshipType enums (30 types, 50 relationships)
+- **Shared sub-models** — TemporalAndVersioning, ProvenanceAndConfidence, and other reusable Pydantic models
+- **Stub entity classes** for all 18 new enterprise types
+- **Backward compatibility tests** and shared sub-model tests
 
 ## [0.1.0] - 2025-02-19
 
 ### Added
-
 - **Core knowledge graph** with KnowledgeGraph facade, event bus, and query builder
 - **12 entity types**: Person, Department, Role, System, Network, Data Asset, Policy, Vendor, Location, Vulnerability, Threat Actor, Incident
 - **19 relationship types**: works_in, reports_to, manages, connects_to, depends_on, stores, governs, exploits, affects, supplied_by, and more
 - **Synthetic data generation** with profile-driven orchestrator and Faker-based generators
 - **3 organization profiles**: tech company, healthcare org, financial services
-- **Auto KG construction** from CSV and text with rule-based extraction, heuristic linking, and deduplication
-- **CLI tool (`hckg`)** with commands: demo, generate, inspect, auto build, auto extract, export
+- **Auto KG construction** from CSV and text with rule-based extraction
+- **CLI tool (`hckg`)** with demo, generate, inspect, auto, export commands
 - **Export formats**: JSON and GraphML
-- **Analysis module** with centrality metrics, risk scoring, attack path finding, and blast radius queries
+- **Analysis module** with centrality metrics, risk scoring, attack paths, blast radius
 - **NetworkX graph backend** with pluggable engine abstraction
+- **MCP server** — 10 tools for Claude Desktop integration
+- **REST API server** — Flask-based with OpenAI-compatible endpoints
+- **GraphRAG retrieval pipeline**
+- **Interactive visualization** via pyvis
+- **`hckg serve`** — Unified server with REST and MCP stdio modes
+- **`hckg install`** — Register with Claude Desktop
 - **124 tests** (unit + integration)
-- **Full documentation** in README with CLI reference, Python API examples, and troubleshooting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md — Project Guide for AI Assistants
+
+## Project Overview
+
+**hc-enterprise-kg** is an open-source enterprise knowledge graph platform. It generates structurally accurate organizational models ("digital twins") with 30 entity types and 50 relationship types, enabling scenario analysis, risk modeling, and dependency mapping.
+
+## Quick Commands
+
+```bash
+poetry run pytest tests/ -v          # Run all tests (~488)
+poetry run ruff check src/ tests/    # Lint
+poetry run hckg demo --clean         # Generate fresh graph.json
+poetry run hckg demo --employees 200 # Larger org
+```
+
+## Architecture
+
+```
+src/
+  domain/       # Pydantic v2 entity models (30 types), BaseEntity, EntityType/RelationshipType enums
+  engine/       # AbstractGraphEngine → NetworkXGraphEngine (pluggable backend)
+  graph/        # KnowledgeGraph facade, event bus, QueryBuilder
+  synthetic/    # Profile-driven generators + relationship weaving (SyntheticOrchestrator)
+  auto/         # Auto KG from CSV/text (rule-based + optional LLM)
+  ingest/       # CSVIngestor, JSONIngestor with schema mappings
+  export/       # JSONExporter, GraphMLExporter
+  analysis/     # Centrality, risk scoring, attack paths, blast radius
+  rag/          # GraphRAG retrieval pipeline
+  cli/          # Click CLI (demo, generate, inspect, auto, serve, install, visualize, export)
+  mcp_server/   # MCP server for Claude Desktop (state.py, helpers.py, tools.py, server.py)
+  serve/        # REST API server (Flask)
+```
+
+## Layer Build Order (Synthetic Generation)
+
+L00 Foundation → L01 Compliance → L02 Technology → L03 Data → L04 Organization → L05 People → L06 Capabilities → L07 Locations → L08 Products → L09 Customers → L10 Vendors → L11 Initiatives
+
+## Entity Types (30)
+
+**v0.1 (12):** Person, Department, Role, System, Network, DataAsset, Policy, Vendor, Location, Vulnerability, ThreatActor, Incident
+
+**Enterprise (18):** Regulation, Control, Risk, Threat, Integration, DataDomain, DataFlow, OrganizationalUnit, BusinessCapability, Site, Geography, Jurisdiction, ProductPortfolio, Product, MarketSegment, Customer, Contract, Initiative
+
+## Key Pitfalls
+
+1. **`extra="allow"` on BaseEntity** — Wrong field names silently go to `__pydantic_extra__`, no validation error. Always verify field names against the entity class.
+
+2. **Sub-model fields** — Many enterprise entity fields that look like scalars are Pydantic sub-models (e.g., `Site.address` is `SiteAddress`, not `str`). Always check the entity class before writing generators.
+
+3. **Temporal/provenance naming inconsistency** — Most entities use `temporal`/`provenance`. But Initiative, Vendor, Contract, Customer, MarketSegment, ProductPortfolio, Product use `temporal_and_versioning`/`provenance_and_confidence`. Geography/Jurisdiction use inline scalars.
+
+4. **Relationship types are lowercase** — Stats show `"implements"` not `"IMPLEMENTS"`. The `RelationshipType` enum values are lowercase strings.
+
+5. **EntityRegistry.auto_discover()** — Must be called before using `EntityRegistry.get()` in ingestion contexts.
+
+## MCP Server
+
+The MCP server (`src/mcp_server/`) provides 10 tools for Claude Desktop:
+- `load_graph`, `get_statistics`, `list_entities`, `get_entity`, `get_neighbors`
+- `find_shortest_path`, `get_blast_radius`, `compute_centrality`, `find_most_connected`, `search_entities`
+
+**Auto-reload:** The server detects graph file changes via mtime checking on every tool call. After `hckg demo --clean`, Claude Desktop tools automatically pick up the new graph.
+
+## Git Workflow
+
+- Branch from `main`, push immediately
+- Push commits as they're made
+- PR → merge → (at phase boundary) bump version → tag → `gh release create`
+
+## Testing Patterns
+
+- Engine contract tests in `tests/unit/engine/test_contract.py`
+- MCP tool tests call tools via `mcp._tool_manager._tools` registry
+- Synthetic pipeline integration tests in `tests/integration/test_synthetic_pipeline.py`
+- Ingestor tests in `tests/unit/ingest/`

--- a/README.md
+++ b/README.md
@@ -113,23 +113,49 @@ After that, all examples below work without the `poetry run` prefix. The rest of
 
 ## What Gets Generated
 
-Each knowledge graph contains interconnected entities that model a real organization:
+Each knowledge graph contains **30 interconnected entity types** modelling a real organization across 12 layers:
 
-| Entity Type | Description | Example Fields |
+**Core Entities (12)**
+
+| Entity Type | Description |
+|---|---|
+| **Person** | Employees, contractors — name, email, title, clearance |
+| **Department** | Organizational units — headcount, budget |
+| **Role** | Job roles — title, level, permissions |
+| **System** | Servers, apps, SaaS — hostname, IP, OS, criticality |
+| **Network** | Network segments — CIDR, zone |
+| **Data Asset** | Databases, file stores — classification |
+| **Vendor** | Third-party suppliers — risk tier |
+| **Policy** | Governance documents — framework, status |
+| **Vulnerability** | Security weaknesses — CVE, CVSS, patch status |
+| **Threat Actor** | Adversaries — motivation, sophistication |
+| **Incident** | Security events — severity, affected systems |
+| **Location** | Physical sites — city, country |
+
+**Enterprise Entities (18)**
+
+| Entity Type | Layer | Description |
 |---|---|---|
-| **Person** | Employees, contractors | name, email, title, department, clearance level |
-| **Department** | Organizational units | name, headcount, budget, data sensitivity |
-| **System** | Servers, applications, SaaS | hostname, IP, OS, criticality, internet-facing |
-| **Network** | Network segments | CIDR, zone (internal/DMZ/guest) |
-| **Data Asset** | Databases, file stores | classification (public/internal/confidential/restricted) |
-| **Vendor** | Third-party suppliers | contract value, risk tier |
-| **Policy** | Governance documents | compliance framework, enforcement status |
-| **Vulnerability** | Security weaknesses | CVE ID, CVSS score, severity, patch status |
-| **Threat Actor** | Adversaries | motivation, sophistication, target sectors |
-| **Incident** | Security events | severity, status, affected systems |
-| **Location** | Physical sites | city, country, building type |
+| **Regulation** | L01 Compliance | Laws and standards (GDPR, SOX, HIPAA) |
+| **Control** | L01 Compliance | Security/compliance controls (SCF-aligned) |
+| **Risk** | L01 Compliance | Enterprise risks with scoring and treatment |
+| **Threat** | L01 Compliance | Threat catalog (MITRE ATT&CK-aligned) |
+| **Integration** | L02 Technology | System-to-system integrations |
+| **Data Domain** | L03 Data | Logical data groupings with ownership |
+| **Data Flow** | L03 Data | Data movement between systems |
+| **Organizational Unit** | L04 Organization | Business units, divisions, subsidiaries |
+| **Business Capability** | L06 Capabilities | Capability map (L1/L2/L3 hierarchy) |
+| **Site** | L07 Locations | Physical facilities with address and capacity |
+| **Geography** | L07 Locations | Geographic regions and territories |
+| **Jurisdiction** | L07 Locations | Regulatory jurisdictions |
+| **Product Portfolio** | L08 Products | Product groupings and strategy |
+| **Product** | L08 Products | Individual products and services |
+| **Market Segment** | L09 Customers | Target markets and segments |
+| **Customer** | L09 Customers | Customer accounts and relationships |
+| **Contract** | L10 Vendors | Vendor contracts with SLAs |
+| **Initiative** | L11 Initiatives | Strategic programs and projects |
 
-These entities are connected by 19 relationship types: `works_in`, `reports_to`, `manages`, `connects_to`, `depends_on`, `stores`, `governs`, `exploits`, `affects`, `supplied_by`, and more.
+These entities are connected by **50 relationship types**: `works_in`, `reports_to`, `manages`, `connects_to`, `depends_on`, `stores`, `governs`, `exploits`, `implements`, `mitigates`, `regulates`, and more.
 
 ## CLI Reference
 
@@ -420,18 +446,18 @@ json_string = JSONExporter().export_string(kg.engine)
 ```
 src/
   cli/          # Click-based CLI (demo, generate, auto, inspect, export, serve, mcp, visualize)
-  domain/       # Pydantic v2 entity models (Person, System, Vulnerability, etc.)
+  domain/       # Pydantic v2 entity models (30 types), enums, registry
   engine/       # Graph backend abstraction (NetworkX; swappable to Neo4j)
   graph/        # KnowledgeGraph facade, event bus, query builder
   synthetic/    # Profile-driven synthetic data generation + relationship weaving
   auto/         # Auto KG construction (rule-based, CSV, LLM extraction + linking)
-  ingest/       # Data ingestion (JSON)
+  ingest/       # Data ingestion (JSON, CSV with schema mappings + transforms)
   export/       # Export (JSON, GraphML)
   analysis/     # Graph metrics (centrality, PageRank) + security queries
   rag/          # GraphRAG retrieval pipeline (search, context builder, retriever)
   serve/        # REST API server (Flask, OpenAI-compatible endpoints)
-  mcp_server/   # MCP server for Claude Desktop integration
-tests/          # 217 tests (unit + integration)
+  mcp_server/   # MCP server for Claude Desktop (state, helpers, tools, server)
+tests/          # 488+ tests (unit + integration)
 examples/       # Runnable example scripts
 ```
 
@@ -463,7 +489,7 @@ poetry install --extras dev
 
 ```bash
 make install    # Install with dev dependencies
-make test       # Run 217 tests
+make test       # Run all tests (~488)
 make test-cov   # Run tests with coverage report
 make lint       # Lint with ruff
 make format     # Auto-format with ruff


### PR DESCRIPTION
## Summary
- New `CLAUDE.md` project guide for AI-assisted development
- Updated README with all 30 entity types, 50 relationship types, 488 test count
- Backfilled CHANGELOG from v0.2.0 through v0.17.0
- Updated CONTRIBUTING with MCP development guide and entity pitfalls

Closes #44, closes #45, closes #46, closes #47