### PR TITLE
Add explicit permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `permissions: contents: read` to CI workflow to lock down GITHUB_TOKEN to least privilege
- Resolves CodeQL `actions/missing-workflow-permissions` alert (CWE-275)

Closes #119

## Test plan
- [x] All 692 tests pass
- [x] Ruff clean