### PR TITLE
Fix stack trace exposure in REST API error handler

### DIFF
--- a/src/serve/app.py
+++ b/src/serve/app.py
@@ -747,14 +747,14 @@ def create_app(graph_path: str | None = None) -> Any:
 
             handler = dispatch.get(name)
             if handler is None:
-                return _error(f"Unknown tool '{name}'. Available: {list(dispatch.keys())}")
+                return _error(f"Unknown tool. Available: {list(dispatch.keys())}")
 
             result = handler(arguments)
             return _json_response({"result": result})
 
         except _NoGraphError:
             return _error("No graph loaded. POST to /load first.", 409)
-        except KeyError as exc:
-            return _error(f"Missing required argument: {exc}")
+        except KeyError:
+            return _error("Missing required argument in tool call.")
 
     return app


### PR DESCRIPTION
## Summary
- Replace exception details with generic error messages in `/openai/call` endpoint
- Also remove user-echoed tool name from "unknown tool" error
- Resolves CodeQL `py/stack-trace-exposure` alert (CWE-209, CWE-497)

Closes #123

## Test plan
- [x] All 692 tests pass
- [x] Ruff clean