### PR TITLE
Version reset to 0.15.0 + industry-aware scaling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hc-enterprise-kg"
-version = "1.1.0"
+version = "0.15.0"
 description = "Enterprise knowledge graph platform for rapid organizational modelling, scenario analysis, and data & AI leadership"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/synthetic/profiles/base_profile.py
+++ b/src/synthetic/profiles/base_profile.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from pydantic import BaseModel, Field
 
 
@@ -66,3 +68,155 @@ class OrgProfile(BaseModel):
     customer_count_range: tuple[int, int] = (5, 20)
     contract_count_range: tuple[int, int] = (5, 20)
     initiative_count_range: tuple[int, int] = (3, 10)
+
+
+# ---------------------------------------------------------------------------
+# Industry-aware scaling
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ScalingCoefficients:
+    """Industry-specific ratios: employees-per-entity.
+
+    Lower coefficient = more entities per employee (denser infrastructure).
+    """
+
+    systems: float = 12
+    vendors: float = 50
+    data_assets: float = 20
+    policies: float = 80
+    controls: float = 50
+    risks: float = 80
+    threats: float = 200
+    integrations: float = 40
+    data_domains: float = 500
+    data_flows: float = 30
+    org_units: float = 150
+    capabilities: float = 100
+    sites: float = 500
+    geographies: float = 1000
+    jurisdictions: float = 1000
+    product_portfolios: float = 2000
+    products: float = 200
+    market_segments: float = 1000
+    customers: float = 100
+    contracts: float = 80
+    initiatives: float = 200
+    threat_actors: float = 250
+    incidents: float = 200
+
+
+INDUSTRY_COEFFICIENTS: dict[str, ScalingCoefficients] = {
+    "technology": ScalingCoefficients(
+        systems=8,
+        vendors=40,
+        data_assets=15,
+        policies=100,
+        controls=50,
+        risks=80,
+        threats=200,
+        integrations=30,
+        data_domains=400,
+        data_flows=25,
+        org_units=150,
+        capabilities=100,
+        sites=500,
+        geographies=1000,
+        jurisdictions=1000,
+        product_portfolios=2000,
+        products=200,
+        market_segments=1000,
+        customers=100,
+        contracts=60,
+        initiatives=200,
+        threat_actors=250,
+        incidents=200,
+    ),
+    "financial_services": ScalingCoefficients(
+        systems=12,
+        vendors=35,
+        data_assets=10,
+        policies=40,
+        controls=20,
+        risks=30,
+        threats=150,
+        integrations=40,
+        data_domains=300,
+        data_flows=20,
+        org_units=100,
+        capabilities=80,
+        sites=400,
+        geographies=800,
+        jurisdictions=600,
+        product_portfolios=1500,
+        products=150,
+        market_segments=800,
+        customers=50,
+        contracts=40,
+        initiatives=150,
+        threat_actors=200,
+        incidents=150,
+    ),
+    "healthcare": ScalingCoefficients(
+        systems=15,
+        vendors=50,
+        data_assets=5,
+        policies=50,
+        controls=25,
+        risks=40,
+        threats=200,
+        integrations=35,
+        data_domains=200,
+        data_flows=15,
+        org_units=120,
+        capabilities=100,
+        sites=300,
+        geographies=800,
+        jurisdictions=600,
+        product_portfolios=2000,
+        products=200,
+        market_segments=1000,
+        customers=80,
+        contracts=50,
+        initiatives=200,
+        threat_actors=300,
+        incidents=100,
+    ),
+}
+
+
+def _size_tier_multiplier(employee_count: int) -> float:
+    """Organizational maturity multiplier based on size tier.
+
+    Startups share systems and have informal controls.
+    Large enterprises have complex hierarchies and regulatory burden.
+    """
+    if employee_count < 250:
+        return 0.7
+    if employee_count < 2000:
+        return 1.0
+    if employee_count < 10000:
+        return 1.2
+    return 1.4
+
+
+def scaled_range(
+    employee_count: int,
+    coefficient: float,
+    floor: int,
+    ceiling: int,
+) -> tuple[int, int]:
+    """Compute (low, high) entity count range scaled by industry and size.
+
+    Args:
+        employee_count: Number of employees in the org.
+        coefficient: Employees-per-entity ratio from ScalingCoefficients.
+        floor: Minimum count regardless of org size.
+        ceiling: Maximum count (hard cap).
+    """
+    tier = _size_tier_multiplier(employee_count)
+    base = max(floor, int((employee_count / coefficient) * tier))
+    low = min(ceiling - 1, max(floor, int(base * 0.8)))
+    high = min(ceiling, max(low + 1, int(base * 1.2)))
+    return (low, high)

--- a/src/synthetic/profiles/financial_org.py
+++ b/src/synthetic/profiles/financial_org.py
@@ -3,14 +3,19 @@
 from __future__ import annotations
 
 from synthetic.profiles.base_profile import (
+    INDUSTRY_COEFFICIENTS,
     DepartmentSpec,
     NetworkSpec,
     OrgProfile,
+    scaled_range,
 )
 
 
 def financial_org(employee_count: int = 1000) -> OrgProfile:
     """Create an org profile for a financial services organization."""
+    c = INDUSTRY_COEFFICIENTS["financial_services"]
+    s = lambda coeff, floor, ceiling: scaled_range(employee_count, coeff, floor, ceiling)  # noqa: E731
+
     return OrgProfile(
         name="Atlas Financial Group",
         industry="financial_services",
@@ -81,8 +86,8 @@ def financial_org(employee_count: int = 1000) -> OrgProfile:
                 data_sensitivity="critical",
             ),
         ],
-        location_count=4,
-        system_count_range=(60, 200),
+        location_count=max(1, min(30, employee_count // 600 + 1)),
+        system_count_range=s(c.systems, 30, 2000),
         network_specs=[
             NetworkSpec(name="Trading Floor", cidr="10.0.0.0/24", zone="restricted"),
             NetworkSpec(name="Corporate", cidr="10.1.0.0/16", zone="internal"),
@@ -90,31 +95,31 @@ def financial_org(employee_count: int = 1000) -> OrgProfile:
             NetworkSpec(name="DR Site", cidr="10.2.0.0/16", zone="internal"),
             NetworkSpec(name="Guest", cidr="192.168.0.0/24", zone="guest"),
         ],
-        vendor_count_range=(15, 50),
-        data_asset_count_range=(25, 80),
-        policy_count_range=(20, 50),
+        vendor_count_range=s(c.vendors, 10, 500),
+        data_asset_count_range=s(c.data_assets, 15, 2000),
+        policy_count_range=s(c.policies, 10, 300),
         vulnerability_probability=0.12,
-        threat_actor_count_range=(5, 15),
-        incident_count_range=(1, 12),
+        threat_actor_count_range=s(c.threat_actors, 3, 50),
+        incident_count_range=s(c.incidents, 1, 100),
         contractor_fraction=0.20,
         remote_fraction=0.25,
         # Enterprise ontology — financial-heavy compliance & risk
-        regulation_count_range=(6, 18),
-        control_count_range=(12, 40),
-        risk_count_range=(6, 20),
-        threat_count_range=(4, 12),
-        integration_count_range=(6, 22),
-        data_domain_count_range=(4, 10),
-        data_flow_count_range=(6, 22),
-        org_unit_count_range=(5, 15),
-        capability_count_range=(8, 22),
-        site_count_range=(3, 8),
-        geography_count_range=(3, 8),
-        jurisdiction_count_range=(4, 10),
-        product_portfolio_count_range=(2, 6),
-        product_count_range=(6, 25),
-        market_segment_count_range=(3, 8),
-        customer_count_range=(15, 50),
-        contract_count_range=(12, 40),
-        initiative_count_range=(5, 15),
+        regulation_count_range=s(80, 5, 40),
+        control_count_range=s(c.controls, 8, 500),
+        risk_count_range=s(c.risks, 5, 200),
+        threat_count_range=s(c.threats, 3, 50),
+        integration_count_range=s(c.integrations, 5, 300),
+        data_domain_count_range=s(c.data_domains, 3, 25),
+        data_flow_count_range=s(c.data_flows, 5, 600),
+        org_unit_count_range=s(c.org_units, 4, 100),
+        capability_count_range=s(c.capabilities, 5, 60),
+        site_count_range=s(c.sites, 2, 30),
+        geography_count_range=s(c.geographies, 2, 15),
+        jurisdiction_count_range=s(c.jurisdictions, 3, 20),
+        product_portfolio_count_range=s(c.product_portfolios, 1, 10),
+        product_count_range=s(c.products, 4, 100),
+        market_segment_count_range=s(c.market_segments, 2, 15),
+        customer_count_range=s(c.customers, 10, 300),
+        contract_count_range=s(c.contracts, 8, 300),
+        initiative_count_range=s(c.initiatives, 4, 80),
     )

--- a/src/synthetic/profiles/healthcare_org.py
+++ b/src/synthetic/profiles/healthcare_org.py
@@ -3,14 +3,19 @@
 from __future__ import annotations
 
 from synthetic.profiles.base_profile import (
+    INDUSTRY_COEFFICIENTS,
     DepartmentSpec,
     NetworkSpec,
     OrgProfile,
+    scaled_range,
 )
 
 
 def healthcare_org(employee_count: int = 2000) -> OrgProfile:
     """Create an org profile for a healthcare organization."""
+    c = INDUSTRY_COEFFICIENTS["healthcare"]
+    s = lambda coeff, floor, ceiling: scaled_range(employee_count, coeff, floor, ceiling)  # noqa: E731
+
     return OrgProfile(
         name="MedCare Health Systems",
         industry="healthcare",
@@ -74,8 +79,8 @@ def healthcare_org(employee_count: int = 2000) -> OrgProfile:
                 systems_count_range=(3, 8),
             ),
         ],
-        location_count=5,
-        system_count_range=(80, 250),
+        location_count=max(1, min(30, employee_count // 500 + 1)),
+        system_count_range=s(c.systems, 30, 2000),
         network_specs=[
             NetworkSpec(name="Clinical Network", cidr="10.0.0.0/16", zone="restricted"),
             NetworkSpec(name="Administrative", cidr="10.1.0.0/16", zone="internal"),
@@ -83,31 +88,31 @@ def healthcare_org(employee_count: int = 2000) -> OrgProfile:
             NetworkSpec(name="Guest WiFi", cidr="192.168.0.0/24", zone="guest"),
             NetworkSpec(name="DMZ", cidr="172.16.0.0/24", zone="dmz"),
         ],
-        vendor_count_range=(20, 60),
-        data_asset_count_range=(30, 100),
-        policy_count_range=(15, 40),
+        vendor_count_range=s(c.vendors, 10, 500),
+        data_asset_count_range=s(c.data_assets, 20, 3000),
+        policy_count_range=s(c.policies, 8, 250),
         vulnerability_probability=0.18,
-        threat_actor_count_range=(3, 12),
-        incident_count_range=(2, 15),
+        threat_actor_count_range=s(c.threat_actors, 2, 40),
+        incident_count_range=s(c.incidents, 1, 120),
         contractor_fraction=0.15,
         remote_fraction=0.10,
         # Enterprise ontology — healthcare-heavy compliance
-        regulation_count_range=(5, 15),
-        control_count_range=(10, 35),
-        risk_count_range=(5, 18),
-        threat_count_range=(3, 10),
-        integration_count_range=(8, 25),
-        data_domain_count_range=(4, 10),
-        data_flow_count_range=(6, 20),
-        org_unit_count_range=(5, 15),
-        capability_count_range=(8, 20),
-        site_count_range=(3, 10),
-        geography_count_range=(2, 6),
-        jurisdiction_count_range=(3, 8),
-        product_portfolio_count_range=(2, 5),
-        product_count_range=(5, 20),
-        market_segment_count_range=(3, 8),
-        customer_count_range=(10, 40),
-        contract_count_range=(15, 45),
-        initiative_count_range=(5, 15),
+        regulation_count_range=s(80, 4, 35),
+        control_count_range=s(c.controls, 8, 400),
+        risk_count_range=s(c.risks, 4, 180),
+        threat_count_range=s(c.threats, 2, 45),
+        integration_count_range=s(c.integrations, 5, 300),
+        data_domain_count_range=s(c.data_domains, 3, 25),
+        data_flow_count_range=s(c.data_flows, 5, 700),
+        org_unit_count_range=s(c.org_units, 4, 100),
+        capability_count_range=s(c.capabilities, 5, 55),
+        site_count_range=s(c.sites, 2, 35),
+        geography_count_range=s(c.geographies, 2, 15),
+        jurisdiction_count_range=s(c.jurisdictions, 2, 15),
+        product_portfolio_count_range=s(c.product_portfolios, 1, 10),
+        product_count_range=s(c.products, 4, 90),
+        market_segment_count_range=s(c.market_segments, 2, 15),
+        customer_count_range=s(c.customers, 8, 250),
+        contract_count_range=s(c.contracts, 8, 300),
+        initiative_count_range=s(c.initiatives, 4, 70),
     )

--- a/src/synthetic/profiles/tech_company.py
+++ b/src/synthetic/profiles/tech_company.py
@@ -3,14 +3,19 @@
 from __future__ import annotations
 
 from synthetic.profiles.base_profile import (
+    INDUSTRY_COEFFICIENTS,
     DepartmentSpec,
     NetworkSpec,
     OrgProfile,
+    scaled_range,
 )
 
 
 def mid_size_tech_company(employee_count: int = 500) -> OrgProfile:
     """Create an org profile for a mid-size technology company."""
+    c = INDUSTRY_COEFFICIENTS["technology"]
+    s = lambda coeff, floor, ceiling: scaled_range(employee_count, coeff, floor, ceiling)  # noqa: E731
+
     return OrgProfile(
         name="Acme Technologies",
         industry="technology",
@@ -70,37 +75,37 @@ def mid_size_tech_company(employee_count: int = 500) -> OrgProfile:
                 data_sensitivity="critical",
             ),
         ],
-        location_count=3,
-        system_count_range=(40, 120),
+        location_count=max(1, min(30, employee_count // 800 + 1)),
+        system_count_range=s(c.systems, 20, 2000),
         network_specs=[
             NetworkSpec(name="Corporate", cidr="10.0.0.0/16", zone="internal"),
             NetworkSpec(name="DMZ", cidr="172.16.0.0/24", zone="dmz"),
             NetworkSpec(name="Dev/Staging", cidr="10.1.0.0/16", zone="internal"),
             NetworkSpec(name="Guest WiFi", cidr="192.168.0.0/24", zone="guest"),
         ],
-        vendor_count_range=(10, 40),
-        data_asset_count_range=(15, 60),
-        policy_count_range=(8, 25),
+        vendor_count_range=s(c.vendors, 5, 500),
+        data_asset_count_range=s(c.data_assets, 10, 1500),
+        policy_count_range=s(c.policies, 5, 200),
         vulnerability_probability=0.20,
-        threat_actor_count_range=(3, 10),
-        incident_count_range=(1, 8),
+        threat_actor_count_range=s(c.threat_actors, 2, 50),
+        incident_count_range=s(c.incidents, 1, 100),
         # Enterprise ontology
-        regulation_count_range=(3, 8),
-        control_count_range=(8, 25),
-        risk_count_range=(4, 12),
-        threat_count_range=(3, 8),
-        integration_count_range=(5, 20),
-        data_domain_count_range=(3, 8),
-        data_flow_count_range=(5, 18),
-        org_unit_count_range=(4, 12),
-        capability_count_range=(6, 18),
-        site_count_range=(2, 6),
-        geography_count_range=(2, 5),
-        jurisdiction_count_range=(2, 5),
-        product_portfolio_count_range=(1, 3),
-        product_count_range=(4, 15),
-        market_segment_count_range=(2, 6),
-        customer_count_range=(8, 30),
-        contract_count_range=(8, 30),
-        initiative_count_range=(4, 12),
+        regulation_count_range=s(100, 3, 30),
+        control_count_range=s(c.controls, 5, 400),
+        risk_count_range=s(c.risks, 3, 150),
+        threat_count_range=s(c.threats, 2, 40),
+        integration_count_range=s(c.integrations, 3, 300),
+        data_domain_count_range=s(c.data_domains, 3, 20),
+        data_flow_count_range=s(c.data_flows, 4, 500),
+        org_unit_count_range=s(c.org_units, 3, 80),
+        capability_count_range=s(c.capabilities, 5, 50),
+        site_count_range=s(c.sites, 2, 30),
+        geography_count_range=s(c.geographies, 2, 15),
+        jurisdiction_count_range=s(c.jurisdictions, 2, 15),
+        product_portfolio_count_range=s(c.product_portfolios, 1, 10),
+        product_count_range=s(c.products, 3, 80),
+        market_segment_count_range=s(c.market_segments, 2, 15),
+        customer_count_range=s(c.customers, 5, 200),
+        contract_count_range=s(c.contracts, 5, 250),
+        initiative_count_range=s(c.initiatives, 3, 60),
     )

--- a/src/synthetic/relationships.py
+++ b/src/synthetic/relationships.py
@@ -173,8 +173,9 @@ class RelationshipWeaver:
                 )
             )
 
-        # Add some inter-system dependencies
-        for _i in range(min(len(systems) // 3, 20)):
+        # Add inter-system dependencies — scale cap with system count
+        dep_cap = max(5, len(systems) // 3)
+        for _i in range(dep_cap):
             src, tgt = random.sample(systems, 2)
             rels.append(
                 BaseRelationship(

--- a/tests/integration/test_stress.py
+++ b/tests/integration/test_stress.py
@@ -1,4 +1,4 @@
-"""Stress tests — large graph generation, performance, and roundtrip validation."""
+"""Stress tests — scaled generation, performance gates, and roundtrip validation."""
 
 from __future__ import annotations
 
@@ -12,6 +12,8 @@ from export.json_export import JSONExporter
 from graph.knowledge_graph import KnowledgeGraph
 from ingest.json_ingestor import JSONIngestor
 from synthetic.orchestrator import SyntheticOrchestrator
+from synthetic.profiles.financial_org import financial_org
+from synthetic.profiles.healthcare_org import healthcare_org
 from synthetic.profiles.tech_company import mid_size_tech_company
 
 # All 30 entity types expected in a full generation
@@ -49,50 +51,142 @@ ALL_ENTITY_TYPES = {
 }
 
 
-@pytest.mark.slow
-class TestLargeGraphGeneration:
-    """Tests with 500+ employee graphs."""
+# ---------------------------------------------------------------------------
+# Parametrized scale tests — 100 to 20,000 employees
+# ---------------------------------------------------------------------------
 
-    def test_500_employee_generation(self):
-        """Generate a 500-employee org — all types present, reasonable timing."""
+
+@pytest.mark.slow
+class TestScaledGeneration:
+    """Verify generation scales correctly from startup to large enterprise."""
+
+    @pytest.mark.parametrize(
+        "emp,max_sec",
+        [
+            (100, 10),
+            (500, 30),
+            (1000, 60),
+            (5000, 180),
+            (10000, 300),
+            (20000, 600),
+        ],
+    )
+    def test_generation_at_scale(self, emp: int, max_sec: int):
+        """Generate a tech company at various employee counts within time gates."""
         kg = KnowledgeGraph()
-        profile = mid_size_tech_company(500)
+        profile = mid_size_tech_company(emp)
 
         start = time.time()
         counts = SyntheticOrchestrator(kg, profile, seed=42).generate()
         elapsed = time.time() - start
 
-        assert counts["person"] == 500
-        assert elapsed < 30, f"Generation took {elapsed:.1f}s — expected <30s"
+        assert counts["person"] == emp
+        assert elapsed < max_sec, (
+            f"{emp}-employee generation took {elapsed:.1f}s (limit {max_sec}s)"
+        )
 
         stats = kg.statistics
-        assert stats["entity_count"] > 500
+        assert stats["entity_count"] > emp
         assert stats["relationship_count"] > 0
 
-        # All 30 types should be present
+        # All 30 entity types should be present
         generated_types = set(stats["entity_types"].keys())
         missing = ALL_ENTITY_TYPES - generated_types
-        assert not missing, f"Missing types in 500-employee graph: {missing}"
+        assert not missing, f"Missing types at {emp} employees: {missing}"
 
-    def test_1000_employee_generation(self):
-        """Generate a 1000-employee org."""
+    def test_scaling_ratios(self):
+        """A 20k org must have >10x the non-person entities of a 100-person org."""
+        kg_small = KnowledgeGraph()
+        SyntheticOrchestrator(kg_small, mid_size_tech_company(100), seed=1).generate()
+        small_entities = kg_small.statistics["entity_count"]
+        small_non_person = small_entities - 100
+
+        kg_large = KnowledgeGraph()
+        SyntheticOrchestrator(kg_large, mid_size_tech_company(20000), seed=1).generate()
+        large_entities = kg_large.statistics["entity_count"]
+        large_non_person = large_entities - 20000
+
+        ratio = large_non_person / max(1, small_non_person)
+        assert ratio > 10, (
+            f"20k org has only {ratio:.1f}x non-person entities vs 100 org "
+            f"({large_non_person} vs {small_non_person}). Scaling is broken."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-industry profile tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestIndustryProfiles:
+    """Verify all industry profiles generate valid graphs at scale."""
+
+    @pytest.mark.parametrize(
+        "profile_fn,emp",
+        [
+            (mid_size_tech_company, 1000),
+            (financial_org, 1000),
+            (healthcare_org, 1000),
+        ],
+    )
+    def test_industry_generation(self, profile_fn, emp: int):
+        """Each industry profile generates all 30 types with valid counts."""
         kg = KnowledgeGraph()
-        profile = mid_size_tech_company(1000)
+        profile = profile_fn(emp)
 
         start = time.time()
-        counts = SyntheticOrchestrator(kg, profile, seed=99).generate()
+        counts = SyntheticOrchestrator(kg, profile, seed=42).generate()
         elapsed = time.time() - start
 
-        assert counts["person"] == 1000
-        assert elapsed < 60, f"Generation took {elapsed:.1f}s — expected <60s"
+        assert counts["person"] == emp
+        assert elapsed < 60, f"{profile.industry} generation took {elapsed:.1f}s"
 
         stats = kg.statistics
-        assert stats["entity_count"] > 1000
-        assert stats["relationship_count"] > stats["entity_count"]
+        generated_types = set(stats["entity_types"].keys())
+        missing = ALL_ENTITY_TYPES - generated_types
+        assert not missing, f"{profile.industry} missing types: {missing}"
+
+    def test_financial_has_more_controls_than_tech(self):
+        """Financial services should generate denser controls than tech."""
+        emp = 2000
+
+        kg_tech = KnowledgeGraph()
+        SyntheticOrchestrator(kg_tech, mid_size_tech_company(emp), seed=42).generate()
+        tech_controls = kg_tech.statistics["entity_types"].get("control", 0)
+
+        kg_fin = KnowledgeGraph()
+        SyntheticOrchestrator(kg_fin, financial_org(emp), seed=42).generate()
+        fin_controls = kg_fin.statistics["entity_types"].get("control", 0)
+
+        assert fin_controls > tech_controls, (
+            f"Financial ({fin_controls}) should have more controls than tech ({tech_controls})"
+        )
+
+    def test_healthcare_has_more_data_assets_than_tech(self):
+        """Healthcare should generate denser data assets than tech."""
+        emp = 2000
+
+        kg_tech = KnowledgeGraph()
+        SyntheticOrchestrator(kg_tech, mid_size_tech_company(emp), seed=42).generate()
+        tech_data = kg_tech.statistics["entity_types"].get("data_asset", 0)
+
+        kg_hc = KnowledgeGraph()
+        SyntheticOrchestrator(kg_hc, healthcare_org(emp), seed=42).generate()
+        hc_data = kg_hc.statistics["entity_types"].get("data_asset", 0)
+
+        assert hc_data > tech_data, (
+            f"Healthcare ({hc_data}) should have more data assets than tech ({tech_data})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Export/Import roundtrip
+# ---------------------------------------------------------------------------
 
 
 class TestExportImportRoundtrip:
-    """Verify export → import preserves graph fidelity."""
+    """Verify export -> import preserves graph fidelity."""
 
     def test_roundtrip_preserves_counts(self):
         """Export to JSON, reimport, verify entity/relationship counts match."""
@@ -118,7 +212,7 @@ class TestExportImportRoundtrip:
         assert len(result.relationships) == original_stats["relationship_count"]
 
     def test_roundtrip_preserves_all_types(self):
-        """All entity types survive export → import."""
+        """All entity types survive export -> import."""
         kg = KnowledgeGraph()
         profile = mid_size_tech_company(50)
         SyntheticOrchestrator(kg, profile, seed=42).generate()
@@ -136,8 +230,13 @@ class TestExportImportRoundtrip:
         assert not missing_after, f"Import missing types: {missing_after}"
 
 
-class TestBlastRadiusPerformance:
-    """Blast radius should complete in reasonable time even on large graphs."""
+# ---------------------------------------------------------------------------
+# Performance gates
+# ---------------------------------------------------------------------------
+
+
+class TestPerformanceGates:
+    """Query and analytics operations within time bounds."""
 
     def test_blast_radius_timing(self):
         """Blast radius on a 200-employee graph should complete in <2s."""
@@ -145,7 +244,6 @@ class TestBlastRadiusPerformance:
         profile = mid_size_tech_company(200)
         SyntheticOrchestrator(kg, profile, seed=42).generate()
 
-        # Pick a well-connected entity
         systems = kg.query().entities(EntityType.SYSTEM).execute()
         assert len(systems) > 0
         system_id = systems[0].id
@@ -154,13 +252,9 @@ class TestBlastRadiusPerformance:
         result = kg.blast_radius(system_id, max_depth=3)
         elapsed = time.time() - start
 
-        assert elapsed < 2.0, f"Blast radius took {elapsed:.2f}s — expected <2s"
+        assert elapsed < 2.0, f"Blast radius took {elapsed:.2f}s"
         total = sum(len(entities) for entities in result.values())
         assert total > 0, "Blast radius returned no affected entities"
-
-
-class TestQueryPerformance:
-    """Query operations should be efficient on medium-large graphs."""
 
     def test_list_entities_with_type_filter(self):
         """Listing entities by type should be fast on a 300-employee graph."""
@@ -173,7 +267,7 @@ class TestQueryPerformance:
         elapsed = time.time() - start
 
         assert len(people) == 300
-        assert elapsed < 1.0, f"Query took {elapsed:.2f}s — expected <1s"
+        assert elapsed < 1.0, f"Query took {elapsed:.2f}s"
 
     def test_statistics_performance(self):
         """Computing statistics should be fast."""
@@ -185,5 +279,26 @@ class TestQueryPerformance:
         stats = kg.statistics
         elapsed = time.time() - start
 
-        assert elapsed < 1.0, f"Statistics took {elapsed:.2f}s — expected <1s"
+        assert elapsed < 1.0, f"Statistics took {elapsed:.2f}s"
         assert stats["entity_count"] > 300
+
+    @pytest.mark.slow
+    def test_analytics_at_5k_employees(self):
+        """Analytics operations on a 5k graph stay within bounds."""
+        kg = KnowledgeGraph()
+        profile = mid_size_tech_company(5000)
+        SyntheticOrchestrator(kg, profile, seed=42).generate()
+
+        # Statistics
+        start = time.time()
+        stats = kg.statistics
+        elapsed = time.time() - start
+        assert elapsed < 5.0, f"Statistics at 5k took {elapsed:.2f}s"
+        assert stats["entity_count"] > 5000
+
+        # Blast radius
+        systems = kg.query().entities(EntityType.SYSTEM).execute()
+        start = time.time()
+        kg.blast_radius(systems[0].id, max_depth=2)
+        elapsed = time.time() - start
+        assert elapsed < 10.0, f"Blast radius at 5k took {elapsed:.2f}s"


### PR DESCRIPTION
## Summary
- Reset version from 1.x to 0.15.0 (pre-production) to address fundamental gaps in scaling, semantic coherence, and relationship enrichment
- Add `ScalingCoefficients` per industry (technology, financial_services, healthcare) with size-tier maturity multipliers (startup 0.7x, mid-market 1.0x, enterprise 1.2x, large 1.4x)
- All 3 profiles now scale entity counts proportionally from 100 to 20,000 employees
- Scale inter-system DEPENDS_ON cap proportionally to system count
- Parametrized stress tests cover 100/500/1k/5k/10k/20k employees with performance gates
- Industry comparison tests verify financial has denser controls, healthcare has denser data assets

## Test plan
- [x] 651 tests passing (638 unit + 13 integration)
- [x] All 18 stress tests pass including 20k employees
- [x] Scaling ratio test: 20k org has >10x non-person entities vs 100 org
- [x] All 3 industry profiles generate all 30 entity types at 1000 employees
- [x] Ruff clean

Closes #65, #66, #67