### PR TITLE
Cross-reference ADRs across all project documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -166,12 +166,21 @@ CSV/JSON file → Ingestor (with schema mapping + transforms) → IngestResult (
 
 ## Key Design Decisions
 
-1. **Pydantic v2 for entities** — Runtime validation, JSON serialization, and IDE support. `extra="allow"` enables forward compatibility but requires careful field naming.
+Each major architectural decision is documented in a formal Architecture Decision Record (ADR) with rationale, rejected alternatives, trade-offs, and re-evaluation triggers.
 
-2. **NetworkX MultiDiGraph** — Supports multiple edges between same nodes (common in enterprise graphs), directed relationships, and rich node/edge attributes. In-memory, no external dependencies.
+| Decision | ADR | Summary |
+|----------|-----|---------|
+| Pydantic v2 with `extra="allow"` | [002](docs/adr/002-pydantic-v2-extra-allow.md) | Forward compatibility over strict validation |
+| NetworkX MultiDiGraph | [003](docs/adr/003-networkx-multidigraph.md) | In-memory, zero-infrastructure, pluggable backend |
+| KnowledgeGraph facade + event bus | [004](docs/adr/004-knowledge-graph-facade.md) | Single entry point with synchronous event dispatch |
+| Layered generation order | [005](docs/adr/005-layered-generation-order.md) | Sequential topological build for referential integrity |
+| Coordinated template dicts | [006](docs/adr/006-coordinated-template-dicts.md) | Semantic coherence over random generation |
+| Research-backed scaling | [007](docs/adr/007-research-backed-scaling.md) | Industry coefficients from Gartner, NIST, McKinsey |
+| Relationship weaving | [008](docs/adr/008-relationship-weaving.md) | Post-generation phase with enriched metadata |
+| MCP mtime auto-reload | [009](docs/adr/009-mcp-mtime-auto-reload.md) | Zero-dependency file change detection |
+| Compact serialization | [010](docs/adr/010-compact-entity-serialization.md) | Optimized for LLM context windows |
+| rapidfuzz search | [011](docs/adr/011-rapidfuzz-search.md) | Fuzzy string matching over embeddings |
+| JSON primary export | [012](docs/adr/012-json-primary-export.md) | Human-readable, round-trip-safe |
+| Custom synthetic pipeline | [001](docs/adr/001-custom-synthetic-data-pipeline.md) | Purpose-built over SDV, Faker, Gretel |
 
-3. **mtime-based reload** — Zero-dependency file change detection. Checked on every tool call (microsecond cost) rather than file watching (which requires extra threads/dependencies).
-
-4. **Profile-driven generation** — Industry profiles (tech, healthcare, financial) control generation parameters. Easy to add new profiles without changing generators.
-
-5. **Layer-ordered generation** — Ensures referential integrity. L01 entities exist before L02 entities reference them.
+> See [docs/adr/](docs/adr/) for the complete Architecture Decision Records.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-**hc-enterprise-kg** is an open-source enterprise knowledge graph platform. It generates structurally accurate organizational models ("digital twins") with 30 entity types and 50 relationship types, enabling scenario analysis, risk modeling, and dependency mapping.
+**hc-enterprise-kg** is an open-source enterprise knowledge graph platform. It generates structurally accurate organizational models ("digital twins") with 30 entity types and 50 relationship types, enabling scenario analysis, risk modeling, and dependency mapping. Every major design choice is documented as an [Architecture Decision Record](docs/adr/).
 
 ## Quick Commands
 
@@ -20,21 +20,21 @@ poetry run hckg charts --full        # All 3 profiles, 6 scales
 
 ```
 src/
-  domain/       # Pydantic v2 entity models (30 types), BaseEntity, EntityType/RelationshipType enums
-  engine/       # AbstractGraphEngine → NetworkXGraphEngine (pluggable backend)
-  graph/        # KnowledgeGraph facade, event bus, QueryBuilder
-  synthetic/    # Profile-driven generators + relationship weaving + quality scoring (SyntheticOrchestrator)
+  domain/       # Pydantic v2 entity models (30 types), BaseEntity (ADR-002), EntityType/RelationshipType enums
+  engine/       # AbstractGraphEngine → NetworkXGraphEngine (ADR-003, pluggable backend)
+  graph/        # KnowledgeGraph facade (ADR-004), event bus, QueryBuilder
+  synthetic/    # Profile-driven generators (ADR-001, ADR-006) + relationship weaving (ADR-008) + quality scoring
   auto/         # Auto KG from CSV/text (rule-based + optional LLM)
   ingest/       # CSVIngestor, JSONIngestor with schema mappings
-  export/       # JSONExporter, GraphMLExporter
+  export/       # JSONExporter (ADR-012), GraphMLExporter
   analysis/     # Centrality, risk scoring, attack paths, blast radius, benchmarking, charts
   rag/          # GraphRAG retrieval pipeline
   cli/          # Click CLI (demo, generate, inspect, auto, serve, install, visualize, export, benchmark, charts)
-  mcp_server/   # MCP server for Claude Desktop (state.py, helpers.py, tools.py, server.py)
+  mcp_server/   # MCP server for Claude Desktop (ADR-009, ADR-010: state.py, helpers.py, tools.py, server.py)
   serve/        # REST API server (Flask)
 ```
 
-## Layer Build Order (Synthetic Generation)
+## Layer Build Order (Synthetic Generation) — [ADR-005](docs/adr/005-layered-generation-order.md)
 
 L00 Foundation → L01 Compliance → L02 Technology → L03 Data → L04 Organization → L05 People → L06 Capabilities → L07 Locations → L08 Products → L09 Customers → L10 Vendors → L11 Initiatives
 
@@ -46,19 +46,19 @@ L00 Foundation → L01 Compliance → L02 Technology → L03 Data → L04 Organi
 
 ## Synthetic Data Pipeline
 
-**Scaling**: Entity counts use `scaled_range(employee_count, coefficient, floor, ceiling)` with industry-specific `ScalingCoefficients` and size-tier multipliers (0.7x startup, 1.0x mid, 1.2x enterprise, 1.4x large). Three profiles: tech, financial, healthcare. Departments exceeding 500 headcount are subdivided into sub-departments via `SUB_DEPARTMENT_TEMPLATES` (30+ sets). Roles expand with seniority variants (Junior/Senior/Staff) based on sub-department headcount. At 14k emp (tech): 42 depts, 301 roles.
+**Scaling** ([ADR-007](docs/adr/007-research-backed-scaling.md)): Entity counts use `scaled_range(employee_count, coefficient, floor, ceiling)` with industry-specific `ScalingCoefficients` and size-tier multipliers (0.7x startup, 1.0x mid, 1.2x enterprise, 1.4x large). Three profiles: tech, financial, healthcare. Departments exceeding 500 headcount are subdivided into sub-departments via `SUB_DEPARTMENT_TEMPLATES` (30+ sets). Roles expand with seniority variants (Junior/Senior/Staff) based on sub-department headcount. At 14k emp (tech): 42 depts, 301 roles.
 
 **Count Overrides**: `SyntheticOrchestrator(kg, profile, count_overrides={"system": 500})` pins exact counts. CLI: `--systems 500 --vendors 100` (25 flags via `entity_overrides.py` decorator). `OVERRIDABLE_ENTITIES` dict in `orchestrator.py` maps CLI names → EntityType.
 
-**Generators**: All 30 generators use coordinated template dicts (not independent random). No faker.sentence()/faker.bs() — all descriptions are domain-specific. Risk levels derived from RISK_MATRIX[likelihood][impact].
+**Generators** ([ADR-006](docs/adr/006-coordinated-template-dicts.md)): All 30 generators use coordinated template dicts (not independent random). No faker.sentence()/faker.bs() — all descriptions are domain-specific. Risk levels derived from RISK_MATRIX[likelihood][impact].
 
-**Relationships**: 33 weaver methods produce 30+ relationship types with contextual weight/confidence/properties via `_make_rel()`. Mirror fields populated post-weave.
+**Relationships** ([ADR-008](docs/adr/008-relationship-weaving.md)): 33 weaver methods produce 30+ relationship types with contextual weight/confidence/properties via `_make_rel()`. Mirror fields populated post-weave.
 
 **Quality**: `assess_quality(context) → QualityReport` checks risk math, descriptions, tech coherence, field correlations, encryption↔classification. Orchestrator warns if < 0.7.
 
 ## Key Pitfalls
 
-1. **`extra="allow"` on BaseEntity** — Wrong field names silently go to `__pydantic_extra__`, no validation error. Always verify field names against the entity class.
+1. **`extra="allow"` on BaseEntity** ([ADR-002](docs/adr/002-pydantic-v2-extra-allow.md)) — Wrong field names silently go to `__pydantic_extra__`, no validation error. Always verify field names against the entity class. Use `HCKG_STRICT=1` to catch extras during development.
 
 2. **Sub-model fields** — Many enterprise entity fields that look like scalars are Pydantic sub-models (e.g., `Site.address` is `SiteAddress`, not `str`). Always check the entity class before writing generators.
 
@@ -90,7 +90,26 @@ The MCP server (`src/mcp_server/`) provides 10 tools for Claude Desktop:
 - `load_graph`, `get_statistics`, `list_entities`, `get_entity`, `get_neighbors`
 - `find_shortest_path`, `get_blast_radius`, `compute_centrality`, `find_most_connected`, `search_entities`
 
-**Auto-reload:** The server detects graph file changes via mtime checking on every tool call. After `hckg demo --clean`, Claude Desktop tools automatically pick up the new graph.
+**Auto-reload** ([ADR-009](docs/adr/009-mcp-mtime-auto-reload.md))**:** The server detects graph file changes via mtime checking on every tool call. After `hckg demo --clean`, Claude Desktop tools automatically pick up the new graph.
+
+## Architecture Decision Records
+
+All major design choices are formally documented in `docs/adr/`. Before proposing changes to any of these areas, read the relevant ADR for context, trade-offs, and re-evaluation triggers.
+
+| ADR | Decision |
+|-----|----------|
+| [001](docs/adr/001-custom-synthetic-data-pipeline.md) | Custom synthetic data pipeline over external libraries |
+| [002](docs/adr/002-pydantic-v2-extra-allow.md) | Pydantic v2 with `extra="allow"` for entity models |
+| [003](docs/adr/003-networkx-multidigraph.md) | NetworkX MultiDiGraph as pluggable graph backend |
+| [004](docs/adr/004-knowledge-graph-facade.md) | KnowledgeGraph facade with synchronous event bus |
+| [005](docs/adr/005-layered-generation-order.md) | Layered generation order for referential integrity |
+| [006](docs/adr/006-coordinated-template-dicts.md) | Coordinated template dicts over random generation |
+| [007](docs/adr/007-research-backed-scaling.md) | Research-backed scaling with industry coefficients |
+| [008](docs/adr/008-relationship-weaving.md) | Relationship weaving as post-generation phase |
+| [009](docs/adr/009-mcp-mtime-auto-reload.md) | MCP server with mtime-based auto-reload |
+| [010](docs/adr/010-compact-entity-serialization.md) | Compact entity serialization for LLM context windows |
+| [011](docs/adr/011-rapidfuzz-search.md) | rapidfuzz over embedding-based search |
+| [012](docs/adr/012-json-primary-export.md) | JSON as primary export format |
 
 ## Engineering Discipline (non-negotiable)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ poetry install --extras dev
 ## Running Tests
 
 ```bash
-make test          # Run all tests (~689)
+make test          # Run all tests (~740)
 make test-cov      # Run with coverage report
 make lint          # Lint with ruff
 make typecheck     # Type check with mypy
@@ -59,9 +59,10 @@ Run `make format` to auto-format your code before committing.
 
 ### Pitfalls to watch for
 
-- **`extra="allow"` on BaseEntity** — Wrong field names silently go to `__pydantic_extra__` instead of raising validation errors. Always double-check field names against the entity class.
+- **`extra="allow"` on BaseEntity** ([ADR-002](docs/adr/002-pydantic-v2-extra-allow.md)) — Wrong field names silently go to `__pydantic_extra__` instead of raising validation errors. This is the most common bug source in the project. Always double-check field names against the entity class. Use `HCKG_STRICT=1` to catch extras during development.
 - **Sub-model fields** — Many enterprise entity fields that look like scalars are actually Pydantic sub-models (e.g., `Site.address` is `SiteAddress`, not `str`). Always verify against the entity class before writing generators.
 - **Temporal/provenance naming** — Most entities use `temporal`/`provenance` fields. But Initiative, Vendor, Contract, Customer, MarketSegment, ProductPortfolio, and Product use `temporal_and_versioning`/`provenance_and_confidence`. Geography and Jurisdiction use inline scalars instead.
+- **Layer ordering** ([ADR-005](docs/adr/005-layered-generation-order.md)) — New entity types must be placed correctly in `GENERATION_ORDER` so they can reference entities from earlier layers.
 
 ## Adding a New Organization Profile
 
@@ -102,6 +103,32 @@ Detailed reference documentation lives in `docs/`:
 | [Organization Profiles](docs/profiles.md) | Industry profiles, scaling model, quality scoring |
 | [Performance & Benchmarking](docs/performance.md) | Benchmark results, scaling, memory, system requirements |
 | [Troubleshooting](docs/troubleshooting.md) | Common issues, setup, examples |
+| [Architecture Decision Records](docs/adr/) | Design rationale for all major architectural choices |
+
+## Architecture Decision Records
+
+Every significant design choice is documented as an ADR in `docs/adr/`. If your contribution changes or challenges an existing architectural decision, update the relevant ADR or propose a new one.
+
+### When to Write an ADR
+
+- You are introducing a new library, framework, or backend
+- You are changing a data model, serialization format, or API contract
+- You are replacing or significantly modifying an existing pattern (e.g., switching search strategies, changing the graph backend)
+- You are making a trade-off that future contributors will need to understand
+
+### ADR Structure
+
+Follow the existing format in `docs/adr/`:
+
+1. **Title and status** — One-line decision statement, date, status (Accepted / Superseded / Deprecated)
+2. **Context** — What problem or requirement prompted this decision
+3. **Decision** — What was chosen and why
+4. **Alternatives Considered** — What was evaluated and rejected, with specific reasons
+5. **Where This Diverges from Best Practice** — Honest assessment of trade-offs and known limitations
+6. **Consequences** — What follows from the decision (positive and negative)
+7. **Re-evaluation Triggers** — Concrete conditions that would warrant revisiting this decision
+
+ADRs are living documents. If the project outgrows a decision, the ADR gets updated with a superseding record — it does not get deleted. The historical record matters.
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://docs.astral.sh/ruff/)
 
-An open-source enterprise knowledge graph platform that generates structurally accurate organizational models in seconds, enabling scenario analysis, dependency mapping, and risk quantification without standing up a production data platform or waiting on a six-month consulting engagement.
+An open-source enterprise knowledge graph platform that generates structurally accurate organizational models in seconds, enabling scenario analysis, dependency mapping, and risk quantification without standing up a production data platform or waiting on a six-month consulting engagement. Every major design choice is [formally documented](docs/adr/) with rationale, trade-offs, and re-evaluation triggers.
 
 ---
 
@@ -91,7 +91,7 @@ src/
   rag/          GraphRAG retrieval pipeline
   serve/        REST API server (Flask, OpenAI-compatible endpoints)
   mcp_server/   MCP server for Claude Desktop (10 tools, auto-reload)
-tests/          692+ tests (unit, integration, stress, performance)
+tests/          740+ tests (unit, integration, stress, performance)
 ```
 
 > See [Architecture](ARCHITECTURE.md) for the full system design.
@@ -128,8 +128,26 @@ tests/          692+ tests (unit, integration, stress, performance)
 | [Performance & Benchmarking](docs/performance.md) | Benchmark results, scaling characteristics, memory profile, system requirements |
 | [Architecture](ARCHITECTURE.md) | System design, layer pipeline, engine abstraction, data flow |
 | [Troubleshooting](docs/troubleshooting.md) | Common issues, setup, runnable examples |
+| [Architecture Decision Records](docs/adr/) | Design rationale for key architectural choices (see index below) |
 | [Contributing](CONTRIBUTING.md) | Development setup, code style, adding entity types |
 | [Changelog](CHANGELOG.md) | Release history |
+
+### Architecture Decision Records
+
+| ADR | Decision |
+|-----|----------|
+| [001](docs/adr/001-custom-synthetic-data-pipeline.md) | Custom synthetic data pipeline over external libraries (SDV, Faker, Gretel) |
+| [002](docs/adr/002-pydantic-v2-extra-allow.md) | Pydantic v2 with `extra="allow"` for entity models |
+| [003](docs/adr/003-networkx-multidigraph.md) | NetworkX MultiDiGraph as pluggable graph backend |
+| [004](docs/adr/004-knowledge-graph-facade.md) | KnowledgeGraph facade with synchronous event bus |
+| [005](docs/adr/005-layered-generation-order.md) | Layered generation order for referential integrity |
+| [006](docs/adr/006-coordinated-template-dicts.md) | Coordinated template dicts over random generation |
+| [007](docs/adr/007-research-backed-scaling.md) | Research-backed scaling with industry coefficients |
+| [008](docs/adr/008-relationship-weaving.md) | Relationship weaving as post-generation phase |
+| [009](docs/adr/009-mcp-mtime-auto-reload.md) | MCP server with mtime-based auto-reload |
+| [010](docs/adr/010-compact-entity-serialization.md) | Compact entity serialization for LLM context windows |
+| [011](docs/adr/011-rapidfuzz-search.md) | rapidfuzz over embedding-based search |
+| [012](docs/adr/012-json-primary-export.md) | JSON as primary export format |
 
 ---
 
@@ -164,7 +182,7 @@ poetry install --extras dev         # Development tools (pytest, mypy, ruff)
 
 ```bash
 make install    # Install with dev dependencies
-make test       # Run all tests (~692)
+make test       # Run all tests (~740)
 make test-cov   # Tests with coverage report
 make lint       # Lint with ruff
 make format     # Auto-format with ruff

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -223,7 +223,7 @@ When running in `--stdio` mode, the server exposes 10 tools to Claude Desktop:
 
 `load_graph`, `get_statistics`, `list_entities`, `get_entity`, `get_neighbors`, `find_shortest_path`, `get_blast_radius`, `compute_centrality`, `find_most_connected`, `search_entities`
 
-The MCP server auto-reloads when the graph file changes (mtime-based detection on every tool call).
+The MCP server auto-reloads when the graph file changes (mtime-based detection on every tool call — see [ADR-009](adr/009-mcp-mtime-auto-reload.md)).
 
 ---
 
@@ -283,7 +283,7 @@ hckg export --source graph.json --format graphml --output graph.graphml
 
 ## Entity Count Overrides
 
-Both `hckg demo` and `hckg generate org` accept individual flags to override specific entity counts. When provided, these bypass the `scaled_range()` scaling formula and produce exactly the specified number of entities.
+Both `hckg demo` and `hckg generate org` accept individual flags to override specific entity counts. When provided, these bypass the `scaled_range()` scaling formula ([ADR-007](adr/007-research-backed-scaling.md)) and produce exactly the specified number of entities.
 
 ```bash
 # Pin systems to 500 and vendors to 100, let everything else scale normally

--- a/docs/entity-model.md
+++ b/docs/entity-model.md
@@ -2,7 +2,7 @@
 
 The knowledge graph models an enterprise organization as a network of typed entities connected by typed relationships. Thirty entity types span twelve generation layers, from compliance frameworks and technology infrastructure through people, products, customers, and strategic initiatives. Fifty-two relationship types encode how those entities depend on, govern, contain, and affect each other.
 
-Every entity extends `BaseEntity` (Pydantic v2) and carries a UUID, name, description, tags, metadata, and temporal fields. Every relationship carries a type, source/target IDs, contextual weight, confidence score, and a properties dict. The model is designed for structural analysis: dependency mapping, blast radius computation, centrality scoring, and risk quantification all operate directly on this graph.
+Every entity extends `BaseEntity` (Pydantic v2 with `extra="allow"` — see [ADR-002](adr/002-pydantic-v2-extra-allow.md) for the rationale and trade-offs) and carries a UUID, name, description, tags, metadata, and temporal fields. Every relationship carries a type, source/target IDs, contextual weight, confidence score, and a properties dict. The model is designed for structural analysis: dependency mapping, blast radius computation, centrality scoring, and risk quantification all operate directly on this graph.
 
 ---
 
@@ -56,7 +56,7 @@ These entity types extend the model to cover compliance, data governance, busine
 
 ## Generation Layers (L00-L11)
 
-Entities are generated in layer order to ensure referential integrity. Each layer can reference entities from all previous layers but not from subsequent ones.
+Entities are generated in layer order to ensure referential integrity ([ADR-005](adr/005-layered-generation-order.md)). Each layer can reference entities from all previous layers but not from subsequent ones.
 
 | Layer | Name | Entity Types | Purpose |
 |---|---|---|---|
@@ -233,4 +233,4 @@ All relationships inherit these fields:
 
 ---
 
-For the full architecture, layer pipeline, and engine abstraction details, see [ARCHITECTURE.md](../ARCHITECTURE.md).
+For the full architecture, layer pipeline, and engine abstraction details, see [ARCHITECTURE.md](../ARCHITECTURE.md). For design rationale on the entity model, relationship weaving, and generation pipeline, see [ADR-002](adr/002-pydantic-v2-extra-allow.md), [ADR-008](adr/008-relationship-weaving.md), and [ADR-005](adr/005-layered-generation-order.md).

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -138,7 +138,7 @@ These recommendations include headroom for analysis operations after generation.
 
 ## Architecture Guidance
 
-The default **NetworkX backend** is sufficient for most use cases up to 20,000 employees. It runs in-process with no external dependencies, making it ideal for development, testing, CI/CD pipelines, and single-user analysis.
+The default **NetworkX backend** ([ADR-003](adr/003-networkx-multidigraph.md)) is sufficient for most use cases up to 20,000 employees. It runs in-process with no external dependencies, making it ideal for development, testing, CI/CD pipelines, and single-user analysis.
 
 Consider a **Neo4j backend** (via the pluggable engine abstraction) when:
 
@@ -180,4 +180,4 @@ Your results will vary based on hardware. Use `hckg benchmark` to generate resul
 
 ---
 
-For full CLI usage, see [CLI Reference](cli.md). For the Python API, see [Python API Guide](python-api.md).
+For full CLI usage, see [CLI Reference](cli.md). For the Python API, see [Python API Guide](python-api.md). For design rationale on backend choice and search strategy, see [ADR-003](adr/003-networkx-multidigraph.md) and [ADR-011](adr/011-rapidfuzz-search.md).

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,6 +1,6 @@
 # Organization Profiles & Scaling
 
-Synthetic generation is driven by organization profiles that define industry characteristics, department structures, and entity density. Three profiles are included out of the box: technology, financial services, and healthcare. Each produces structurally different graphs that reflect real-world industry patterns.
+Synthetic generation is driven by organization profiles that define industry characteristics, department structures, and entity density. Three profiles are included out of the box: technology, financial services, and healthcare. Each produces structurally different graphs that reflect real-world industry patterns. For the design rationale behind the scaling model, including why we use research-backed coefficients and where the approach diverges from conventional practices, see [ADR-007](adr/007-research-backed-scaling.md).
 
 ---
 
@@ -206,4 +206,4 @@ Wire it into the CLI by adding a factory function in `src/synthetic/profiles/` a
 
 ---
 
-For the full entity model reference, see [Entity Model](entity-model.md). For architecture details, see [ARCHITECTURE.md](../ARCHITECTURE.md).
+For the full entity model reference, see [Entity Model](entity-model.md). For architecture details, see [ARCHITECTURE.md](../ARCHITECTURE.md). For design rationale: [ADR-007](adr/007-research-backed-scaling.md) (scaling model), [ADR-006](adr/006-coordinated-template-dicts.md) (template coherence), [ADR-001](adr/001-custom-synthetic-data-pipeline.md) (why we build our own pipeline).

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -311,7 +311,7 @@ json_string = JSONExporter().export_string(kg.engine)
 
 ## Event Bus
 
-Track mutations to the graph in real time.
+Track mutations to the graph in real time. The event bus is synchronous and in-process — see [ADR-004](adr/004-knowledge-graph-facade.md) for the design rationale and trade-offs.
 
 ```python
 from graph.knowledge_graph import KnowledgeGraph, MutationType
@@ -329,4 +329,4 @@ print(kg.event_log)
 
 ---
 
-For the full entity model reference, see [Entity Model](entity-model.md). For CLI usage, see [CLI Reference](cli.md).
+For the full entity model reference, see [Entity Model](entity-model.md). For CLI usage, see [CLI Reference](cli.md). For design rationale on the facade, event bus, and export format, see [ADR-004](adr/004-knowledge-graph-facade.md) and [ADR-012](adr/012-json-primary-export.md).


### PR DESCRIPTION
## Summary
- Add ADR references at decision-point context across 9 documentation files
- Add full ADR index table to ARCHITECTURE.md, README.md, and CLAUDE.md
- Add ADR authoring guidance section to CONTRIBUTING.md for contributors
- Fix stale test count in CONTRIBUTING.md (689→740)
- GitHub repo description updated to mention formally documented architectural decisions

## Test plan
- [ ] All ADR links resolve correctly from each document
- [ ] CONTRIBUTING.md ADR guidance section renders properly
- [ ] No broken cross-references

Closes #188