### PR TITLE
Fix CI: ruff format check on chart module files

### DIFF
--- a/src/analysis/charts/data_collector.py
+++ b/src/analysis/charts/data_collector.py
@@ -32,9 +32,7 @@ class ScaleDataCollector:
     def __init__(self, config: ChartConfig) -> None:
         self._config = config
 
-    def collect(
-        self, progress_callback: Callable[[str, int], None] | None = None
-    ) -> ChartDataSet:
+    def collect(self, progress_callback: Callable[[str, int], None] | None = None) -> ChartDataSet:
         """Run generation at all (profile, scale) combinations and collect data."""
         dataset = ChartDataSet(
             profiles=list(self._config.profiles),

--- a/src/analysis/charts/renderer.py
+++ b/src/analysis/charts/renderer.py
@@ -196,9 +196,7 @@ class ChartRenderer:
 
         ax.set_xlabel("Employee Count", fontsize=FONT_LABEL)
         ax.set_ylabel("Entity Count", fontsize=FONT_LABEL)
-        ax.set_title(
-            f"Entity Distribution by Type Group ({profile_name})", fontsize=FONT_TITLE
-        )
+        ax.set_title(f"Entity Distribution by Type Group ({profile_name})", fontsize=FONT_TITLE)
         ax.set_xticks(x)
         ax.set_xticklabels([str(s) for s in scales], fontsize=FONT_TICK)
         ax.legend(fontsize=FONT_TICK, loc="upper left")
@@ -277,9 +275,7 @@ class ChartRenderer:
         common_scale = max(self._data.scales)
         profile_snaps = []
         for profile_name in self._data.profiles:
-            snaps_at = [
-                s for s in self._data.at_scale(common_scale) if s.profile == profile_name
-            ]
+            snaps_at = [s for s in self._data.at_scale(common_scale) if s.profile == profile_name]
             if snaps_at:
                 profile_snaps.append(snaps_at[0])
 
@@ -330,9 +326,7 @@ class ChartRenderer:
                 )
 
         ax.set_ylabel("Count", fontsize=FONT_LABEL)
-        ax.set_title(
-            f"Profile Comparison at {common_scale:,} Employees", fontsize=FONT_TITLE
-        )
+        ax.set_title(f"Profile Comparison at {common_scale:,} Employees", fontsize=FONT_TITLE)
         ax.set_xticks(x)
         ax.set_xticklabels(metrics, fontsize=FONT_LABEL)
         ax.legend(fontsize=FONT_TICK)
@@ -542,8 +536,7 @@ class ChartRenderer:
             has_data = True
 
         if not has_data:
-            ax.text(0.5, 0.5, "No quality data", ha="center", va="center",
-                    transform=ax.transAxes)
+            ax.text(0.5, 0.5, "No quality data", ha="center", va="center", transform=ax.transAxes)
 
         ax.set_xticks(angles[:-1])
         ax.set_xticklabels(dimension_labels, fontsize=FONT_TICK)

--- a/tests/integration/test_charts_pipeline.py
+++ b/tests/integration/test_charts_pipeline.py
@@ -67,10 +67,14 @@ class TestChartsPipeline:
         result = runner.invoke(
             charts,
             [
-                "--scales", "100",
-                "--profiles", "tech",
-                "--output", str(tmp_path),
-                "--format", "png",
+                "--scales",
+                "100",
+                "--profiles",
+                "tech",
+                "--output",
+                str(tmp_path),
+                "--format",
+                "png",
             ],
         )
         assert result.exit_code == 0, f"CLI failed: {result.output}"

--- a/tests/unit/analysis/test_charts.py
+++ b/tests/unit/analysis/test_charts.py
@@ -501,9 +501,7 @@ class TestChartRenderer:
                     density=0.004,
                 )
             )
-        dataset = ChartDataSet(
-            snapshots=snapshots, profiles=["tech", "financial"], scales=[500]
-        )
+        dataset = ChartDataSet(snapshots=snapshots, profiles=["tech", "financial"], scales=[500])
         cfg = ChartConfig(output_dir=str(tmp_path), format="png")
         renderer = ChartRenderer(dataset, cfg)
         path = renderer.render_profile_comparison()
@@ -610,9 +608,12 @@ class TestChartsCLI:
         result = runner.invoke(
             charts,
             [
-                "--scales", "100",
-                "--profiles", "tech",
-                "--output", str(tmp_path),
+                "--scales",
+                "100",
+                "--profiles",
+                "tech",
+                "--output",
+                str(tmp_path),
                 "--no-centrality",
                 "--no-quality",
             ],


### PR DESCRIPTION
## Summary
- Run `ruff format` on 4 chart module files that were missing formatting during v0.20.0-v0.20.7 development
- Fixes CI `ruff format --check` step failure

Fixes #162