### PR TITLE
Add hckg benchmark CLI command

### DIFF
--- a/src/cli/benchmark_cmd.py
+++ b/src/cli/benchmark_cmd.py
@@ -1,0 +1,106 @@
+"""CLI command: hckg benchmark — run performance benchmarks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+
+@click.command()
+@click.option(
+    "--profiles",
+    default="tech",
+    help="Comma-separated profile names (tech, financial, healthcare).",
+)
+@click.option(
+    "--scales",
+    default="100,500",
+    help="Comma-separated employee counts.",
+)
+@click.option(
+    "--full",
+    is_flag=True,
+    default=False,
+    help="Run all 3 profiles at 100, 500, 1000, 5000, 10000, 20000.",
+)
+@click.option(
+    "--output",
+    type=click.Path(),
+    default=None,
+    help="Save report to file.",
+)
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["markdown", "json"]),
+    default="markdown",
+    help="Report format (default: markdown).",
+)
+@click.option("--seed", type=int, default=42, help="Random seed.")
+def benchmark(
+    profiles: str,
+    scales: str,
+    full: bool,
+    output: str | None,
+    fmt: str,
+    seed: int,
+) -> None:
+    """Run performance benchmarks across profiles and scales.
+
+    \b
+    Quick benchmark (default):
+        hckg benchmark
+
+    \b
+    Full benchmark (all profiles, all scales):
+        hckg benchmark --full
+
+    \b
+    Custom:
+        hckg benchmark --profiles tech,financial --scales 100,1000,5000
+
+    \b
+    Save report:
+        hckg benchmark --output report.md
+        hckg benchmark --full --format json --output report.json
+    """
+    from analysis.benchmark import BenchmarkSuite
+
+    if full:
+        profile_list = ["tech", "financial", "healthcare"]
+        scale_list = [100, 500, 1000, 5000, 10000, 20000]
+    else:
+        profile_list = [p.strip() for p in profiles.split(",")]
+        scale_list = [int(s.strip()) for s in scales.split(",")]
+
+    valid_profiles = {"tech", "financial", "healthcare"}
+    for p in profile_list:
+        if p not in valid_profiles:
+            raise click.BadParameter(
+                f"Unknown profile '{p}'. Valid: {', '.join(sorted(valid_profiles))}",
+                param_hint="--profiles",
+            )
+
+    click.echo(f"Running benchmarks: profiles={profile_list}, scales={scale_list}")
+    click.echo()
+
+    suite = BenchmarkSuite(profiles=profile_list, scales=scale_list, seed=seed)
+
+    def progress(phase: str) -> None:
+        click.echo(f"  {phase}...")
+
+    report = suite.run_all(progress_callback=progress)
+
+    click.echo()
+    click.echo(f"Completed: {len(report.results)} measurements")
+    click.echo()
+
+    content = report.to_json() if fmt == "json" else report.to_markdown()
+
+    if output:
+        out_path = Path(output)
+        out_path.write_text(content)
+        click.echo(f"Report saved to {out_path}")
+    else:
+        click.echo(content)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -17,6 +17,7 @@ def cli(ctx: click.Context, backend: str) -> None:
 
 # Import and register subcommand groups
 from cli.auto_cmd import auto  # noqa: E402
+from cli.benchmark_cmd import benchmark  # noqa: E402
 from cli.demo_cmd import demo  # noqa: E402
 from cli.export_cmd import export_cmd  # noqa: E402
 from cli.generate import generate  # noqa: E402
@@ -25,6 +26,7 @@ from cli.install_cmd import install_group  # noqa: E402
 from cli.serve_cmd import serve_cmd  # noqa: E402
 from cli.visualize_cmd import visualize_cmd  # noqa: E402
 
+cli.add_command(benchmark)
 cli.add_command(demo)
 cli.add_command(generate)
 cli.add_command(auto)


### PR DESCRIPTION
## Summary
- Adds `hckg benchmark` CLI command wrapping `BenchmarkSuite`
- Options: `--profiles`, `--scales`, `--full`, `--output`, `--format` (markdown/json), `--seed`
- `--full` runs all 3 profiles at 6 scales (100-20k)
- Progress output during execution, markdown report to stdout by default

## Test plan
- [x] `hckg benchmark --help` shows all options
- [x] `hckg benchmark --scales 100` produces markdown report
- [x] `hckg benchmark --format json --output report.json` saves JSON file
- [x] Invalid profile name raises clear error
- [x] All 679 existing tests pass
- [x] Ruff lint clean

Closes #99