### PR TITLE
Add CLI flags for static entity count overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.19.3] - 2026-02-20
+
+### Added
+- **Entity count override flags** — 25 individual CLI flags (`--systems`, `--vendors`, `--controls`, etc.) for `hckg demo` and `hckg generate org` to pin exact entity counts, bypassing `scaled_range()` (#115)
+- `count_overrides` parameter on `SyntheticOrchestrator` for programmatic use
+- 3 new tests for override mechanism (apply, noop, zero-suppression)
+
 ## [0.19.2] - 2026-02-20
 
 ### Changed

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,6 +28,7 @@ hckg demo
 hckg demo --profile healthcare --employees 500 --output hospital.json
 hckg demo --format graphml --output graph.graphml
 hckg demo --clean  # removes previous output files before generating
+hckg demo --employees 5000 --systems 500 --vendors 100  # override entity counts
 ```
 
 | Option | Default | Description |
@@ -38,6 +39,7 @@ hckg demo --clean  # removes previous output files before generating
 | `--output` | `graph.json` | Output file path |
 | `--format` | `json` | Output format: `json` or `graphml` |
 | `--clean` | off | Remove previous output files before generating (`graph.json`, `graph.graphml`, `result.json`, `*_viz.html`) |
+| `--systems`, `--vendors`, etc. | None | Override specific entity counts (see [Entity Count Overrides](#entity-count-overrides)) |
 
 ---
 
@@ -49,6 +51,7 @@ Synthetic generation with the same engine as `demo`, using different defaults. A
 hckg generate org
 hckg generate org --profile financial --employees 1000 --seed 99
 hckg generate org --output large_org.json
+hckg generate org --employees 14512 --systems 500 --vendors 100 --controls 200
 ```
 
 | Option | Default | Description |
@@ -57,6 +60,7 @@ hckg generate org --output large_org.json
 | `--employees` | `500` | Number of employees to generate |
 | `--seed` | None | Random seed for reproducibility (omit for random) |
 | `--output` | `graph.json` | Export file path |
+| `--systems`, `--vendors`, etc. | None | Override specific entity counts (see [Entity Count Overrides](#entity-count-overrides)) |
 
 ---
 
@@ -274,6 +278,52 @@ hckg export --source graph.json --format graphml --output graph.graphml
 | `--source` | — | Source JSON knowledge graph file (required) |
 | `--format` | `json` | Output format: `json` or `graphml` |
 | `--output` | — | Output file path (required) |
+
+---
+
+## Entity Count Overrides
+
+Both `hckg demo` and `hckg generate org` accept individual flags to override specific entity counts. When provided, these bypass the `scaled_range()` scaling formula and produce exactly the specified number of entities.
+
+```bash
+# Pin systems to 500 and vendors to 100, let everything else scale normally
+hckg generate org --employees 14512 --systems 500 --vendors 100
+
+# Override controls and risks for a compliance-focused scenario
+hckg demo --employees 5000 --controls 200 --risks 50 --customers 1000
+```
+
+### Available Override Flags
+
+| Flag | Entity Type |
+|---|---|
+| `--systems` | System |
+| `--data-assets` | DataAsset |
+| `--policies` | Policy |
+| `--vendors` | Vendor |
+| `--locations` | Location |
+| `--threat-actors` | ThreatActor |
+| `--incidents` | Incident |
+| `--regulations` | Regulation |
+| `--controls` | Control |
+| `--risks` | Risk |
+| `--threats` | Threat |
+| `--integrations` | Integration |
+| `--data-domains` | DataDomain |
+| `--data-flows` | DataFlow |
+| `--org-units` | OrganizationalUnit |
+| `--capabilities` | BusinessCapability |
+| `--sites` | Site |
+| `--geographies` | Geography |
+| `--jurisdictions` | Jurisdiction |
+| `--product-portfolios` | ProductPortfolio |
+| `--products` | Product |
+| `--market-segments` | MarketSegment |
+| `--customers` | Customer |
+| `--contracts` | Contract |
+| `--initiatives` | Initiative |
+
+**Not overridable** (derived from other state): departments, roles, networks, vulnerabilities, persons (use `--employees`).
 
 ---
 

--- a/src/cli/entity_overrides.py
+++ b/src/cli/entity_overrides.py
@@ -1,0 +1,67 @@
+"""Shared CLI options for entity count overrides.
+
+Provides a Click decorator that adds --systems, --vendors, --controls, etc.
+flags to any CLI command. The decorator collects all provided overrides into
+a dict[str, int] mapping EntityType.value → count.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING, Any
+
+import click
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+from synthetic.orchestrator import OVERRIDABLE_ENTITIES
+
+# Build the list of Click options from OVERRIDABLE_ENTITIES.
+# Each option is --{name} with type=int and default=None.
+_OVERRIDE_OPTIONS: list[tuple[str, str]] = [
+    (cli_name, entity_type.value) for cli_name, entity_type in OVERRIDABLE_ENTITIES.items()
+]
+
+
+def _build_help(cli_name: str) -> str:
+    """Build help text for an entity count override flag."""
+    label = cli_name.replace("_", " ")
+    return f"Override {label} count (bypasses scaling)."
+
+
+def entity_count_overrides(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Click decorator that adds --systems, --vendors, etc. override flags.
+
+    Injects a `count_overrides` keyword argument (dict[str, int]) into the
+    decorated function containing all entity count overrides that were provided.
+
+    Usage:
+        @click.command()
+        @entity_count_overrides
+        def my_command(count_overrides, **kwargs):
+            orchestrator = SyntheticOrchestrator(kg, profile, count_overrides=count_overrides)
+    """
+
+    @functools.wraps(func)
+    def wrapper(**kwargs: Any) -> Any:
+        # Collect all provided overrides into a dict
+        overrides: dict[str, int] = {}
+        for cli_name, entity_value in _OVERRIDE_OPTIONS:
+            value = kwargs.pop(cli_name, None)
+            if value is not None:
+                overrides[entity_value] = value
+        kwargs["count_overrides"] = overrides
+        return func(**kwargs)
+
+    # Apply Click options in reverse order so they appear in declaration order
+    for cli_name, _entity_value in reversed(_OVERRIDE_OPTIONS):
+        wrapper = click.option(
+            f"--{cli_name.replace('_', '-')}",
+            cli_name,
+            type=int,
+            default=None,
+            help=_build_help(cli_name),
+        )(wrapper)
+
+    return wrapper

--- a/tests/unit/synthetic/test_orchestrator.py
+++ b/tests/unit/synthetic/test_orchestrator.py
@@ -46,3 +46,41 @@ class TestSyntheticOrchestrator:
         SyntheticOrchestrator(kg, profile, seed=42).generate()
 
         assert len(kg.event_log) > 0
+
+    def test_count_overrides_apply(self):
+        """Entity count overrides should produce exact counts."""
+        kg = KnowledgeGraph()
+        profile = mid_size_tech_company(500)
+        overrides = {"system": 25, "vendor": 5, "control": 3}
+        counts = SyntheticOrchestrator(kg, profile, seed=42, count_overrides=overrides).generate()
+
+        assert counts["system"] == 25
+        assert counts["vendor"] == 5
+        assert counts["control"] == 3
+        # Non-overridden types should still be present and > 0
+        assert counts["person"] == 500
+        assert counts["department"] > 0
+        assert counts["risk"] > 0
+
+    def test_count_overrides_empty_dict_is_noop(self):
+        """Empty overrides dict should not change behavior."""
+        kg1 = KnowledgeGraph()
+        kg2 = KnowledgeGraph()
+        profile = mid_size_tech_company(50)
+
+        counts_no_override = SyntheticOrchestrator(kg1, profile, seed=42).generate()
+        counts_empty_override = SyntheticOrchestrator(
+            kg2, profile, seed=42, count_overrides={}
+        ).generate()
+
+        assert counts_no_override["system"] == counts_empty_override["system"]
+        assert counts_no_override["vendor"] == counts_empty_override["vendor"]
+
+    def test_count_overrides_zero_suppresses_entity(self):
+        """Override of 0 should suppress generation of that entity type."""
+        kg = KnowledgeGraph()
+        profile = mid_size_tech_company(50)
+        overrides = {"threat_actor": 0}
+        counts = SyntheticOrchestrator(kg, profile, seed=42, count_overrides=overrides).generate()
+
+        assert "threat_actor" not in counts or counts.get("threat_actor", 0) == 0


### PR DESCRIPTION
## Summary
- 25 individual flags (`--systems`, `--vendors`, `--controls`, etc.) added to both `hckg demo` and `hckg generate org` for pinning exact entity counts
- `count_overrides` parameter on `SyntheticOrchestrator` for programmatic use
- Shared `entity_overrides.py` decorator avoids duplicating 25 Click options across commands
- Override check in `_resolve_count()` takes priority before profile-based resolution

## Test plan
- [x] 692 tests pass (689 + 3 new override tests)
- [x] `hckg generate org --employees 5000 --systems 50 --vendors 10` → systems=50, vendors=10
- [x] `hckg demo --employees 200 --controls 5 --risks 3` → controls=5, risks=3
- [x] Ruff lint clean
- [x] All 25 flags visible in `--help`

Closes #115