### PR TITLE
Add charts integration tests and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.20.7] - 2026-02-20
+
+### Added
+- **Analytics charts module** (`src/analysis/charts/`) — auto-generates 8 chart types showcasing scaling, distributions, performance, and quality (#126, #128, #130, #132, #134, #136, #138, #140)
+- **`hckg charts` CLI command** — generate charts from synthetic data at multiple scales and profiles
+- **`generate_all_charts()` API** — one-call function for programmatic chart generation
+- **8 chart types**: scaling curves, entity distribution, relationship distribution, profile comparison, performance scaling, density vs scale, centrality distribution, quality radar
+- **ScaleDataCollector** — generates graphs at multiple (profile, scale) combinations and captures comprehensive statistics
+- **ChartRenderer** — matplotlib-based rendering with Agg backend, PNG/SVG output, configurable DPI
+- **Visual theme** — consistent entity colors, profile colors, type groupings, quality dimension labels
+- 48 tests covering models, collector, renderer, CLI, public API, and integration pipeline
+
 ## [0.19.7] - 2026-02-20
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,11 +7,13 @@
 ## Quick Commands
 
 ```bash
-poetry run pytest tests/ -v          # Run all tests (~692)
+poetry run pytest tests/ -v          # Run all tests (~740)
 poetry run pytest tests/performance/ -v  # Performance regression tests
 poetry run ruff check src/ tests/    # Lint
 poetry run hckg demo --clean         # Generate fresh graph.json
 poetry run hckg demo --employees 200 # Larger org
+poetry run hckg charts               # Generate analytics charts (default: tech, 100-5000)
+poetry run hckg charts --full        # All 3 profiles, 6 scales
 ```
 
 ## Architecture
@@ -25,9 +27,9 @@ src/
   auto/         # Auto KG from CSV/text (rule-based + optional LLM)
   ingest/       # CSVIngestor, JSONIngestor with schema mappings
   export/       # JSONExporter, GraphMLExporter
-  analysis/     # Centrality, risk scoring, attack paths, blast radius, benchmarking
+  analysis/     # Centrality, risk scoring, attack paths, blast radius, benchmarking, charts
   rag/          # GraphRAG retrieval pipeline
-  cli/          # Click CLI (demo, generate, inspect, auto, serve, install, visualize, export, benchmark)
+  cli/          # Click CLI (demo, generate, inspect, auto, serve, install, visualize, export, benchmark, charts)
   mcp_server/   # MCP server for Claude Desktop (state.py, helpers.py, tools.py, server.py)
   serve/        # REST API server (Flask)
 ```
@@ -65,6 +67,22 @@ L00 Foundation → L01 Compliance → L02 Technology → L03 Data → L04 Organi
 4. **Relationship types are lowercase** — Stats show `"implements"` not `"IMPLEMENTS"`. The `RelationshipType` enum values are lowercase strings.
 
 5. **EntityRegistry.auto_discover()** — Must be called before using `EntityRegistry.get()` in ingestion contexts.
+
+## Analytics Charts
+
+The charts module (`src/analysis/charts/`) auto-generates 8 chart types from synthetic data:
+
+1. **Scaling Curves** — entity/relationship count vs employee count (demonstrates linearity)
+2. **Entity Distribution** — stacked bar of 30 entity types across scales
+3. **Relationship Distribution** — horizontal bar of top-20 relationship types
+4. **Profile Comparison** — grouped bar comparing tech/financial/healthcare (requires 2+ profiles)
+5. **Performance Scaling** — dual-axis: generation time + peak memory vs employee count
+6. **Density vs Scale** — graph density trend as org grows
+7. **Centrality Distribution** — top-15 entities by degree centrality
+8. **Quality Radar** — 5-axis spider chart from QualityReport dimensions
+
+**CLI:** `hckg charts --profiles tech,financial --scales 100,500,1000,5000 --output ./charts`
+**API:** `from analysis.charts import generate_all_charts, ChartConfig`
 
 ## MCP Server
 

--- a/tests/integration/test_charts_pipeline.py
+++ b/tests/integration/test_charts_pipeline.py
@@ -1,0 +1,96 @@
+"""Integration tests for the analytics charts pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.mark.integration
+class TestChartsPipeline:
+    def test_full_pipeline_single_profile(self, tmp_path):
+        """End-to-end: collect data at 100 employees, render all charts."""
+        from analysis.charts import ChartConfig, generate_all_charts
+
+        config = ChartConfig(
+            output_dir=str(tmp_path),
+            format="png",
+            scales=[100],
+            profiles=["tech"],
+            seed=42,
+        )
+        paths = generate_all_charts(config)
+
+        # Should produce 7 charts (no profile_comparison for single profile)
+        assert len(paths) == 7
+        for p in paths:
+            fp = Path(p)
+            assert fp.exists()
+            assert fp.stat().st_size > 0
+            assert fp.suffix == ".png"
+
+        # Verify expected filenames
+        filenames = {Path(p).name for p in paths}
+        assert "scaling_curves.png" in filenames
+        assert "entity_distribution_tech.png" in filenames
+        assert "relationship_distribution_tech.png" in filenames
+        assert "performance_scaling.png" in filenames
+        assert "density_vs_scale.png" in filenames
+        assert "centrality_tech.png" in filenames
+        assert "quality_radar.png" in filenames
+
+    def test_full_pipeline_multi_profile(self, tmp_path):
+        """Multi-profile pipeline should include profile comparison chart."""
+        from analysis.charts import ChartConfig, generate_all_charts
+
+        config = ChartConfig(
+            output_dir=str(tmp_path),
+            format="png",
+            scales=[100],
+            profiles=["tech", "financial"],
+            seed=42,
+        )
+        paths = generate_all_charts(config)
+
+        # Should produce 8 charts (includes profile_comparison)
+        assert len(paths) == 8
+        filenames = {Path(p).name for p in paths}
+        assert "profile_comparison.png" in filenames
+
+    def test_cli_end_to_end(self, tmp_path):
+        """hckg charts CLI produces output files."""
+        from cli.charts_cmd import charts
+
+        runner = CliRunner()
+        result = runner.invoke(
+            charts,
+            [
+                "--scales", "100",
+                "--profiles", "tech",
+                "--output", str(tmp_path),
+                "--format", "png",
+            ],
+        )
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+        assert "Generated" in result.output
+
+        png_files = list(tmp_path.glob("*.png"))
+        assert len(png_files) == 7
+
+    def test_svg_output(self, tmp_path):
+        """SVG format should produce .svg files."""
+        from analysis.charts import ChartConfig, generate_all_charts
+
+        config = ChartConfig(
+            output_dir=str(tmp_path),
+            format="svg",
+            scales=[100],
+            profiles=["tech"],
+            seed=42,
+        )
+        paths = generate_all_charts(config)
+
+        for p in paths:
+            assert Path(p).suffix == ".svg"


### PR DESCRIPTION
## Summary
- 4 integration tests: single-profile pipeline, multi-profile with comparison chart, CLI end-to-end, SVG output
- CHANGELOG updated for entire v0.20.x series
- CLAUDE.md updated with charts module docs, CLI commands, architecture

Closes #140

## Test plan
- [x] 740 passed, 1 skipped (full suite)
- [x] Ruff clean
- [x] Integration: `test_charts_pipeline.py` — 4 passed