### PR TITLE
Add Architecture Decision Records (ADR-001 through ADR-012)

### DIFF
--- a/docs/adr/001-custom-synthetic-data-pipeline.md
+++ b/docs/adr/001-custom-synthetic-data-pipeline.md
@@ -1,0 +1,168 @@
+# ADR-001: Custom Synthetic Data Pipeline over External Libraries
+
+**Status:** Accepted
+**Date:** 2026-02-21
+**Context:** Synthetic data generation for enterprise knowledge graphs
+
+---
+
+## Summary
+
+The synthetic data pipeline in hc-enterprise-kg is a custom implementation. This document records the architectural decision to build and maintain that pipeline rather than adopt an external synthetic data library, and the evaluation that supports it.
+
+---
+
+## Problem Statement
+
+Generating structurally accurate enterprise organizational models requires producing 30 entity types, 52 relationship types, and domain-specific field values that are internally consistent across industry profiles, scaling tiers, and organizational structures. The question is whether an existing open-source Python library can handle this, or whether the problem demands a purpose-built pipeline.
+
+---
+
+## Evaluation Criteria
+
+Five properties define what the pipeline must deliver:
+
+1. **Graph-native generation** -- Output is a connected knowledge graph with typed, weighted, directional relationships, not tabular rows
+2. **Domain-constrained coherence** -- Coordinated template dicts across 30 generators producing internally consistent field values (risk math, encryption-classification alignment, tech stack coherence)
+3. **Research-backed scaling** -- Entity counts derived from `scaled_range()` with industry-specific `ScalingCoefficients` and size-tier multipliers calibrated against Gartner, MuleSoft, NIST, Hackett Group, and McKinsey benchmarks
+4. **Profile-driven variation** -- Three industry profiles (tech, financial, healthcare) producing structurally different graphs that reflect real-world sector patterns
+5. **Structural validation** -- Automated quality scoring across five dimensions with a 0.70 floor
+
+Any candidate library must satisfy all five, or clearly identify which it can offload.
+
+---
+
+## Libraries Evaluated
+
+### Tier 1: Multi-Table / Relational Synthesis
+
+| Library | Version | License | Approach | Active |
+|---------|---------|---------|----------|--------|
+| **SDV (Synthetic Data Vault)** | 1.32.1 | Business Source License | Gaussian Copula + HMA for multi-table relational data | Yes |
+
+SDV is the most capable general-purpose synthetic data library available. Its `HMASynthesizer` models parent-child relationships using hierarchical recursive algorithms, and its `DayZSynthesizer` can generate multi-table data from metadata alone without training data.
+
+**Where it falls short:**
+
+- **Table limit** -- `HMASynthesizer` is optimized for ~5 tables at 1 level of depth. Modelling 30 entity types with 52 relationship types would require flattening the graph into dozens of interrelated tables, losing the graph semantics that make the output useful for blast radius, centrality, and path analysis
+- **Tabular paradigm** -- SDV operates on foreign-key parent-child relationships. Enterprise knowledge graphs have many-to-many, directional, weighted relationships with typed properties (`depends_on` with dependency strength, `mitigates` with effectiveness metadata). This is not a tabular problem
+- **Requires training data** -- SDV learns statistical distributions from existing datasets. Our pipeline generates from domain rules and scaling coefficients, not from real organizational data. `DayZSynthesizer` can generate from metadata, but without the domain constraints that make the output structurally accurate
+- **License incompatibility** -- BSL restricts commercial use. hc-enterprise-kg is MIT-licensed
+
+### Tier 2: Field-Level Data Providers
+
+| Library | Version | License | Approach | Active |
+|---------|---------|---------|----------|--------|
+| **Faker** | 40.4.0 | MIT | Provider-based fake data (names, addresses, dates, text) | Yes |
+| **Mimesis** | 19.1.0 | MIT | Schema-based fake data, zero dependencies, typed | Yes |
+
+Both libraries generate realistic atomic field values -- names, company names, addresses, IP addresses, phone numbers, dates. Neither provides relational modelling, constraint enforcement, or domain-specific generation logic.
+
+**Current usage:** Faker is already a dependency for leaf-level field values (person names, email addresses, network CIDRs). This is the correct scope for a field-level provider. The generators layer domain-specific coordinated templates on top of these atomic values.
+
+**Mimesis as alternative:** Mimesis offers ~2x performance over Faker, zero external dependencies, full type annotations, and schema-based generation. It is a viable drop-in for leaf-level values if Faker performance becomes a bottleneck. It does not change the architectural picture.
+
+### Tier 3: Privacy-Preserving Synthesis (Wrong Paradigm)
+
+| Library | Version | License | Approach | Active |
+|---------|---------|---------|----------|--------|
+| **Gretel Synthetics** | 0.22.20 | Source Available | LSTM/GAN-based, differential privacy | Slow cadence |
+| **ydata-synthetic** | 1.4.0 | GPL-3.0 | GAN-based (CTGAN, WGAN) | Deprecated |
+| **DataSynthesizer** | 0.1.13 | MIT | Bayesian networks, differential privacy | Inactive |
+| **Synthcity** | 0.2.12 | Apache-2.0 | Plugin-based, 20+ generative models | Yes |
+
+These libraries solve a fundamentally different problem: learning statistical distributions from sensitive real-world data and producing privacy-safe copies. Our pipeline generates organizational models from scratch using domain rules and scaling coefficients. There is no source dataset to learn from, no privacy constraint to satisfy, and no statistical distribution to preserve. Wrong tool for the job.
+
+### Tier 4: Knowledge Graph / RDF Generators
+
+| Library | Version | License | Approach | Active |
+|---------|---------|---------|----------|--------|
+| **PyGraft** | Academic | MIT | Schema + KG generation with OWL reasoning | Academic |
+| **RDFGraphGen** | PyPI | -- | RDF graphs from SHACL shape constraints | Academic |
+
+Both operate in the Semantic Web / RDF ontology space. They generate abstract ontological graphs with RDFS/OWL constructs, not structured enterprise organizational models with Pydantic entities, industry profiles, and domain-specific field values. Closer in spirit to the graph generation problem, but targeting a different domain and data model entirely.
+
+---
+
+## What the Custom Pipeline Does That No Library Can
+
+The gap between available libraries and the requirements is not incremental -- it is structural. The pipeline's value is in the domain logic, not the data generation mechanics.
+
+### 1. Layered Generation with Referential Integrity
+
+Twelve generation layers (L00 Foundation through L11 Initiatives) execute in dependency order. L01 Compliance entities exist before L02 Technology entities reference them. L05 People are assigned to L04 Departments. This is a topological build, not independent table generation.
+
+### 2. Research-Backed Scaling
+
+`scaled_range(employee_count, coefficient, floor, ceiling)` with industry-specific `ScalingCoefficients` and four size-tier multipliers (startup 0.7x, mid-market 1.0x, enterprise 1.2x, large 1.4x) produces entity counts calibrated to published research. At 14,512 employees, a tech profile generates 42 departments and 301 roles. No library encodes this domain knowledge.
+
+### 3. Dynamic Structural Adaptation
+
+Departments exceeding 500 headcount subdivide into sub-departments via 30+ industry-specific `SUB_DEPARTMENT_TEMPLATES`. Roles expand with seniority variants (Junior/Senior/Staff) based on sub-department headcount. The organizational structure reshapes itself as the graph scales.
+
+### 4. Coordinated Template Dicts
+
+All 30 generators use domain-specific template dictionaries that produce internally consistent field values. A system's technology stack, vendor associations, data classifications, and compliance mappings are correlated, not independently randomized. This is what makes the graph structurally accurate rather than statistically plausible.
+
+### 5. Relationship Weaving
+
+33 weaver methods produce 52 relationship types with contextual weight, confidence scores, and typed properties via `_make_rel()`. Mirror fields are populated post-weave. A `depends_on` between two systems carries dependency type and strength. A `mitigates` between a control and a risk carries effectiveness metadata. This is domain modelling, not foreign-key generation.
+
+### 6. Quality Scoring
+
+`assess_quality()` validates five dimensions: risk math consistency (RISK_MATRIX determinism), description quality (no lorem ipsum), tech stack coherence, field correlations, and encryption-classification alignment. The orchestrator warns if the composite score falls below 0.70. No external library provides enterprise-domain quality validation.
+
+---
+
+## Decision
+
+**Build and maintain the custom synthetic data pipeline.**
+
+The external library ecosystem addresses two adjacent problems (privacy-preserving copies of real data, and realistic atomic field values) but does not address the core problem: generating structurally accurate, domain-constrained, scaling-aware enterprise organizational models as connected knowledge graphs.
+
+The architecture is:
+
+- **Custom code** (~85%) -- Orchestrator, 30 generators, 33 relationship weavers, quality scoring, scaling logic, profile system, layer ordering
+- **Faker** (~15%) -- Leaf-level field values (names, addresses, dates, IPs, CIDRs) where domain-specific templates are not required
+
+This is the correct boundary. The domain logic is the product.
+
+---
+
+## Alternatives Considered and Rejected
+
+| Alternative | Rejection Reason |
+|-------------|------------------|
+| SDV as orchestrator | Tabular paradigm, ~5 table limit, BSL license, requires training data |
+| Mimesis replacing Faker | Valid micro-optimization, not an architectural change. Evaluate if Faker becomes a performance bottleneck |
+| PyGraft for graph structure | RDF/OWL domain, no enterprise organizational modelling, no Pydantic integration |
+| Hybrid (SDV for entities, custom for relationships) | Adds complexity without reducing it. SDV cannot encode scaling coefficients or coordinated templates. The orchestrator already handles entity generation cleanly |
+
+---
+
+## Risks of This Decision
+
+1. **Maintenance burden** -- 30 generators and 33 weavers are custom code that must be maintained, tested, and extended. Mitigated by 740+ tests, quality scoring, and the performance benchmarking suite
+2. **Knowledge concentration** -- The domain logic encodes specific scaling research and industry patterns. Mitigated by CLAUDE.md, ARCHITECTURE.md, and comprehensive inline documentation
+3. **No free lunch from upstream improvements** -- If SDV or a future library develops graph-native generation with constraint support, we do not benefit automatically. Mitigated by periodic re-evaluation (see below)
+
+---
+
+## Re-Evaluation Triggers
+
+Revisit this decision if any of the following occur:
+
+- A Python library with MIT/Apache-2.0 license ships graph-native synthetic data generation with typed, weighted, directional relationships
+- SDV or equivalent adds support for 30+ table schemas without requiring training data, under a permissive license
+- The maintenance cost of custom generators exceeds the cost of adapting an external library (measured by test failures, bug frequency, or time-to-add-entity-type)
+- A domain-specific enterprise modelling library emerges that encodes organizational scaling research
+
+---
+
+## References
+
+- [SDV Documentation](https://docs.sdv.dev/sdv) -- Multi-table relational synthesis
+- [Faker Documentation](https://faker.readthedocs.io/) -- Field-level fake data
+- [Mimesis Documentation](https://mimesis.name/) -- High-performance fake data
+- [PyGraft](https://github.com/nicolas-hbt/pygraft) -- Synthetic knowledge graph generation (RDF/OWL)
+- Gartner, MuleSoft, NIST, Hackett Group, McKinsey -- Scaling coefficient sources (see `docs/profiles.md`)

--- a/docs/adr/002-pydantic-v2-extra-allow.md
+++ b/docs/adr/002-pydantic-v2-extra-allow.md
@@ -1,0 +1,114 @@
+# ADR-002: Pydantic v2 with `extra="allow"` for Entity Models
+
+**Status:** Accepted
+**Date:** 2026-02-21
+**Context:** Entity model framework and validation strategy
+
+---
+
+## Summary
+
+All 30 entity types extend `BaseEntity`, a Pydantic v2 `BaseModel` with `model_config = ConfigDict(extra="allow")`. This decision prioritizes forward compatibility and schema flexibility over strict validation. It is the single most consequential design choice in the project and the most common source of bugs.
+
+---
+
+## Decision
+
+Use Pydantic v2 as the entity model framework with `extra="allow"` on the base class.
+
+---
+
+## Context
+
+An enterprise knowledge graph with 30 entity types, 52 relationship types, and hundreds of fields needs a model layer that provides runtime validation, JSON serialization, type safety, and IDE support. The ontology grew from 12 types (v0.1) to 30 types over 20+ releases, and will continue to evolve.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Assessment |
+|-------------|------------|
+| **Pydantic v2 with `extra="forbid"`** | Strict validation catches typos at construction. Rejected because serialized graphs from older versions fail to load when new fields are added, and mirror fields (`Person.holds_roles`) set by the relationship weaver would require schema changes for every new denormalized field |
+| **Pydantic v2 with `extra="ignore"`** | Silently drops unknown fields. Loses data on round-trip, which is worse than storing it in extras |
+| **Python dataclasses** | Lighter weight, stdlib. No built-in JSON serialization, no runtime validation beyond type hints, no `model_dump(mode="json")` for export |
+| **attrs** | Strong validation via converters, fast. No native JSON serialization, less IDE support than Pydantic, smaller ecosystem |
+| **Marshmallow** | Mature serialization library. Separate schema classes from data classes creates duplication. No runtime validation on the data objects themselves |
+
+---
+
+## Rationale
+
+Pydantic v2 provides the best combination of capabilities for this use case:
+
+1. **Runtime validation** -- Field types are enforced at construction. A `System` with `criticality="high"` validates; `criticality=42` fails. This catches a class of bugs that dataclasses miss entirely
+2. **JSON serialization** -- `model_dump(mode="json")` produces export-ready dicts. `model_validate()` reconstructs from JSON. The export/ingest pipeline is three lines of code
+3. **IDE support** -- Full autocomplete, type checking, and inline documentation for all 30 entity classes. This matters for a 200+ field ontology
+4. **`TemporalMixin`** -- `BaseEntity` inherits `created_at`, `updated_at`, `valid_from`, `valid_until`, `version` from `TemporalMixin` via Pydantic's model inheritance. Every entity gets temporal tracking for free
+
+The `extra="allow"` choice specifically enables:
+
+- **Forward compatibility** -- Older graph.json files load in newer code. Newer files with unknown fields load in older code. Neither case raises `ValidationError`
+- **Mirror field injection** -- The relationship weaver's `_populate_mirror_fields()` sets fields like `Person.holds_roles` and `Role.filled_by_persons` post-construction. With `extra="forbid"`, every mirror field would need a schema declaration
+- **Metadata passthrough** -- The auto-KG pipeline attaches `_confidence` and `_source` keys via the metadata dict pattern. Third-party consumers can attach arbitrary metadata without forking the model
+
+---
+
+## Where This Diverges from Best Practice
+
+The conventional recommendation is `extra="forbid"` for domain models. The Pydantic documentation recommends it. Most Pydantic guides recommend it. We chose differently, and the cost is real.
+
+### The Silent Failure Problem
+
+With `extra="allow"`, a misspelled field name does not raise an error. It lands in `__pydantic_extra__` as if nothing happened:
+
+```python
+# This silently succeeds. 'descritpion' goes to extras.
+System(entity_type="system", name="Jenkins", descritpion="CI server")
+```
+
+This is the single most common bug pattern in the project. Generator authors write `descritpion` instead of `description`, the entity validates, the tests pass, and the field is missing in the output. The bug is invisible until someone reads the exported JSON carefully.
+
+### Mitigations Built to Compensate
+
+The project maintains a validation module (`src/domain/validation.py`) specifically to address this:
+
+- **`check_extra_fields(entity)`** -- Returns any keys in `__pydantic_extra__`. A non-empty result is almost always a bug
+- **`warn_extra_fields(entity)`** -- Logs a warning. In strict mode (`HCKG_STRICT=1`), raises `ValueError`
+- **`validate_entity_strict(entity)`** -- Full strict validation check suite
+
+These exist because `extra="allow"` creates a problem that needs compensating controls. With `extra="forbid"`, none of this code would be necessary.
+
+---
+
+## Trade-Offs
+
+| Benefit | Cost |
+|---------|------|
+| Forward/backward graph compatibility | Misspelled fields silently succeed |
+| Mirror field injection without schema changes | Entities can accumulate undiscovered garbage fields |
+| Metadata passthrough for third-party consumers | Required building a separate validation module |
+| Simpler ontology evolution (add fields without breaking old graphs) | Generator authors must be more careful with field names |
+
+---
+
+## Risks
+
+1. **Silent data corruption** -- Misspelled fields produce entities that look correct but are missing data. Mitigated by `HCKG_STRICT=1` in CI and quality scoring checks
+2. **Schema drift** -- Over time, extras accumulate. No enforcement that extras are intentional vs. accidental. Mitigated by `check_extra_fields()` in tests
+3. **Type safety erosion** -- Extras bypass Pydantic's type system entirely. A datetime in an extra field is a string. An int is an int. No validation
+
+---
+
+## Re-Evaluation Triggers
+
+- If the ontology stabilizes at 30 types with no new additions for 3+ releases, `extra="forbid"` becomes more attractive (less forward-compatibility pressure)
+- If a bug audit shows that extra-field typos account for a significant fraction of defects, the cost/benefit balance may have shifted
+- If Pydantic adds a mode like `extra="warn"` that allows extras but logs them, that would be the ideal middle ground
+
+---
+
+## References
+
+- `src/domain/base.py` -- `BaseEntity` with `model_config = ConfigDict(extra="allow")`
+- `src/domain/validation.py` -- Compensating validation controls
+- [Pydantic v2 Model Config](https://docs.pydantic.dev/latest/api/config/) -- `extra` field documentation

--- a/docs/adr/003-networkx-multidigraph.md
+++ b/docs/adr/003-networkx-multidigraph.md
@@ -1,0 +1,125 @@
+# ADR-003: NetworkX MultiDiGraph as Graph Backend
+
+**Status:** Accepted
+**Date:** 2026-02-21
+**Context:** Graph storage engine selection and abstraction strategy
+
+---
+
+## Summary
+
+The graph storage backend is NetworkX's `MultiDiGraph`, an in-memory directed multigraph. It runs behind a 20-method `AbstractGraphEngine` interface that makes the backend pluggable. This decision trades scalability and persistence for zero operational overhead and deployment simplicity.
+
+---
+
+## Decision
+
+Use `nx.MultiDiGraph` as the default (and currently only) graph backend, accessed exclusively through the `AbstractGraphEngine` abstraction.
+
+---
+
+## Why MultiDiGraph Specifically
+
+The choice of `MultiDiGraph` over other NetworkX graph types is deliberate:
+
+| Graph Type | Directed | Multi-Edge | Fit |
+|------------|----------|------------|-----|
+| `Graph` | No | No | Cannot model directional relationships (`manages`, `depends_on`) |
+| `DiGraph` | Yes | No | Cannot model multiple relationships between the same pair of entities |
+| `MultiGraph` | No | Yes | Directionality is essential for organizational modelling |
+| **`MultiDiGraph`** | **Yes** | **Yes** | **Correct model for enterprise knowledge graphs** |
+
+Enterprise graphs routinely have multiple directed edges between the same nodes. A person can both `WORKS_IN` and `MANAGES` a department. Two systems can have both `DEPENDS_ON` and `CONNECTS_TO` relationships with different properties. `MultiDiGraph` is the only NetworkX type that models this correctly.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Assessment |
+|-------------|------------|
+| **Neo4j** | The industry standard for graph databases. Native Cypher queries, ACID transactions, horizontal scaling, persistence. Rejected because it requires a running database server, Java runtime, operational management, and network configuration. For a tool positioned as "run in seconds without standing up a production data platform," an external database contradicts the value proposition |
+| **igraph (python-igraph)** | Faster than NetworkX for large-scale analytics (C core). Less Pythonic API, weaker attribute support on nodes/edges, smaller ecosystem. Would require significant adapter code for rich entity/relationship attribute storage |
+| **graph-tool** | Fastest Python graph library (C++/Boost core). Excellent for analytics but heavy dependency (compiled C++), GPL license, harder to install. Overkill for the scale this project targets |
+| **RDFLib / triple stores** | Native semantic web support, SPARQL queries, ontology reasoning. Wrong data model — we use a property graph (typed nodes with rich attributes and typed, weighted, directional edges), not RDF triples |
+| **Dict-of-dicts adjacency structure** | Zero dependencies, complete control. Too low-level — would require reimplementing shortest_path, centrality, PageRank, BFS, and every graph algorithm from scratch |
+| **SQLAlchemy / relational** | Mature, persistent, ACID. Graph traversal queries are complex and slow in SQL (recursive CTEs, multiple joins). Poor fit for blast radius, centrality, and path analysis |
+
+---
+
+## Rationale
+
+1. **Zero infrastructure** -- `pip install networkx`. No server, no configuration, no connection strings. The graph exists in the Python process
+2. **Rich node/edge attributes** -- Entities are stored as node attributes via `model_dump()`. Relationships are stored as edge attributes with weight, confidence, and typed properties. NetworkX supports arbitrary Python dicts on every node and edge
+3. **Built-in algorithms** -- `nx.shortest_path()`, `nx.degree_centrality()`, `nx.betweenness_centrality()`, `nx.pagerank()`, `nx.density()`, `nx.is_weakly_connected()` are all single function calls. No algorithm reimplementation required
+4. **Pluggable backend** -- The `AbstractGraphEngine` ABC defines 20 abstract methods spanning CRUD, traversal, analytics, bulk operations, and introspection. `GraphEngineFactory` provides `register()` and `auto_discover()`. Swapping to Neo4j means implementing one class, not rewriting the application
+
+---
+
+## Where This Diverges from Best Practice
+
+For a "knowledge graph platform," the conventional choice would be Neo4j, Amazon Neptune, or a similar graph database. We chose an in-memory library instead.
+
+### The Scalability Ceiling
+
+NetworkX stores the entire graph in Python memory. At 20,000 employees (~2,500 entities, ~5,000 relationships), memory usage is tens of megabytes and all operations complete in seconds. This is adequate for the project's stated target range (100-20,000 employees).
+
+It will not scale to millions of nodes. If the project needs to model an organization with 100,000+ employees or ingest production data at enterprise scale, NetworkX is the bottleneck. The `AbstractGraphEngine` abstraction exists specifically for this eventuality — but the second backend has not been built.
+
+### No Persistence
+
+The graph lives in memory. Export to JSON. Re-import from JSON. There is no incremental persistence, no transactions, no crash recovery. The generation pipeline runs in seconds, so regeneration is cheap, but this model does not support a live, evolving graph that persists between sessions.
+
+### Single-Process Model
+
+No concurrent access. The MCP server, REST API, and CLI all assume a single-process model with a single graph instance. This is acceptable for a scenario-analysis tool but would not support multi-user access.
+
+---
+
+## The Pluggable Backend Abstraction
+
+The `AbstractGraphEngine` interface is the insurance policy:
+
+- **20 abstract methods** cover entity CRUD (5), relationship CRUD (4), traversal (3), analytics (4 as `NotImplementedError`), bulk operations (2), and introspection (3)
+- **`blast_radius()`** has a default BFS implementation in the abstract class, overridable for backend-specific optimization
+- **Analytics methods** (`degree_centrality`, `betweenness_centrality`, `pagerank`, `most_connected`) raise `NotImplementedError` in the base class — each backend must provide its own implementation
+- **`GraphEngineFactory.register(name, cls)`** and **`auto_discover()`** provide the registration mechanism
+
+No consumer of the graph (KnowledgeGraph facade, synthetic pipeline, MCP server, REST API, analysis module) imports `NetworkXGraphEngine` directly. Everything goes through `AbstractGraphEngine`. This means a Neo4j backend, when built, requires zero changes to any other module.
+
+---
+
+## Trade-Offs
+
+| Benefit | Cost |
+|---------|------|
+| Zero operational overhead | Cannot scale beyond ~20k employees in memory |
+| Single `pip install` deployment | No persistence between sessions |
+| Built-in graph algorithms | Single-process, no concurrent access |
+| Pluggable backend for future migration | Second backend not yet implemented |
+| Complete control over data model | No native query language (no Cypher, no SPARQL) |
+
+---
+
+## Risks
+
+1. **Backend lock-in despite abstraction** -- The abstraction exists but has only one implementation. Untested abstractions rot. Mitigated by engine contract tests in `tests/unit/engine/test_contract.py`
+2. **Memory pressure at scale** -- Large organizations with many entities may approach memory limits. Mitigated by stress tests validating 20k employees and the performance benchmarking suite
+3. **Algorithm performance** -- `betweenness_centrality` scales super-linearly with graph size. At 5,000+ employees it becomes the slowest operation. Mitigated by recommending `degree_centrality` or `pagerank` for large graphs
+
+---
+
+## Re-Evaluation Triggers
+
+- User demand for persistent, evolving graphs (not regenerated each session)
+- Need to model organizations with 100,000+ employees
+- Multi-user access requirements (concurrent reads/writes)
+- A contributor submits a Neo4j backend implementation
+
+---
+
+## References
+
+- `src/engine/abstract.py` -- `AbstractGraphEngine` (20 abstract methods + 4 analytics + BFS)
+- `src/engine/networkx_engine.py` -- `NetworkXGraphEngine` implementation
+- `src/engine/factory.py` -- `GraphEngineFactory` with registration and auto-discovery
+- [NetworkX Documentation](https://networkx.org/documentation/stable/) -- MultiDiGraph reference

--- a/docs/adr/004-knowledge-graph-facade.md
+++ b/docs/adr/004-knowledge-graph-facade.md
@@ -1,0 +1,106 @@
+# ADR-004: KnowledgeGraph Facade with Event Bus
+
+**Status:** Accepted
+**Date:** 2026-02-21
+**Context:** Application-level graph interface and mutation tracking
+
+---
+
+## Summary
+
+A `KnowledgeGraph` class serves as the single entry point for all graph operations. It wraps the engine backend with an in-process synchronous event bus and a fluent query builder. Every consumer (synthetic pipeline, MCP server, REST API, analysis module) interacts with this facade, never with the engine directly.
+
+---
+
+## Decision
+
+Implement a facade pattern with synchronous event dispatch on every graph mutation.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Assessment |
+|-------------|------------|
+| **Direct engine access** | Callers use `NetworkXGraphEngine` directly. Simpler, fewer layers. No cross-cutting concerns (events, query abstraction). Every consumer must handle engine setup and entity registry initialization independently |
+| **Repository pattern per entity type** | `PersonRepository`, `SystemRepository`, etc. Type-safe but creates 30 repository classes with significant duplication. Fragmented interface — callers must know which repository to use |
+| **CQRS (Command Query Responsibility Segregation)** | Separate read/write models. Appropriate for distributed systems with eventual consistency. Overengineered for a single-process, in-memory graph |
+| **No abstraction** | Use NetworkX `MultiDiGraph` directly throughout the codebase. Eliminates indirection but couples every module to NetworkX and makes backend migration impossible |
+
+---
+
+## What the Facade Provides
+
+### 1. Initialization Coordination
+
+On construction, `KnowledgeGraph` calls `EntityRegistry.auto_discover()` and `GraphEngineFactory.auto_discover()`. This ensures all 30 entity types and the engine backend are registered before any operation. Without the facade, every consumer would need to remember this initialization sequence.
+
+### 2. Synchronous Event Bus
+
+Every mutating operation (CREATE, UPDATE, DELETE, LINK, UNLINK) emits a `GraphEvent` through the `EventBus`:
+
+- `EventBus.subscribe(handler, mutation_type)` -- Register a callback for specific mutations or all mutations (mutation_type=None)
+- `EventBus.emit(event)` -- Synchronous dispatch to all matching handlers
+- `GraphEvent` captures `mutation_type`, `entity_type`, `entity_id`, `relationship_id`, `before_snapshot`, `after_snapshot`
+
+The event log is also stored as an unbounded in-memory list (`_event_log`) for audit trail access.
+
+### 3. Fluent Query Builder
+
+`kg.query()` returns a `QueryBuilder` that chains `.entities()`, `.where()`, `.connected_to()`, `.limit()`, `.offset()`, `.execute()`. This provides a readable API for filtered traversals without requiring callers to understand engine internals.
+
+---
+
+## Where This Diverges from Best Practice
+
+### The Event Bus is Synchronous and In-Process
+
+Modern event-driven architectures use asynchronous message brokers (Kafka, RabbitMQ, Redis Streams) for event dispatch. Our event bus is a `defaultdict(list)` of handler functions called inline during mutation. There is no queue, no retry, no ordering guarantee beyond call order, no persistence.
+
+This is intentional. The graph is in-memory. The process is single-threaded. The consumers are local. An async message broker would add operational complexity without solving a problem that exists at this scale.
+
+The cost: if a handler throws an exception, it propagates into the mutation call. If a handler is slow, it blocks the mutation. If the process crashes, the event log is lost.
+
+### The Event Log is Unbounded
+
+`_event_log` is a `list[GraphEvent]` that grows with every mutation. For a generation run producing ~800 entities and ~1,500 relationships, that is ~2,300 events. At ~500 bytes per event, this is ~1.1 MB — negligible. For an application that performs millions of mutations over time, this would be a memory leak.
+
+The project does not perform millions of mutations. Generation runs once, the graph is used for analysis, and the process exits. But if the graph were used in a long-running service with continuous mutations, the unbounded log would need rotation or persistence.
+
+---
+
+## Trade-Offs
+
+| Benefit | Cost |
+|---------|------|
+| Single initialization point for registry and engine | One layer of indirection on every call |
+| Audit trail on every mutation | Unbounded event log in memory |
+| Subscriber pattern for reactive logic | Synchronous handlers block mutations |
+| Fluent query API | QueryBuilder loads all entities then filters in Python (no query pushdown) |
+| Engine isolation (consumers never import the backend) | Facade must proxy every engine method |
+
+---
+
+## Risks
+
+1. **Event log memory growth** -- Unbounded list grows with mutations. Acceptable for batch generation, problematic for long-running services. Mitigated by the current usage pattern (generate, analyze, exit)
+2. **Handler exceptions** -- A failing subscriber handler crashes the mutation operation. Mitigated by the current absence of error-prone handlers (no subscribers are registered by default)
+3. **Query performance** -- `QueryBuilder.execute()` calls `list_entities()` to load all matching entities, then applies traversal filters in Python. No query pushdown to the engine. Acceptable for sub-20k entity graphs
+
+---
+
+## Re-Evaluation Triggers
+
+- Long-running service usage pattern requiring event log rotation
+- Performance profiling showing facade overhead is significant
+- Need for asynchronous event processing or external subscribers
+- Query patterns requiring engine-level optimization (index-backed filtering)
+
+---
+
+## References
+
+- `src/graph/knowledge_graph.py` -- `KnowledgeGraph` facade
+- `src/graph/events.py` -- `EventBus` with synchronous dispatch
+- `src/engine/query.py` -- `QueryBuilder` fluent API
+- `src/domain/temporal.py` -- `GraphEvent`, `MutationType` definitions

--- a/docs/adr/005-layered-generation-order.md
+++ b/docs/adr/005-layered-generation-order.md
@@ -1,0 +1,113 @@
+# ADR-005: Layered Generation Order for Referential Integrity
+
+**Status:** Accepted
+**Date:** 2026-02-21
+**Context:** Synthetic data generation pipeline ordering strategy
+
+---
+
+## Summary
+
+Synthetic entities are generated in a hardcoded 12-layer dependency order defined by the `GENERATION_ORDER` list in the orchestrator. Each layer can reference entities from previous layers. Relationships are woven in a separate phase after all entities exist. This is a sequential, topological build — not parallel, not declarative, not two-pass.
+
+---
+
+## Decision
+
+Generate entities in a fixed, explicit dependency order. Wire relationships after all entities exist.
+
+---
+
+## The Ordering
+
+```
+L00  Foundation    → Location
+L04  Organization  → Department, Role
+L05  People        → Person
+L02  Technology    → Network, System
+L03  Data          → DataAsset
+L01  Compliance    → Policy, Vulnerability, ThreatActor, Incident
+L01  Governance    → Regulation, Control, Risk, Threat
+L02  Technology    → Integration
+L03  Data          → DataDomain, DataFlow
+L04  Organization  → OrganizationalUnit
+L06  Capabilities  → BusinessCapability
+L07  Locations     → Site, Geography, Jurisdiction
+L08  Products      → ProductPortfolio, Product
+L09  Customers     → MarketSegment, Customer
+L10  Vendors       → Contract
+L11  Initiatives   → Initiative
+```
+
+The orchestrator iterates this list sequentially. Each generator receives a `GenerationContext` containing all previously generated entities.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Assessment |
+|-------------|------------|
+| **Topological sort at runtime** | Generators declare dependencies explicitly; a DAG sort computes the order. More flexible but adds complexity. The dependency graph between 30 types is stable — it has not changed in 15+ releases. Runtime sorting solves a problem that does not exist |
+| **Two-pass generation** | First pass creates all entities without references. Second pass populates cross-references. Avoids ordering entirely but means entities are incomplete after the first pass and generators cannot use inter-entity context during creation |
+| **No ordering (parallel generation)** | Generate all types concurrently, resolve dangling references after. Requires post-hoc validation and repair. Fragile for a domain where a Person's department assignment affects their data sensitivity, which affects the systems they access |
+| **Graph-of-generators with explicit dependency edges** | Each generator registers which entity types it requires. A framework resolves and schedules execution. Framework overhead for a linear pipeline. The current `GENERATION_ORDER` list is 42 lines and immediately readable |
+
+---
+
+## Rationale
+
+1. **Referential integrity by construction** -- L05 People generators reference L04 Department entities that already exist. L10 Contract generators reference L10 Vendor entities. No dangling references, no post-hoc repair
+2. **Context accumulation** -- `GenerationContext.get_entities(EntityType.DEPARTMENT)` returns all departments when the Person generator runs. The generator uses department headcount fractions to distribute people proportionally. This cross-entity reasoning is only possible because departments exist first
+3. **Explicit and auditable** -- Anyone reading `GENERATION_ORDER` sees the full dependency chain in 42 lines. No framework magic, no implicit resolution, no debugging "why did this type generate before that type"
+4. **Relationship weaving as final phase** -- `RelationshipWeaver.weave_all()` runs after all 30 entity types exist. The 33 weaver methods can reference any entity type without ordering constraints
+
+---
+
+## Where This Diverges from Best Practice
+
+### No Parallelism
+
+Types within the same layer (e.g., Site, Geography, Jurisdiction are all L07) could theoretically generate in parallel. The orchestrator does not exploit this. Generation is purely sequential.
+
+At the current scale (100-20,000 employees), the total generation time is 0.3-8.0 seconds. Parallelism would add threading complexity for marginal speedup. If generation time becomes a bottleneck at larger scales, layer-internal parallelism is the first optimization to consider.
+
+### Hardcoded, Not Declarative
+
+The ordering is a Python list, not a configuration file or a declarative dependency graph. Adding a new entity type requires editing `GENERATION_ORDER` in the orchestrator module and placing it in the correct position. There is no validation that the ordering is topologically correct — the correctness depends on the developer placing it correctly.
+
+This is a deliberate trade-off. The ordering has been stable across 20+ releases. The overhead of a declarative dependency framework is not justified by a list that changes once or twice per minor version.
+
+---
+
+## Trade-Offs
+
+| Benefit | Cost |
+|---------|------|
+| Referential integrity guaranteed by construction | No parallelism in generation |
+| Cross-entity reasoning available in generators | New types require careful placement in the ordering |
+| Immediately readable ordering (42 lines) | No runtime validation of ordering correctness |
+| Relationship weaving has full entity access | Sequential execution is slower than theoretical parallel |
+
+---
+
+## Risks
+
+1. **Ordering errors** -- A new entity type placed too early in the list may reference types that do not yet exist. Mitigated by integration tests that run the full pipeline and validate entity/relationship counts
+2. **Circular dependencies** -- The current ontology has no circular dependencies between generation layers. If the ontology evolves to require them (e.g., type A references type B and type B references type A), the linear ordering model breaks. Would require a two-pass approach for those specific types
+
+---
+
+## Re-Evaluation Triggers
+
+- Generation time exceeding 30 seconds at target scales (20k employees)
+- Circular dependency between entity types in the ontology
+- Frequent reordering of `GENERATION_ORDER` indicating the static list is a maintenance burden
+- A contributor proposes a declarative dependency framework with clear benefits over the current approach
+
+---
+
+## References
+
+- `src/synthetic/orchestrator.py` -- `GENERATION_ORDER` list and `SyntheticOrchestrator.generate()`
+- `src/synthetic/base.py` -- `GenerationContext` with `get_entities()` for cross-type access
+- `src/synthetic/relationships.py` -- `RelationshipWeaver.weave_all()` (post-generation phase)

--- a/docs/adr/006-coordinated-template-dicts.md
+++ b/docs/adr/006-coordinated-template-dicts.md
@@ -1,0 +1,126 @@
+# ADR-006: Coordinated Template Dicts over Random Generation
+
+**Status:** Accepted
+**Date:** 2026-02-21
+**Context:** Field-level data generation strategy for entity attributes
+
+---
+
+## Summary
+
+All 30 generators use pre-coordinated template dictionaries where related fields are bundled together (system name, OS, tech stack, and ports are a coherent unit), rather than selecting each field independently from separate random pools. Risk levels are computed deterministically from `RISK_MATRIX[likelihood][impact]`. No generator uses `faker.sentence()` or `faker.bs()` for descriptions.
+
+This produces entities that are structurally accurate rather than statistically plausible.
+
+---
+
+## Decision
+
+Use coordinated template dictionaries for all domain-specific field generation. Reserve Faker for leaf-level atomic values only (names, addresses, dates, IPs).
+
+---
+
+## Alternatives Considered
+
+| Alternative | Assessment |
+|-------------|------------|
+| **Faker for everything** | `faker.sentence()` for descriptions, `faker.bs()` for business context, `faker.company()` for vendor names. Fast to implement, zero domain knowledge. Produces lorem ipsum that is immediately recognizable as fake and carries no analytical value |
+| **Independent random selection per field** | System type from one list, OS from another, tech stack from a third. Fields are uncorrelated. A "Jenkins CI" system with "Windows Server" OS and "SAP HANA" technology stack undermines the structural accuracy claim |
+| **Markov chain / probabilistic models** | Learn field correlations from training data. Produces statistically plausible output. Requires training data that does not exist (we are generating from domain rules, not copying real organizations). Adds ML complexity for a rule-based problem |
+| **Real-world data sampling with anonymization** | Sample from actual organizational data, anonymize PII. Produces the most realistic output. Requires access to real organizational data, raises privacy concerns, and contradicts the project's purpose (generating synthetic models, not anonymizing real ones) |
+
+---
+
+## How Coordinated Templates Work
+
+A system generator template bundles related fields:
+
+```
+"Jenkins CI" → type=application, os=linux, technologies=[java, groovy],
+               ports=[8080], criticality=high
+```
+
+When the generator selects "Jenkins CI," all correlated fields come with it. The system is coherent because the template was designed as a unit by someone who knows what Jenkins is.
+
+This pattern applies across all 30 entity types:
+
+- **Systems** -- Name, type, OS, technologies, ports, criticality are bundled
+- **Risks** -- `RISK_MATRIX[likelihood][impact] → risk_level` is deterministic, not random
+- **Threat actors** -- 12 named profiles with correlated TTPs, motivation, and sophistication
+- **Sites** -- Data centers always have "Restricted" physical security tier
+- **Data flows** -- Restricted/Confidential classification correlates with encryption-in-transit
+- **Vulnerabilities** -- CVSS score correlates with severity, patch availability correlates with status
+
+---
+
+## Where This Diverges from Best Practice
+
+### Finite Variety
+
+Template dictionaries have finite entries. At very large scales (10,000+ entities of a given type), templates repeat. A 5,000-employee org with 400 systems will have system names and configurations that appear multiple times.
+
+This is acceptable because the graph's value is in the structure and relationships, not in the uniqueness of every system name. But it is a known limitation. Faker supplements templates with randomized names, descriptions, and identifiers to add surface-level variety.
+
+### Manual Maintenance
+
+Every coordinated template was hand-written with domain expertise. Adding a new system type means adding a new template entry with correct field correlations. There is no automated way to generate or validate these templates — correctness depends on the author's domain knowledge.
+
+The quality scoring module (`assess_quality()`) partially compensates by checking tech stack coherence, risk math consistency, and encryption-classification alignment. But it only catches categories of errors, not individual template mistakes.
+
+### Opinionated Domain Assumptions
+
+Templates encode assumptions about what constitutes a coherent technology stack, a reasonable risk profile, or a realistic vendor configuration. These assumptions reflect the authors' experience in technology, financial services, and healthcare organizations. They may not match every organization.
+
+The `count_overrides` mechanism does not extend to template content — you can override how many systems are generated, but not which system templates are used.
+
+---
+
+## What Quality Scoring Validates
+
+The quality module (`assess_quality()`) runs five checks that are only meaningful because templates enforce correlations:
+
+1. **Risk math consistency** -- `risk_level == RISK_MATRIX[likelihood][impact]` for every Risk entity
+2. **Description quality** -- No lorem ipsum patterns (regex detection of `faker.sentence()` output)
+3. **Tech stack coherence** -- Appliance-type systems do not have web frameworks
+4. **Field correlations** -- Residual risk ≤ inherent risk. Data center sites have restricted security
+5. **Encryption-classification consistency** -- Restricted/Confidential data flows use encryption in transit
+
+These checks would be meaningless with random generation because there would be no expected correlations to validate.
+
+---
+
+## Trade-Offs
+
+| Benefit | Cost |
+|---------|------|
+| Entities are internally consistent and domain-plausible | Templates require manual authoring and maintenance |
+| Quality scoring can validate structural correctness | Finite variety at large scale |
+| Output is useful for scenario analysis, not just load testing | Adding new entity archetypes requires domain expertise |
+| No lorem ipsum in any field | More code complexity than random selection |
+| Risk math is deterministic and verifiable | Templates encode opinionated domain assumptions |
+
+---
+
+## Risks
+
+1. **Template staleness** -- Technology templates reference specific products (Jenkins, Splunk, SAP HANA). These become dated as products evolve. Mitigated by periodic updates, but no automated detection
+2. **Domain bias** -- Templates reflect the authors' experience in US/UK enterprise environments. Organizations in other regions or industries may find the templates unrealistic. Mitigated partially by the three-profile system (tech, financial, healthcare)
+3. **Correlation gaps** -- Not all field correlations are enforced by templates. Some entities have fields that should correlate but are selected independently. Quality scoring catches some of these, but coverage is incomplete
+
+---
+
+## Re-Evaluation Triggers
+
+- Template variety becomes visibly insufficient at target scales (repeated system names in a single generation)
+- Quality scoring identifies correlation gaps that templates should enforce but do not
+- A new industry profile (e.g., government, manufacturing) requires templates that do not exist
+- LLM-based entity generation becomes viable and can produce domain-coherent entities without hand-authored templates
+
+---
+
+## References
+
+- `src/synthetic/generators/enterprise.py` -- `RISK_MATRIX` and enterprise entity templates
+- `src/synthetic/generators/systems.py` -- System templates with correlated fields
+- `src/synthetic/quality.py` -- `assess_quality()` with five validation checks
+- `docs/adr/001-custom-synthetic-data-pipeline.md` -- Related: why we build our own pipeline

--- a/docs/adr/007-research-backed-scaling.md
+++ b/docs/adr/007-research-backed-scaling.md
@@ -1,0 +1,139 @@
+# ADR-007: Research-Backed Scaling with Industry Coefficients
+
+**Status:** Accepted
+**Date:** 2026-02-21
+**Context:** Entity count scaling model for synthetic organizations
+
+---
+
+## Summary
+
+Entity counts scale with employee count using `ScalingCoefficients` dataclasses per industry, a `scaled_range()` function, and four size-tier multipliers (startup 0.7x, mid-market 1.0x, enterprise 1.2x, large 1.4x). Coefficients are calibrated against Gartner, MuleSoft, NIST, Hackett Group, and McKinsey benchmarks. This is the model that makes a 200-employee tech startup structurally different from a 10,000-employee financial institution.
+
+---
+
+## Decision
+
+Scale entity counts dynamically based on employee count, industry profile, and organizational size tier, using research-calibrated coefficients.
+
+---
+
+## The Scaling Model
+
+### `scaled_range(employee_count, coefficient, floor, ceiling)`
+
+1. Determine the size-tier multiplier: startup (<250) = 0.7x, mid-market (250-2000) = 1.0x, enterprise (2000-10000) = 1.2x, large (10000+) = 1.4x
+2. Compute `base = max(floor, int((employee_count / coefficient) * tier))`
+3. Return `(low, high)` where `low = 0.8 × base` and `high = 1.2 × base`, both clamped to `[floor, ceiling]`
+4. The orchestrator calls `random.randint(low, high)` for natural variance
+
+### Industry Coefficients
+
+`ScalingCoefficients` defines the employees-per-entity ratio for each entity type. Lower coefficient = more entities per employee = denser infrastructure.
+
+Example differentials across industries:
+
+| Entity Type | Technology | Financial Services | Healthcare |
+|-------------|-----------|-------------------|------------|
+| Systems | 1:8 | 1:12 | 1:15 |
+| Controls | 1:50 | 1:20 | 1:25 |
+| Data Assets | 1:15 | 1:10 | 1:5 |
+| Customers | 1:50 | 1:25 | 1:40 |
+| Contracts | 1:15 | 1:8 | 1:12 |
+
+Financial services has 2.5x the controls of tech (regulatory burden). Healthcare has 3x the data assets of tech (patient records, clinical data, imaging).
+
+---
+
+## Alternatives Considered
+
+| Alternative | Assessment |
+|-------------|------------|
+| **Fixed ranges per entity type** | Simple, predictable. A 100-person startup and a 10,000-person enterprise get the same 20-100 systems. This is obviously wrong — organizational infrastructure scales with headcount |
+| **Linear scaling with a single universal ratio** | Every industry, every size tier, same ratio. Ignores the reality that financial services orgs have dramatically more compliance infrastructure than tech startups. The single ratio would be wrong for everyone |
+| **User-specified exact counts for everything** | Maximum flexibility, zero automation. Users must decide how many systems, vendors, controls, etc. an organization should have. Most users do not know the answer. Exists as `count_overrides` escape hatch |
+| **Logarithmic or power-law scaling** | Some entity types may scale sub-linearly (departments do not double when headcount doubles). Currently not modeled — `scaled_range()` is approximately linear with a tier multiplier. A power-law model could be more accurate but adds complexity |
+| **ML from real organizational data** | Train a model on real-world organizational structures. Would produce the most accurate scaling. Requires a training dataset of real organizational models that does not exist and would be highly sensitive data |
+
+---
+
+## Research Basis
+
+The coefficients are calibrated against published research, not invented:
+
+- **Gartner** -- IT spending ratios, system-to-employee benchmarks by industry
+- **MuleSoft** -- Enterprise integration density research
+- **NIST** -- Control framework density per regulatory regime
+- **Hackett Group** -- Shared services and organizational structure benchmarks
+- **McKinsey** -- Operating model research, department sizing
+
+These are directional calibrations, not exact replication. A coefficient of `systems=8` for technology does not mean "every real tech company has exactly 1 system per 8 employees." It means "at this ratio, the generated graph produces a system landscape that is structurally plausible for a tech company of this size."
+
+---
+
+## Where This Diverges from Best Practice
+
+### Coefficients Are Estimates
+
+The research sources provide ranges, not point estimates. The project collapses ranges into single coefficients per industry. A technology company's system density could realistically be anywhere from 1:5 to 1:15. We chose 1:8 and applied a ±20% variance band via `scaled_range()`. The variance is narrower than reality.
+
+### Size-Tier Breakpoints Are Discrete
+
+The four size tiers (250, 2000, 10000) create discontinuities. A 249-employee org gets 0.7x multiplier; a 250-employee org gets 1.0x. In reality, organizational maturity scales continuously. The discrete tiers are a simplification — accurate enough for the project's purpose (scenario analysis, not actuarial modelling) but not smooth.
+
+### Three Profiles for Every Industry
+
+Technology, financial services, and healthcare. Every other industry (government, manufacturing, retail, energy, education) must pick the closest match. This is a known gap. Adding a profile requires authoring a full `ScalingCoefficients` instance with 22 coefficients and a set of `DepartmentSpec` entries, which requires industry-specific domain knowledge.
+
+### The Dynamic Department Subdivision
+
+Departments exceeding 500 headcount subdivide into sub-departments via 30+ industry-specific `SUB_DEPARTMENT_TEMPLATES`. Roles expand with seniority variants (Junior/Senior/Staff). At 14,512 employees (tech profile): 42 departments (was 10), 301 roles (was 35).
+
+The 500-headcount threshold is hardcoded, not configurable per profile. It models a common span-of-control inflection point, but different organizations subdivide at different thresholds. The sub-department templates are industry-specific but may not match every organization's actual hierarchy.
+
+---
+
+## The Count Override Escape Hatch
+
+`count_overrides` bypasses scaling entirely: `SyntheticOrchestrator(kg, profile, count_overrides={"system": 500})` pins systems at exactly 500 regardless of employee count or profile. The CLI exposes 25 flags (`--systems 500 --vendors 100`).
+
+Five entity types are excluded from overrides because they are derived: department (from `DepartmentSpec`), role (from departments), network (from `NetworkSpec`), vulnerability (from system count × probability), and person (from `employee_count`).
+
+---
+
+## Trade-Offs
+
+| Benefit | Cost |
+|---------|------|
+| Structurally different graphs per industry and scale | Coefficients are estimates, not measurements |
+| Research-backed credibility | Only three industry profiles |
+| Natural variance via randomized range | Discrete size-tier breakpoints create discontinuities |
+| Count overrides as escape hatch | Five entity types cannot be overridden |
+| Dynamic dept/role expansion at scale | 500-headcount subdivision threshold is hardcoded |
+
+---
+
+## Risks
+
+1. **Coefficient drift** -- Industry benchmarks evolve. Coefficients calibrated to 2024-era research may not reflect 2028-era organizational structures. Mitigated by periodic recalibration, but no automated detection
+2. **Edge case math** -- At large employee counts, `low` can exceed `ceiling` in `scaled_range()`. This is a documented bug pattern, mitigated by explicit clamping: `low = min(ceiling - 1, max(floor, ...))`
+3. **Profile gap** -- Organizations in industries without a profile (government, manufacturing) get a best-guess approximation. No way to know how wrong it is without domain-specific validation
+
+---
+
+## Re-Evaluation Triggers
+
+- New industry benchmark data that significantly changes known ratios
+- User reports that generated graphs are structurally implausible for their organization size/industry
+- Demand for additional industry profiles (government, manufacturing, retail)
+- Evidence that continuous scaling (power-law) would produce meaningfully better graphs than the current tier model
+
+---
+
+## References
+
+- `src/synthetic/profiles/base_profile.py` -- `ScalingCoefficients`, `INDUSTRY_COEFFICIENTS`, `scaled_range()`, `_size_tier_multiplier()`
+- `src/synthetic/profiles/tech_company.py` -- Technology profile
+- `src/synthetic/profiles/financial_org.py` -- Financial services profile
+- `src/synthetic/profiles/healthcare_org.py` -- Healthcare profile
+- `docs/profiles.md` -- User-facing profile documentation

--- a/docs/adr/008-relationship-weaving.md
+++ b/docs/adr/008-relationship-weaving.md
@@ -1,0 +1,141 @@
+# ADR-008: Relationship Weaving as Post-Generation Phase
+
+**Status:** Accepted
+**Date:** 2026-02-21
+**Context:** Relationship creation strategy in the synthetic pipeline
+
+---
+
+## Summary
+
+Relationships are created in a separate `RelationshipWeaver` phase after all 30 entity types have been generated, not inline during entity generation. The weaver contains 33 methods producing 52 relationship types with contextual weight, confidence scores, and typed properties. Mirror fields on entities are populated from woven relationships as a final step.
+
+---
+
+## Decision
+
+Separate relationship creation from entity generation. All relationships are woven in a single phase after all entities exist.
+
+---
+
+## The Two-Phase Architecture
+
+```
+Phase 1: Entity Generation (sequential, 30 types in GENERATION_ORDER)
+    → Each generator produces entities for one type
+    → Entities are added to the KnowledgeGraph via add_entities_bulk()
+    → GenerationContext accumulates all entities for cross-type access
+
+Phase 2: Relationship Weaving (single pass, 33 methods)
+    → RelationshipWeaver.weave_all() runs after all entities exist
+    → 33 weaver methods produce relationships across all type pairs
+    → _make_rel() enforces consistent metadata on every relationship
+    → _populate_mirror_fields() denormalizes key relationships onto entities
+    → All relationships added via add_relationships_bulk()
+```
+
+---
+
+## Alternatives Considered
+
+| Alternative | Assessment |
+|-------------|------------|
+| **Generators create their own relationships** | Each generator emits entities AND relationships. PersonGenerator creates `WORKS_IN` relationships when creating people. Rejected because cross-layer relationships (Control → Regulation, Initiative → System) would require generators to reach into other generators' output, creating tight coupling. The 33 weaver methods would fragment across 30 generator files |
+| **Declarative relationship rules** | Relationships auto-generated from type-matching rules ("every Person gets a WORKS_IN to a Department"). Too rigid for the contextual logic needed (headcount-proportional assignment, severity-based weights, type-filtered hosting) |
+| **Interleaved generation** | Generate Layer 1 entities, then Layer 1 relationships, then Layer 2 entities, then Layer 2 relationships. Avoids holding all entities in memory simultaneously. But cross-layer relationships (L11 Initiative → L02 System) would require backfilling, making this effectively a multi-pass approach with more complexity |
+| **Two-pass entity generation** | First pass creates all entities without references. Second pass populates cross-references on entities. Does not address relationships — only entity-to-entity field references. Still needs a relationship phase |
+
+---
+
+## What the Weaver Provides
+
+### Contextual Relationship Metadata
+
+Every relationship carries `weight`, `confidence`, and `properties` — not just source/target/type:
+
+- **`_make_rel()`** enforces `round(weight, 2)` and `round(confidence, 2)` on every relationship
+- **`SEVERITY_WEIGHT`** maps severity levels to edge weights: low=0.3, medium=0.5, high=0.8, critical=1.0
+- **Confidence values** are semantically grounded: 0.95 for organizational facts (person works in department), 0.70 for uncertain attribution (threat actor exploits vulnerability)
+- **Properties** carry typed context: `dependency_type` (runtime/build/data/authentication/monitoring), `exploit_maturity` (weaponized/proof_of_concept/theoretical), `supply_type` (license/service/hardware/subscription/support)
+
+### Domain Logic in the Weaver Methods
+
+The 33 methods encode organizational structure logic:
+
+- **`_assign_people_to_departments()`** -- Distributes people proportionally based on department headcount fractions. Not random — a department with 30% headcount fraction gets ~30% of people
+- **`_create_management_chains()`** -- Creates `MANAGES` and `REPORTS_TO` relationships reflecting organizational hierarchy
+- **`_assign_systems_hosting()`** -- Infrastructure systems `HOSTS` application systems. Type-filtered: only infrastructure can host
+- **`_link_controls_to_regulations()`** -- Controls `IMPLEMENTS` regulations with enforcement metadata
+- **`_link_risks_to_controls()`** -- Controls `MITIGATES` risks with effectiveness metadata
+
+### Mirror Field Denormalization
+
+`_populate_mirror_fields()` runs after all relationships are woven and sets convenience fields on entities:
+
+- `Person.holds_roles` -- List of role IDs from `HAS_ROLE` relationships
+- `Role.filled_by_persons` -- List of person IDs (inverse)
+- `Role.headcount_filled` -- Count of people holding this role
+- `Person.located_at` -- Location ID from `LOCATED_AT` relationship
+- `Person.participates_in_initiatives` -- Initiative IDs from `MEMBER_OF` relationships
+
+These mirror fields enable O(1) access to common traversals in exported JSON without requiring the graph engine.
+
+---
+
+## Where This Diverges from Best Practice
+
+### All-or-Nothing Weaving
+
+`weave_all()` creates every relationship type in one call. There is no way to weave a subset of relationship types or re-weave a single type after modification. If you want to regenerate only vendor relationships, you must re-run the entire weaver.
+
+### No Relationship Validation During Weaving
+
+The `RELATIONSHIP_SCHEMA` dict in `src/domain/relationship_schema.py` defines valid source/target types for each relationship type. The weaver does not call `validate_relationship()` during generation. It relies on each weaver method being correctly implemented. Validation is available for external consumers but is not enforced internally.
+
+This is a deliberate trade-off: the weaver methods are tested, and adding validation on every relationship creation would slow generation. But it means a bug in a weaver method can produce relationships that violate the schema without detection at generation time.
+
+### Mirror Fields via `extra="allow"`
+
+Mirror fields like `Person.holds_roles` are not declared on the `Person` model. They land in `__pydantic_extra__` via the `extra="allow"` config (ADR-002). This means they are not type-checked, not documented in the schema, and discoverable only by reading the weaver code or the exported JSON.
+
+### In-Place Entity Mutation
+
+`_populate_mirror_fields()` modifies entity objects that already exist in the knowledge graph by setting attributes directly. This is a side effect that happens after `add_entities_bulk()` has already stored the entities. The mirror fields exist on the Python objects in the `GenerationContext` and in the exported JSON, but not necessarily on the entity as stored in the engine (which stores a snapshot at `add_entity()` time).
+
+---
+
+## Trade-Offs
+
+| Benefit | Cost |
+|---------|------|
+| All entities available when weaving — no ordering constraints within relationships | Must hold all entities in memory simultaneously |
+| 33 methods centralized in one file — auditable relationship topology | Adding a new entity type may require modifying multiple weaver methods |
+| Consistent metadata via `_make_rel()` | No schema validation during weaving |
+| Mirror fields for O(1) access in exported JSON | Mirror fields are undeclared extras, not schema-enforced |
+| Proportional, type-filtered, context-aware relationship logic | All-or-nothing weaving, no incremental updates |
+
+---
+
+## Risks
+
+1. **Weaver method bugs** -- A method creating `DEPENDS_ON` between two wrong entity types would produce invalid relationships undetected. Mitigated by integration tests that validate relationship type distributions
+2. **Mirror field staleness** -- If relationships are modified after `_populate_mirror_fields()` runs, mirror fields become stale. Currently not an issue because the pipeline is generate-once, but would be a problem in a mutable graph
+3. **Memory footprint** -- All entities from all 30 types are held in `GenerationContext` during weaving. At 20k employees this is tens of megabytes — acceptable but worth monitoring
+
+---
+
+## Re-Evaluation Triggers
+
+- Need for incremental relationship re-weaving (modify vendors without re-weaving everything)
+- Mirror field inconsistencies discovered in exported graphs
+- Weaver method count exceeding 50, suggesting the single-file approach needs decomposition
+- A mutable graph use case where mirror fields must stay synchronized with relationship changes
+
+---
+
+## References
+
+- `src/synthetic/relationships.py` -- `RelationshipWeaver` with 33 methods, `_make_rel()`, `_populate_mirror_fields()`
+- `src/synthetic/orchestrator.py` -- Two-phase pipeline: `generate()` then `weave_all()`
+- `src/domain/relationship_schema.py` -- `RELATIONSHIP_SCHEMA` (not enforced during weaving)
+- `docs/adr/005-layered-generation-order.md` -- Related: why entity generation is ordered

--- a/docs/adr/009-mcp-mtime-auto-reload.md
+++ b/docs/adr/009-mcp-mtime-auto-reload.md
@@ -1,0 +1,116 @@
+# ADR-009: MCP Server with mtime-Based Auto-Reload
+
+**Status:** Accepted
+**Date:** 2026-02-21
+**Context:** MCP server state management and graph file change detection
+
+---
+
+## Summary
+
+The MCP server uses a module-level singleton `KnowledgeGraph` instance with file modification time (mtime) polling on every tool call to detect when graph.json changes on disk. After `hckg demo --clean`, the next Claude Desktop tool call automatically picks up the new graph without server restart or manual reload.
+
+Zero dependencies. Zero threads. One `os.path.getmtime()` call per tool invocation.
+
+---
+
+## Decision
+
+Poll file mtime on every tool call. Reload the graph if the file has changed since last load.
+
+---
+
+## How It Works
+
+```
+_kg: KnowledgeGraph | None = None    # Module-level singleton
+_loaded_path: str | None = None       # Last loaded file path
+_loaded_mtime: float = 0.0            # Last known modification time
+
+require_graph() → KnowledgeGraph:
+    1. Call _maybe_reload()
+    2. _maybe_reload() checks os.path.getmtime(_loaded_path)
+    3. If mtime differs from _loaded_mtime, re-ingest the file
+    4. Return _kg (newly loaded or existing)
+```
+
+Every MCP tool calls `require_graph()` before accessing the graph. The mtime check adds microseconds — one `stat()` syscall.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Assessment |
+|-------------|------------|
+| **File system watcher (watchdog, inotify)** | Background thread monitors file changes, triggers reload. Requires the `watchdog` dependency or platform-specific `inotify`/`FSEvents`. Adds threading complexity (the MCP stdio transport is single-threaded). A daemon thread for a file that changes once per session |
+| **Manual reload** | User must call `load_graph` tool in Claude Desktop after every `hckg demo --clean`. Friction for the most common workflow. Users will forget, get stale data, and file bugs |
+| **Timer-based polling** | Check mtime every N seconds on a background timer. Uses CPU when idle. Still requires threading. Adds latency between file change and detection. The per-call check is both simpler and more responsive |
+| **Database backend with live queries** | No file to watch — queries hit a live database. Requires a running database (contradicts the zero-infrastructure decision in ADR-003). Adds operational complexity for a solved problem |
+| **IPC signal from CLI to server** | `hckg demo` sends a signal (Unix socket, named pipe) to the MCP server when generation completes. Requires inter-process communication infrastructure. Platform-specific. Tight coupling between CLI and server |
+
+---
+
+## Rationale
+
+1. **Zero dependencies** -- `os.path.getmtime()` is stdlib. No watchdog, no threading, no platform-specific file watching
+2. **Zero threads** -- The MCP stdio transport is single-threaded by design. Adding a watcher thread introduces concurrency concerns (thread safety of module-level globals, GIL contention) for no benefit
+3. **Responsive** -- The reload happens on the next tool call after the file changes. For the Claude Desktop workflow (regenerate graph, then query it), the very first query after regeneration gets the new data
+4. **Microsecond cost** -- One `stat()` syscall per tool call. On modern filesystems this is <1μs. Negligible compared to the graph query itself
+
+---
+
+## Where This Diverges from Best Practice
+
+### Module-Level Globals
+
+`_kg`, `_loaded_path`, and `_loaded_mtime` are module-level mutable state. In a multi-threaded or multi-process context, this is unsafe — two concurrent tool calls could race on `_maybe_reload()`, both detecting a changed mtime, both triggering a reload, and one getting a partially loaded graph.
+
+This is acceptable because the MCP stdio transport is single-threaded. Tool calls are sequential, not concurrent. But the code is not thread-safe by design, and adapting it to a multi-connection transport would require locks or a different state management pattern.
+
+### No File Locking
+
+If a tool call arrives while `hckg demo --clean` is writing graph.json, the server may load a partial file. The `JSONIngestor` would either parse incomplete JSON (and fail with an error dict) or parse a complete but outdated version (if the OS buffer has not flushed).
+
+In practice, graph generation completes in under 8 seconds and writes atomically via `Path.write_text()`. The window for this race is small. But there is no file locking, no write-then-rename atomic swap, and no retry logic.
+
+### No Proactive Notification
+
+The server cannot tell Claude Desktop "new data is available." It waits passively for the next tool call. If a user regenerates the graph but does not make another query, the old data persists silently. This is a pull model, not push.
+
+For the Claude Desktop workflow this is fine — users regenerate because they intend to query. For a hypothetical multi-client scenario, proactive notification would be necessary.
+
+---
+
+## Trade-Offs
+
+| Benefit | Cost |
+|---------|------|
+| Zero dependencies, zero threads | Module-level globals are not thread-safe |
+| Microsecond detection cost | No file locking during reload |
+| Transparent to the user — just works | No proactive notification to clients |
+| Simpler than every alternative considered | Race condition window during file write |
+
+---
+
+## Risks
+
+1. **Partial file load** -- If reload happens during file write, the graph may be corrupt. Mitigated by the small write window and `JSONIngestor` error handling
+2. **State management** -- Module-level globals are the simplest possible state management. Any evolution toward multi-connection support requires rethinking this. Mitigated by the single-threaded MCP transport assumption
+3. **Silent stale data** -- If `os.path.getmtime()` fails (file deleted, permission error), `_maybe_reload()` silently returns. The server continues with the old graph without alerting the user
+
+---
+
+## Re-Evaluation Triggers
+
+- MCP transport changes to support concurrent connections
+- Users report stale data after graph regeneration (race condition evidence)
+- Need for proactive push notification to Claude Desktop
+- File write atomicity becomes a reliability issue
+
+---
+
+## References
+
+- `src/mcp_server/state.py` -- `_maybe_reload()`, `require_graph()`, module-level globals
+- `src/mcp_server/server.py` -- MCP tool registrations calling `require_graph()`
+- `docs/adr/003-networkx-multidigraph.md` -- Related: zero-infrastructure backend choice

--- a/docs/adr/010-compact-entity-serialization.md
+++ b/docs/adr/010-compact-entity-serialization.md
@@ -1,0 +1,116 @@
+# ADR-010: Compact Entity Serialization for LLM Context Windows
+
+**Status:** Accepted
+**Date:** 2026-02-21
+**Context:** Response formatting for MCP and REST API consumers
+
+---
+
+## Summary
+
+MCP and REST API responses use a `compact_entity()` function that strips `None`, empty strings, empty lists, and internal temporal/metadata fields from entity dicts before returning them. This reduces response size for LLM context window efficiency. The same approach is applied to relationships via `compact_relationship()`.
+
+This is a lossy serialization — information is deliberately discarded to optimize for the primary consumer (language models with token budgets).
+
+---
+
+## Decision
+
+Strip empty values and internal fields from all API responses. Optimize for LLM token efficiency over information completeness.
+
+---
+
+## What Gets Stripped
+
+**Null/empty fields:**
+- `None` values
+- Empty strings (`""`)
+- Empty lists (`[]`)
+- Empty dicts (`{}`) (relationships only)
+
+**Internal temporal fields:**
+- `created_at`
+- `updated_at`
+- `valid_from`
+- `valid_until`
+- `version`
+
+**Internal metadata:**
+- `metadata` dict (which may contain `_confidence`, `_source` from auto-extraction)
+
+---
+
+## Alternatives Considered
+
+| Alternative | Assessment |
+|-------------|------------|
+| **Full `model_dump()` output** | Return every field on every entity, including nulls, empty lists, and timestamps. For a System entity with 40+ fields, roughly half are None or empty. Full output doubles token cost for zero analytical value. LLMs process tokens linearly — padding with empty fields reduces the useful-content-to-context-window ratio |
+| **Custom DTOs per entity type** | Type-specific response schemas for each of the 30 entity types. Maximum control over what each type returns. 30 DTO classes to maintain in parallel with 30 entity classes. Schema drift between entities and DTOs is guaranteed |
+| **GraphQL-style field selection** | Caller specifies which fields to return. Maximum flexibility, no wasted tokens. Requires a query language, schema introspection, and field-level access control. Overengineered for the current consumer set (Claude Desktop, REST clients) |
+| **Binary/protobuf serialization** | Minimal wire size, type-safe deserialization. LLMs consume text, not binary. MCP protocol is JSON-based. Binary is not an option for the primary consumer |
+
+---
+
+## Rationale
+
+1. **Token efficiency** -- A raw `model_dump()` of a System entity is ~2,000 characters. After compact serialization, it is ~800 characters. For a `list_entities` call returning 50 systems, that is 60,000 characters saved — roughly 15,000 tokens
+2. **Signal-to-noise ratio** -- LLMs perform better when context contains relevant information, not padding. `created_at: "2026-02-21T14:30:00Z"` on every entity adds nothing to analytical queries like "which systems have critical vulnerabilities"
+3. **Uniform application** -- One `compact_entity()` function handles all 30 entity types. One `compact_relationship()` handles all relationship types. No per-type logic required
+
+---
+
+## Where This Diverges from Best Practice
+
+### Information Loss Is Deliberate
+
+This is a lossy serialization. The `metadata` dict may contain provenance information (`_confidence`, `_source`) from the auto-KG pipeline. Stripping it means API consumers cannot see where auto-extracted entities came from or how confident the extraction was.
+
+Temporal fields (`created_at`, `version`) carry audit trail information. Stripping them means consumers cannot track when entities were created or how many times they have been modified.
+
+This is a conscious trade-off: the primary consumer (Claude Desktop via MCP) does not need provenance or temporal data for scenario analysis. If a consumer needs full fidelity, they should use the JSON export directly, not the API.
+
+### No Opt-In for Full Detail
+
+There is no `compact=false` parameter. Every API response is always compact. A consumer that needs temporal metadata, provenance information, or the `metadata` dict has no way to request it through the API.
+
+This is a simplicity trade-off. Adding a verbosity parameter means testing two output paths, documenting two modes, and handling edge cases where one consumer expects compact and another expects full. The JSON export file contains full-fidelity data for consumers that need it.
+
+### Duplicated Implementation
+
+`compact_entity()` exists in both `mcp_server/helpers.py` and `serve/app.py` with identical logic but separate implementations. A change to the skip list must be made in both places. This is a known DRY violation.
+
+---
+
+## Trade-Offs
+
+| Benefit | Cost |
+|---------|------|
+| ~60% reduction in response size | Provenance and temporal information lost |
+| Better LLM analytical performance | No opt-in for full detail |
+| Single function handles all 30 entity types | Duplicated across MCP and REST modules |
+| Cleaner output for human readers too | Consumers cannot distinguish "field is empty" from "field was stripped" |
+
+---
+
+## Risks
+
+1. **Lost provenance** -- Auto-extracted entities lose their `_confidence` and `_source` metadata. If an LLM-based consumer needs to reason about extraction confidence, this information is unavailable through the API
+2. **Duplication drift** -- The two `compact_entity()` implementations may diverge over time. Mitigated by extracting to a shared utility (currently not done)
+3. **Assumption about consumers** -- The optimization assumes LLMs are the primary consumer. If the REST API gains non-LLM consumers (dashboards, integrations), the stripped fields may be needed
+
+---
+
+## Re-Evaluation Triggers
+
+- A consumer needs temporal or provenance data through the API (not via JSON export)
+- The duplication between MCP and REST causes a bug (different skip lists)
+- Response size optimization becomes less critical (larger context windows, cheaper tokens)
+- Non-LLM consumers of the REST API need full-fidelity responses
+
+---
+
+## References
+
+- `src/mcp_server/helpers.py` -- `compact_entity()`, `compact_relationship()`
+- `src/serve/app.py` -- `_compact_entity()`, `_compact_relationship()` (duplicate)
+- `src/export/json_export.py` -- Full-fidelity export (no stripping)

--- a/docs/adr/011-rapidfuzz-search.md
+++ b/docs/adr/011-rapidfuzz-search.md
@@ -1,0 +1,119 @@
+# ADR-011: rapidfuzz over Embedding-Based Search
+
+**Status:** Accepted
+**Date:** 2026-02-21
+**Context:** Entity search strategy across MCP, REST, and RAG pipelines
+
+---
+
+## Summary
+
+Entity search uses rapidfuzz's `WRatio` scorer for fuzzy string matching against entity names. The same approach is used in the MCP server, REST API, and RAG retrieval pipeline. No embeddings, no vector database, no external API calls. Search completes in sub-millisecond time with zero infrastructure.
+
+This prioritizes simplicity and zero-dependency operation over semantic understanding.
+
+---
+
+## Decision
+
+Use rapidfuzz fuzzy string matching for all entity search. Do not use embedding-based semantic search.
+
+---
+
+## How It Works
+
+```python
+# GraphSearch.search_by_name()
+matches = process.extract(
+    query,                    # User's search string
+    names,                    # All entity names in the graph
+    scorer=fuzz.WRatio,       # Weighted ratio scorer
+    limit=top_k,              # Max results
+)
+# Filter results below 50.0 score threshold
+```
+
+`WRatio` (Weighted Ratio) combines multiple string similarity algorithms (ratio, partial ratio, token sort ratio, token set ratio) and returns the best score. It handles partial matches, out-of-order tokens, and abbreviations.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Assessment |
+|-------------|------------|
+| **OpenAI/Sentence-Transformers embeddings with vector similarity** | Semantic understanding: "authentication system" finds "SSO Gateway." Requires embedding model (local or API), vector store (FAISS/Chroma), embedding computation on graph load, and either an API key or a multi-GB model download. Adds seconds of latency per search and a significant dependency chain. For a graph with <5,000 entities, the complexity is not justified |
+| **Elasticsearch / OpenSearch** | Full-text search with BM25 ranking, fuzzy matching, analyzers. Requires a running search server (Java, Docker). Contradicts the zero-infrastructure positioning. Would be appropriate for 100,000+ entity graphs |
+| **SQLite FTS5** | Embedded full-text search. No external server. Good for structured text search. Requires building and maintaining an FTS index alongside the graph. Adds a second data store. The graph already supports linear scan in sub-millisecond time |
+| **Simple substring matching** | `if query.lower() in entity.name.lower()`. Simplest possible approach. No fuzzy matching — "Jenkin" would not find "Jenkins CI." Too brittle for real-world queries |
+| **No search (ID-based lookups only)** | Force users to know entity IDs. Unusable for exploratory analysis, which is the primary use case |
+
+---
+
+## Rationale
+
+1. **Zero infrastructure** -- rapidfuzz is a compiled Python/C library. `pip install rapidfuzz`. No server, no API key, no model download, no vector store
+2. **Sub-millisecond execution** -- Linear scan of all entity names with `WRatio` scoring completes in <1ms for graphs with <5,000 entities. The computation is CPU-bound string comparison, not network I/O
+3. **Consistent implementation** -- The same `GraphSearch.search_by_name()` method is used in MCP tools (`search_entities`), REST API (`handle_search`), and RAG retrieval (`GraphRAGRetriever`). One implementation, one behavior
+4. **Good-enough matching** -- `WRatio` handles the common search patterns: partial names ("Jenkins" matches "Jenkins CI"), out-of-order tokens ("CI Jenkins" matches "Jenkins CI"), abbreviations, and typos
+
+---
+
+## Where This Diverges from Best Practice
+
+### No Semantic Understanding
+
+Fuzzy string matching operates on character sequences, not meaning. Searching "authentication system" will not find "SSO Gateway" because the strings share zero characters. Searching "vulnerable servers" will not find "Compromised Production Web Server" unless the query happens to contain overlapping substrings.
+
+For the synthetic knowledge graph, this limitation is partially mitigated by the coordinated template system (ADR-006): entity names are descriptive and domain-specific ("Jenkins CI Server," "PCI DSS Compliance," "Customer Data Lake"), so keyword-based queries produce reasonable results. For a graph with cryptic entity names, fuzzy matching would be significantly less useful.
+
+### Linear Scan, No Index
+
+Every search scans all entity names in the graph. At 5,000 entities, this is sub-millisecond. At 500,000 entities, it would be seconds. There is no inverted index, no pre-computed similarity matrix, no spatial data structure for approximate nearest neighbors.
+
+The project's target range (100-20,000 employees, producing <5,000 entities) makes this acceptable. Scaling beyond that range would require an index.
+
+### Fixed Score Threshold
+
+The 50.0 score threshold is hardcoded. It filters noise but may exclude valid low-confidence matches for short entity names. "HR" searching against "Human Resources Department" scores lower than "Jenkins CI" searching against "Jenkins." The threshold is not tunable by the caller.
+
+### No Query Understanding
+
+The search has no concept of query intent. "What systems are vulnerable?" is treated as a name search for entities containing those words. The RAG pipeline adds keyword extraction and entity type detection on top, but the core search is pure string matching.
+
+---
+
+## Trade-Offs
+
+| Benefit | Cost |
+|---------|------|
+| Zero infrastructure, sub-millisecond | No semantic understanding |
+| One implementation across MCP, REST, RAG | Linear scan, no index |
+| Handles typos, partial matches, token reordering | Fixed score threshold, not tunable |
+| No external API calls or model dependencies | Cannot find conceptually related but differently named entities |
+| Deterministic — same query always returns same results | No learning or personalization |
+
+---
+
+## Risks
+
+1. **False positives for short names** -- `WRatio` can produce high scores for very short entity names that coincidentally match query substrings. Mitigated by the 50.0 threshold, but short names (2-3 characters) remain noisy
+2. **Entity name dependency** -- Search quality depends entirely on entity names being descriptive. Cryptic names (codes, abbreviations, internal identifiers) produce poor search results. Mitigated by the coordinated template system generating descriptive names
+3. **Scale ceiling** -- Linear scan breaks down at 100,000+ entities. Currently well within safe range, but the project has no index-based fallback
+
+---
+
+## Re-Evaluation Triggers
+
+- Graph sizes exceeding 50,000 entities where linear scan latency becomes noticeable
+- User reports of search failing to find conceptually related entities (semantic gap)
+- Embedding models becoming lightweight enough (<100MB, sub-100ms inference) to justify as a dependency
+- A requirement for similarity-based entity recommendation (not just name search)
+
+---
+
+## References
+
+- `src/rag/search.py` -- `GraphSearch` with `search_by_name()`, `search_by_type()`, `search_by_attribute()`
+- `src/mcp_server/tools.py` -- `search_entities` tool using fuzzy matching
+- `src/serve/app.py` -- REST API search endpoint
+- [rapidfuzz Documentation](https://rapidfuzz.github.io/RapidFuzz/) -- `WRatio` scorer reference

--- a/docs/adr/012-json-primary-export.md
+++ b/docs/adr/012-json-primary-export.md
@@ -1,0 +1,141 @@
+# ADR-012: JSON as Primary Export Format
+
+**Status:** Accepted
+**Date:** 2026-02-21
+**Context:** Graph export and interchange format selection
+
+---
+
+## Summary
+
+The primary export format is a flat JSON file with `{"entities": [...], "relationships": [...], "statistics": {...}}`. GraphML is supported as a secondary format for graph visualization tools (Gephi, yEd). No other export formats are implemented.
+
+This choice optimizes for human readability, universal parseability, and round-trip fidelity with Pydantic models. It explicitly does not optimize for graph database import, semantic web interchange, or large-scale data processing.
+
+---
+
+## Decision
+
+Use flat JSON as the primary export and interchange format. Support GraphML as a secondary format for visualization.
+
+---
+
+## The JSON Structure
+
+```json
+{
+  "entities": [
+    {
+      "id": "uuid",
+      "entity_type": "system",
+      "name": "Jenkins CI",
+      "description": "Continuous integration server",
+      "system_type": "application",
+      "technologies": ["java", "groovy"],
+      ...
+    }
+  ],
+  "relationships": [
+    {
+      "id": "uuid",
+      "relationship_type": "depends_on",
+      "source_id": "uuid",
+      "target_id": "uuid",
+      "weight": 0.85,
+      "confidence": 0.92,
+      "properties": {"dependency_type": "runtime"}
+    }
+  ],
+  "statistics": {
+    "entity_count": 277,
+    "relationship_count": 543,
+    ...
+  }
+}
+```
+
+Entities and relationships are stored as Pydantic `model_dump(mode="json")` output. The format round-trips perfectly: export via `JSONExporter`, re-import via `JSONIngestor`, `model_validate()` reconstructs the original Pydantic objects.
+
+---
+
+## Alternatives Considered
+
+| Alternative | Assessment |
+|-------------|------------|
+| **Neo4j CSV import format** | `nodes.csv` + `relationships.csv` with Neo4j-specific headers. Couples the export to a specific database. Complex attributes (lists, nested dicts) require custom encoding. The project does not assume Neo4j as the target |
+| **RDF / Turtle / N-Triples** | Native semantic web interchange. Triple-based model (subject-predicate-object) is fundamentally different from the project's property graph model (typed nodes with rich attributes, typed edges with weight/confidence/properties). Converting to RDF would lose the property graph semantics or require reification |
+| **JSON-LD** | JSON format with linked data semantics. Adds `@context`, `@id`, `@type` overhead. Designed for web-scale data linking, not local graph interchange. The project does not participate in the linked data ecosystem |
+| **Pickle / binary serialization** | Fastest serialization, smallest file size. Not human-readable, not portable across Python versions, security risk on deserialization (arbitrary code execution). Unacceptable for a format that users inspect and share |
+| **SQLite database file** | Persistent, queryable, single-file. Adds SQLite dependency for consumers. Not human-readable. Overkill for a read-once export that gets loaded into memory |
+| **Parquet / Arrow columnar format** | Excellent for large-scale data processing. Not human-readable. Designed for tabular data, not graph data with variable-schema entities. Complex attributes require encoding |
+
+---
+
+## Why GraphML as Secondary
+
+GraphML is an XML-based graph format supported natively by NetworkX (`nx.write_graphml()`), Gephi, yEd, Cytoscape, and other graph visualization tools. It is the simplest path from "generated graph" to "visual exploration."
+
+GraphML limitations are accepted:
+- Complex attributes (lists, dicts, booleans, None) are converted to strings. Type fidelity is lost
+- The exported GraphML cannot be re-imported to reconstruct Pydantic entities. It is a one-way format for visualization
+- XML verbose compared to JSON
+
+---
+
+## Where This Diverges from Best Practice
+
+### No Graph Database Export
+
+The most common request for a "knowledge graph platform" would be export to Neo4j, Amazon Neptune, or TigerGraph. The project does not support any graph database import format. Users who want to load the graph into Neo4j must write their own importer.
+
+This is deliberate. The project positions itself as a pre-engagement analysis tool, not a production data platform. The graph is consumed in-memory via MCP, REST API, or Python API. If users need persistent graph database storage, they are past the "scenario analysis" stage and into production data management.
+
+### No Incremental Export
+
+The entire graph is exported every time. There is no diff-based export, no changelog export, no streaming export. A change to one entity requires re-exporting the complete graph.
+
+For generation-and-analysis workflows (generate graph, export, analyze, regenerate), this is acceptable. For an evolving graph with continuous mutations, incremental export would be necessary.
+
+### File Size at Scale
+
+A 5,000-employee graph with ~1,500 entities and ~3,000 relationships produces a ~5 MB JSON file. A 20,000-employee graph approaches 20 MB. JSON is verbose — every field name is repeated for every entity.
+
+This is within acceptable limits for the project's purpose. The file is generated once, loaded once, and discarded when a new graph is generated. It is not a streaming data format or a wire protocol.
+
+---
+
+## Trade-Offs
+
+| Benefit | Cost |
+|---------|------|
+| Human-readable, inspectable in any text editor | Verbose — field names repeated per entity |
+| Universal parseability (every language has a JSON parser) | No graph database import support |
+| Perfect round-trip with Pydantic `model_dump()` / `model_validate()` | No incremental export |
+| Git-friendly (text diffs show exactly what changed) | Multi-megabyte files at scale |
+| GraphML secondary for visualization tools | GraphML loses type fidelity (everything becomes strings) |
+
+---
+
+## Risks
+
+1. **User expectation mismatch** -- Users expecting Neo4j/Neptune import support will be disappointed. Mitigated by clear documentation of what the project is (scenario analysis tool, not ETL pipeline)
+2. **File size growth** -- At 50,000+ entities, JSON files become unwieldy. Mitigated by the current scale ceiling (~20,000 employees, ~5,000 entities)
+3. **GraphML fidelity loss** -- Users who export to GraphML and expect to round-trip back to the original model will lose data. Mitigated by documenting GraphML as a visualization-only format
+
+---
+
+## Re-Evaluation Triggers
+
+- Demand for Neo4j or Neptune import format from users who need persistent graph storage
+- File sizes exceeding 50 MB where JSON verbosity becomes a practical problem
+- Need for incremental or streaming export in an evolving-graph use case
+- A standard graph interchange format (like GEXF 2.0 or a future standard) gaining enough adoption to justify implementation
+
+---
+
+## References
+
+- `src/export/json_export.py` -- `JSONExporter` with `export()` and `export_string()`
+- `src/export/graphml_export.py` -- `GraphMLExporter` with string attribute conversion
+- `src/export/base.py` -- `AbstractExporter` interface
+- `src/ingest/json_ingestor.py` -- `JSONIngestor` for round-trip import


### PR DESCRIPTION
## Summary
- 12 formal Architecture Decision Records documenting every major design choice
- Each ADR covers context, decision, alternatives considered, divergence analysis, consequences, and re-evaluation triggers
- ADR-001 (custom synthetic pipeline) through ADR-012 (JSON export format)

## Test plan
- [ ] All 12 ADR files render correctly on GitHub
- [ ] Internal links between ADRs resolve
- [ ] No broken markdown formatting

Closes #187