### PR TITLE
Add CLI command hckg charts and generate_all_charts() API

### DIFF
--- a/src/analysis/charts/__init__.py
+++ b/src/analysis/charts/__init__.py
@@ -4,10 +4,41 @@ Auto-generates charts showcasing scaling behavior, entity/relationship
 distributions, quality metrics, and performance characteristics.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from analysis.charts.models import ChartConfig, ChartDataSet, ScaleSnapshot
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 __all__ = [
     "ChartConfig",
     "ChartDataSet",
     "ScaleSnapshot",
+    "generate_all_charts",
 ]
+
+
+def generate_all_charts(
+    config: ChartConfig | None = None,
+    progress_callback: Callable[[str, int], None] | None = None,
+) -> list[str]:
+    """One-call API: collect data at multiple scales and render all charts.
+
+    Args:
+        config: Chart generation configuration. Uses defaults if None.
+        progress_callback: Called with (profile, scale) before each generation.
+
+    Returns:
+        List of output file paths.
+    """
+    from analysis.charts.data_collector import ScaleDataCollector
+    from analysis.charts.renderer import ChartRenderer
+
+    config = config or ChartConfig()
+    collector = ScaleDataCollector(config)
+    dataset = collector.collect(progress_callback=progress_callback)
+    renderer = ChartRenderer(dataset, config)
+    return renderer.render_all()

--- a/src/cli/charts_cmd.py
+++ b/src/cli/charts_cmd.py
@@ -1,0 +1,144 @@
+"""CLI command: hckg charts — generate analytics charts."""
+
+from __future__ import annotations
+
+import click
+
+
+@click.command()
+@click.option(
+    "--profiles",
+    default="tech",
+    help="Comma-separated profile names (tech, financial, healthcare).",
+)
+@click.option(
+    "--scales",
+    default="100,500,1000,5000",
+    help="Comma-separated employee counts.",
+)
+@click.option(
+    "--full",
+    is_flag=True,
+    default=False,
+    help="Run all 3 profiles at 100, 500, 1000, 5000, 10000, 20000.",
+)
+@click.option(
+    "--output",
+    type=click.Path(),
+    default="./charts",
+    help="Output directory for chart files (default: ./charts).",
+)
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["png", "svg"]),
+    default="png",
+    help="Output format (default: png).",
+)
+@click.option("--seed", type=int, default=42, help="Random seed.")
+@click.option("--dpi", type=int, default=150, help="Chart resolution (default: 150).")
+@click.option("--scaling/--no-scaling", default=True, help="Scaling curves chart.")
+@click.option("--entities/--no-entities", default=True, help="Entity distribution chart.")
+@click.option(
+    "--relationships/--no-relationships", default=True, help="Relationship distribution chart."
+)
+@click.option("--performance/--no-performance", default=True, help="Performance scaling chart.")
+@click.option("--density/--no-density", default=True, help="Density vs scale chart.")
+@click.option("--centrality/--no-centrality", default=True, help="Centrality distribution chart.")
+@click.option("--quality/--no-quality", default=True, help="Quality radar chart.")
+@click.option(
+    "--profile-comparison/--no-profile-comparison",
+    default=True,
+    help="Profile comparison chart (requires 2+ profiles).",
+)
+def charts(
+    profiles: str,
+    scales: str,
+    full: bool,
+    output: str,
+    fmt: str,
+    seed: int,
+    dpi: int,
+    scaling: bool,
+    entities: bool,
+    relationships: bool,
+    performance: bool,
+    density: bool,
+    centrality: bool,
+    quality: bool,
+    profile_comparison: bool,
+) -> None:
+    """Generate analytics charts from synthetic data at multiple scales.
+
+    \b
+    Quick charts (default):
+        hckg charts
+
+    \b
+    Full suite (all profiles, all scales):
+        hckg charts --full
+
+    \b
+    Custom:
+        hckg charts --profiles tech,financial --scales 100,1000,5000
+
+    \b
+    SVG output:
+        hckg charts --format svg --output ./charts-svg
+
+    \b
+    Selective charts:
+        hckg charts --scaling --performance --no-quality
+    """
+    try:
+        from analysis.charts import ChartConfig, generate_all_charts
+    except ImportError:
+        raise click.ClickException(
+            "Charts require matplotlib. Install with: poetry install --extras viz"
+        ) from None
+
+    if full:
+        profile_list = ["tech", "financial", "healthcare"]
+        scale_list = [100, 500, 1000, 5000, 10000, 20000]
+    else:
+        profile_list = [p.strip() for p in profiles.split(",")]
+        scale_list = [int(s.strip()) for s in scales.split(",")]
+
+    valid_profiles = {"tech", "financial", "healthcare"}
+    for p in profile_list:
+        if p not in valid_profiles:
+            raise click.BadParameter(
+                f"Unknown profile '{p}'. Valid: {', '.join(sorted(valid_profiles))}",
+                param_hint="--profiles",
+            )
+
+    config = ChartConfig(
+        output_dir=output,
+        format=fmt,
+        scales=scale_list,
+        profiles=profile_list,
+        seed=seed,
+        dpi=dpi,
+        render_scaling=scaling,
+        render_entities=entities,
+        render_relationships=relationships,
+        render_performance=performance,
+        render_density=density,
+        render_centrality=centrality,
+        render_quality=quality,
+        render_profile_comparison=profile_comparison,
+    )
+
+    click.echo(f"Generating charts: profiles={profile_list}, scales={scale_list}")
+    click.echo(f"Output: {output} ({fmt.upper()}, {dpi} DPI)")
+    click.echo()
+
+    def progress(profile: str, scale: int) -> None:
+        click.echo(f"  Generating {profile} @ {scale:,} employees...")
+
+    paths = generate_all_charts(config, progress_callback=progress)
+
+    click.echo()
+    click.echo(f"Generated {len(paths)} charts:")
+    for p in paths:
+        click.echo(f"  {p}")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -18,6 +18,7 @@ def cli(ctx: click.Context, backend: str) -> None:
 # Import and register subcommand groups
 from cli.auto_cmd import auto  # noqa: E402
 from cli.benchmark_cmd import benchmark  # noqa: E402
+from cli.charts_cmd import charts  # noqa: E402
 from cli.demo_cmd import demo  # noqa: E402
 from cli.export_cmd import export_cmd  # noqa: E402
 from cli.generate import generate  # noqa: E402
@@ -27,6 +28,7 @@ from cli.serve_cmd import serve_cmd  # noqa: E402
 from cli.visualize_cmd import visualize_cmd  # noqa: E402
 
 cli.add_command(benchmark)
+cli.add_command(charts)
 cli.add_command(demo)
 cli.add_command(generate)
 cli.add_command(auto)


### PR DESCRIPTION
## Summary
- `hckg charts` CLI command with full option suite (profiles, scales, format, dpi, 8 chart toggles)
- `generate_all_charts()` public API function for programmatic use
- Registered in CLI main group
- 4 new tests (44 total)

Closes #138

## Test plan
- [x] 44 passed, ruff clean
- [x] `hckg charts --help` shows all options
- [x] `hckg charts --scales 100 --profiles tech --output /tmp/test` produces 7 PNG files