### PR TITLE
Add pre-flight validation to hckg install claude

### DIFF
--- a/src/cli/install_cmd.py
+++ b/src/cli/install_cmd.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 import json
 import platform
+import subprocess
 import sys
 from pathlib import Path
 
 import click
+
+# ---------------------------------------------------------------------------
+# Detection helpers
+# ---------------------------------------------------------------------------
 
 
 def _detect_claude_config_path() -> Path | None:
@@ -47,6 +52,108 @@ def _detect_project_root() -> Path:
     return Path.cwd()
 
 
+# ---------------------------------------------------------------------------
+# Pre-flight validation
+# ---------------------------------------------------------------------------
+
+
+def _check_mcp_importable(python_path: str) -> tuple[bool, str]:
+    """Check whether the MCP SDK is importable from the given interpreter.
+
+    Returns (ok, detail) where *detail* is a human-readable diagnostic.
+    """
+    try:
+        result = subprocess.run(  # noqa: S603
+            [
+                python_path,
+                "-c",
+                "from mcp.server.fastmcp import FastMCP; print('ok')",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode == 0 and "ok" in result.stdout:
+            return True, "mcp SDK is importable"
+        # Parse the error for a helpful message
+        stderr = result.stderr.strip()
+        if "No module named 'mcp'" in stderr:
+            return False, (
+                "The 'mcp' package is not installed in this Python environment.\n"
+                "  Fix: poetry install --extras mcp"
+            )
+        return False, f"Import check failed:\n  {stderr}"
+    except FileNotFoundError:
+        return False, f"Python interpreter not found: {python_path}"
+    except subprocess.TimeoutExpired:
+        return False, "Import check timed out (>15s)"
+
+
+def _check_server_module(project_root: Path) -> tuple[bool, str]:
+    """Check that mcp_server/server.py exists under src/."""
+    server_file = project_root / "src" / "mcp_server" / "server.py"
+    if server_file.exists():
+        return True, f"Server module found: {server_file}"
+    return False, (
+        f"Server module not found: {server_file}\n"
+        "  Ensure you are running from the hc-enterprise-kg project directory."
+    )
+
+
+def _check_python_version(python_path: str) -> tuple[bool, str]:
+    """Report the Python version for the detected interpreter."""
+    try:
+        result = subprocess.run(  # noqa: S603
+            [python_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        version = result.stdout.strip() or result.stderr.strip()
+        return True, version
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False, f"Could not determine version for: {python_path}"
+
+
+def _run_preflight(python_path: str, project_root: Path) -> list[tuple[str, bool, str]]:
+    """Run all pre-flight checks. Returns list of (check_name, passed, detail)."""
+    checks: list[tuple[str, bool, str]] = []
+
+    # 1. Python version (informational — always "passes" if reachable)
+    ok, detail = _check_python_version(python_path)
+    checks.append(("Python version", ok, detail))
+
+    # 2. Server module exists
+    ok, detail = _check_server_module(project_root)
+    checks.append(("Server module", ok, detail))
+
+    # 3. MCP SDK importable (the critical one)
+    ok, detail = _check_mcp_importable(python_path)
+    checks.append(("MCP SDK", ok, detail))
+
+    return checks
+
+
+def _print_checks(checks: list[tuple[str, bool, str]]) -> int:
+    """Print check results. Returns count of failures."""
+    failures = 0
+    for name, passed, detail in checks:
+        icon = "PASS" if passed else "FAIL"
+        click.echo(f"  [{icon}] {name}: {detail.split(chr(10))[0]}")
+        if not passed:
+            failures += 1
+            # Print additional lines indented
+            lines = detail.split("\n")
+            for line in lines[1:]:
+                click.echo(f"         {line}")
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# CLI commands
+# ---------------------------------------------------------------------------
+
+
 @click.group("install")
 def install_group() -> None:
     """Register hc-enterprise-kg with LLM clients (Claude Desktop, etc.)."""
@@ -67,17 +174,26 @@ def install_group() -> None:
     default=None,
     help="Default graph file to auto-load on startup.",
 )
-def install_claude(config_path: str | None, graph_path: str | None) -> None:
+@click.option(
+    "--skip-checks",
+    is_flag=True,
+    default=False,
+    help="Skip pre-flight validation checks.",
+)
+def install_claude(
+    config_path: str | None, graph_path: str | None, skip_checks: bool
+) -> None:
     """Register hc-enterprise-kg with Claude Desktop.
 
-    Auto-detects the config file location and Python path based on your
-    current environment. Works on macOS, Windows, and Linux.
+    Runs pre-flight validation to ensure the MCP server will start
+    correctly. Use --skip-checks to bypass validation.
 
     \b
     Examples:
       hckg install claude
       hckg install claude --graph graph.json
       hckg install claude --config ~/custom/claude_desktop_config.json
+      hckg install claude --skip-checks
     """
     if config_path:
         conf_file = Path(config_path).expanduser()
@@ -94,10 +210,30 @@ def install_claude(config_path: str | None, graph_path: str | None) -> None:
     python_path = _detect_python_path()
     project_root = _detect_project_root()
 
-    click.echo(f"  Config:  {conf_file}")
-    click.echo(f"  Python:  {python_path}")
-    click.echo(f"  Project: {project_root}")
+    click.echo()
+    click.echo("  Environment")
+    click.echo(f"    Config:  {conf_file}")
+    click.echo(f"    Python:  {python_path}")
+    click.echo(f"    Project: {project_root}")
 
+    # --- Pre-flight checks ---
+    if not skip_checks:
+        click.echo()
+        click.echo("  Pre-flight checks")
+        checks = _run_preflight(python_path, project_root)
+        failures = _print_checks(checks)
+
+        if failures > 0:
+            click.echo()
+            click.echo(
+                f"  {failures} check(s) failed. Resolve the issues above "
+                "or use --skip-checks to bypass."
+            )
+            raise SystemExit(1)
+
+        click.echo()
+
+    # --- Write config ---
     server_entry: dict = {
         "command": python_path,
         "args": ["-m", "mcp_server.server"],
@@ -115,7 +251,7 @@ def install_claude(config_path: str | None, graph_path: str | None) -> None:
         existing["mcpServers"] = {}
 
     if "hc-enterprise-kg" in existing["mcpServers"]:
-        click.echo("\n  Already registered. Updating configuration...")
+        click.echo("  Already registered. Updating configuration...")
 
     existing["mcpServers"]["hc-enterprise-kg"] = server_entry
 
@@ -126,6 +262,92 @@ def install_claude(config_path: str | None, graph_path: str | None) -> None:
     click.echo("\n  Next steps:")
     click.echo("    1. Restart Claude Desktop")
     click.echo('    2. Ask Claude: "Load the graph and show me statistics"')
+
+
+@install_group.command("doctor")
+def install_doctor() -> None:
+    """Diagnose an existing Claude Desktop registration.
+
+    Validates the currently registered configuration without modifying
+    anything. Use this to troubleshoot connection issues.
+
+    \b
+    Examples:
+      hckg install doctor
+    """
+    conf_file = _detect_claude_config_path()
+
+    click.echo()
+    click.echo("  Claude Desktop Doctor")
+    click.echo()
+
+    if conf_file is None or not conf_file.exists():
+        click.echo("  Config file not found.")
+        click.echo("  Run: hckg install claude")
+        raise SystemExit(1)
+
+    config = json.loads(conf_file.read_text())
+    servers = config.get("mcpServers", {})
+
+    if "hc-enterprise-kg" not in servers:
+        click.echo("  hc-enterprise-kg is not registered.")
+        click.echo("  Run: hckg install claude")
+        raise SystemExit(1)
+
+    entry = servers["hc-enterprise-kg"]
+    python_path = entry.get("command", "")
+    cwd = entry.get("cwd", "")
+
+    click.echo("  Registered config:")
+    click.echo(f"    Command: {python_path}")
+    click.echo(f"    Args:    {entry.get('args', [])}")
+    click.echo(f"    CWD:     {cwd}")
+    if "env" in entry:
+        for k, v in entry["env"].items():
+            click.echo(f"    Env:     {k}={v}")
+    click.echo()
+
+    # Derive project_root from cwd (cwd = project_root/src)
+    cwd_path = Path(cwd)
+    project_root = cwd_path.parent if cwd_path.name == "src" else cwd_path
+
+    click.echo("  Validation")
+    checks = _run_preflight(python_path, project_root)
+
+    # Extra check: does the registered Python still exist?
+    python_exists = Path(python_path).exists()
+    if not python_exists:
+        checks.insert(
+            0,
+            (
+                "Python exists",
+                False,
+                f"Interpreter not found at: {python_path}\n"
+                "  The virtualenv may have been deleted. Re-run: hckg install claude",
+            ),
+        )
+
+    # Extra check: does the CWD exist?
+    if not cwd_path.exists():
+        checks.insert(
+            0,
+            (
+                "Working directory",
+                False,
+                f"CWD does not exist: {cwd}\n"
+                "  The project may have been moved. Re-run: hckg install claude",
+            ),
+        )
+
+    failures = _print_checks(checks)
+
+    click.echo()
+    if failures == 0:
+        click.echo("  All checks passed. The MCP server should connect successfully.")
+        click.echo("  If issues persist, restart Claude Desktop.")
+    else:
+        click.echo(f"  {failures} issue(s) found. Resolve them and re-run: hckg install claude")
+        raise SystemExit(1)
 
 
 @install_group.command("status")

--- a/tests/unit/cli/test_mcp_cmd.py
+++ b/tests/unit/cli/test_mcp_cmd.py
@@ -1,14 +1,30 @@
-"""Tests for the hckg install claude/status/remove CLI commands."""
+"""Tests for the hckg install claude/status/remove/doctor CLI commands."""
 
 from __future__ import annotations
 
 import json
+import sys
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
+from cli import install_cmd
 from cli.main import cli
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _setup_project_tree(tmpdir: str) -> Path:
+    """Create a minimal project tree with mcp_server/server.py."""
+    root = Path(tmpdir) / "project"
+    (root / "src" / "mcp_server").mkdir(parents=True)
+    (root / "src" / "mcp_server" / "server.py").write_text("# server\n")
+    (root / "pyproject.toml").write_text("[project]\nname = 'test'\n")
+    return root
 
 
 class TestInstallClaude:
@@ -81,6 +97,229 @@ class TestInstallClaude:
             assert result.exit_code == 0, result.output
             assert "Updating" in result.output or "Registered" in result.output
 
+    def test_install_skip_checks(self):
+        """--skip-checks bypasses pre-flight validation."""
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "claude_desktop_config.json"
+            result = runner.invoke(
+                cli,
+                ["install", "claude", "--config", str(config_path), "--skip-checks"],
+            )
+            assert result.exit_code == 0, result.output
+            assert "Pre-flight" not in result.output
+            assert config_path.exists()
+
+
+class TestPreflightChecks:
+    """Tests for the pre-flight validation functions."""
+
+    def test_check_mcp_importable_with_current_python(self):
+        """Current test env has mcp installed, so this should pass."""
+        ok, detail = install_cmd._check_mcp_importable(sys.executable)
+        assert ok is True
+        assert "importable" in detail
+
+    def test_check_mcp_importable_bad_interpreter(self):
+        """Non-existent interpreter should fail gracefully."""
+        ok, detail = install_cmd._check_mcp_importable("/nonexistent/python")
+        assert ok is False
+        assert "not found" in detail
+
+    def test_check_mcp_importable_missing_module(self):
+        """Python without mcp should report the fix command."""
+        # Use a subprocess that will fail the import
+        ok, detail = install_cmd._check_mcp_importable(sys.executable)
+        # We can't easily test "missing mcp" with the current interpreter,
+        # so we mock subprocess.run to simulate it
+        import subprocess
+
+        fake_result = subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr="ModuleNotFoundError: No module named 'mcp'",
+        )
+        with patch("cli.install_cmd.subprocess.run", return_value=fake_result):
+            ok, detail = install_cmd._check_mcp_importable(sys.executable)
+            assert ok is False
+            assert "poetry install --extras mcp" in detail
+
+    def test_check_server_module_exists(self):
+        """Server module check passes when file exists."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = _setup_project_tree(tmpdir)
+            ok, detail = install_cmd._check_server_module(root)
+            assert ok is True
+            assert "found" in detail
+
+    def test_check_server_module_missing(self):
+        """Server module check fails when file is missing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "empty"
+            root.mkdir()
+            ok, detail = install_cmd._check_server_module(root)
+            assert ok is False
+            assert "not found" in detail
+
+    def test_check_python_version(self):
+        """Python version check returns version string."""
+        ok, detail = install_cmd._check_python_version(sys.executable)
+        assert ok is True
+        assert "Python" in detail
+
+    def test_check_python_version_bad_interpreter(self):
+        """Non-existent interpreter reports failure."""
+        ok, detail = install_cmd._check_python_version("/nonexistent/python")
+        assert ok is False
+
+    def test_run_preflight_all_pass(self):
+        """Full pre-flight with valid environment."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = _setup_project_tree(tmpdir)
+            checks = install_cmd._run_preflight(sys.executable, root)
+            assert len(checks) == 3
+            assert all(passed for _, passed, _ in checks)
+
+    def test_run_preflight_missing_server(self):
+        """Pre-flight detects missing server module."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "empty"
+            root.mkdir()
+            checks = install_cmd._run_preflight(sys.executable, root)
+            # Server module check should fail
+            server_check = [c for c in checks if c[0] == "Server module"][0]
+            assert server_check[1] is False
+
+    def test_install_fails_on_preflight_failure(self):
+        """Install exits with error when pre-flight fails."""
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "claude_desktop_config.json"
+
+            # Mock _check_mcp_importable to simulate missing mcp
+            import subprocess as sp
+
+            fake = sp.CompletedProcess(
+                args=[], returncode=1, stdout="",
+                stderr="ModuleNotFoundError: No module named 'mcp'",
+            )
+            with patch("cli.install_cmd.subprocess.run", return_value=fake):
+                result = runner.invoke(
+                    cli, ["install", "claude", "--config", str(config_path)]
+                )
+                assert result.exit_code != 0
+                assert "FAIL" in result.output
+                assert "poetry install --extras mcp" in result.output
+                # Config should NOT be written
+                assert not config_path.exists()
+
+    def test_print_checks_counts_failures(self):
+        """_print_checks returns correct failure count."""
+        checks = [
+            ("Check A", True, "all good"),
+            ("Check B", False, "broken\n  Fix: do something"),
+            ("Check C", True, "fine"),
+        ]
+        failures = install_cmd._print_checks(checks)
+        assert failures == 1
+
+
+class TestInstallDoctor:
+    def test_doctor_all_pass(self):
+        """Doctor passes when registration is valid."""
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = _setup_project_tree(tmpdir)
+            config_path = Path(tmpdir) / "claude_desktop_config.json"
+            config = {
+                "mcpServers": {
+                    "hc-enterprise-kg": {
+                        "command": sys.executable,
+                        "args": ["-m", "mcp_server.server"],
+                        "cwd": str(root / "src"),
+                    }
+                }
+            }
+            config_path.write_text(json.dumps(config))
+
+            original = install_cmd._detect_claude_config_path
+            try:
+                install_cmd._detect_claude_config_path = lambda: config_path
+                result = runner.invoke(cli, ["install", "doctor"])
+                assert result.exit_code == 0, result.output
+                assert "All checks passed" in result.output
+            finally:
+                install_cmd._detect_claude_config_path = original
+
+    def test_doctor_missing_python(self):
+        """Doctor catches a non-existent Python interpreter."""
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = _setup_project_tree(tmpdir)
+            config_path = Path(tmpdir) / "claude_desktop_config.json"
+            config = {
+                "mcpServers": {
+                    "hc-enterprise-kg": {
+                        "command": "/nonexistent/python",
+                        "args": ["-m", "mcp_server.server"],
+                        "cwd": str(root / "src"),
+                    }
+                }
+            }
+            config_path.write_text(json.dumps(config))
+
+            original = install_cmd._detect_claude_config_path
+            try:
+                install_cmd._detect_claude_config_path = lambda: config_path
+                result = runner.invoke(cli, ["install", "doctor"])
+                assert result.exit_code != 0
+                assert "FAIL" in result.output
+                assert "not found" in result.output
+            finally:
+                install_cmd._detect_claude_config_path = original
+
+    def test_doctor_missing_cwd(self):
+        """Doctor catches a non-existent CWD."""
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "claude_desktop_config.json"
+            config = {
+                "mcpServers": {
+                    "hc-enterprise-kg": {
+                        "command": sys.executable,
+                        "args": ["-m", "mcp_server.server"],
+                        "cwd": "/nonexistent/path/src",
+                    }
+                }
+            }
+            config_path.write_text(json.dumps(config))
+
+            original = install_cmd._detect_claude_config_path
+            try:
+                install_cmd._detect_claude_config_path = lambda: config_path
+                result = runner.invoke(cli, ["install", "doctor"])
+                assert result.exit_code != 0
+                assert "FAIL" in result.output
+            finally:
+                install_cmd._detect_claude_config_path = original
+
+    def test_doctor_not_registered(self):
+        """Doctor reports when not registered."""
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "claude_desktop_config.json"
+            config_path.write_text(json.dumps({"mcpServers": {}}))
+
+            original = install_cmd._detect_claude_config_path
+            try:
+                install_cmd._detect_claude_config_path = lambda: config_path
+                result = runner.invoke(cli, ["install", "doctor"])
+                assert result.exit_code != 0
+                assert "not registered" in result.output
+            finally:
+                install_cmd._detect_claude_config_path = original
+
 
 class TestInstallStatus:
     def test_status_when_registered(self):
@@ -88,8 +327,6 @@ class TestInstallStatus:
         with tempfile.TemporaryDirectory() as tmpdir:
             config_path = Path(tmpdir) / "claude_desktop_config.json"
             runner.invoke(cli, ["install", "claude", "--config", str(config_path)])
-
-            from cli import install_cmd
 
             original = install_cmd._detect_claude_config_path
 
@@ -106,8 +343,6 @@ class TestInstallStatus:
         with tempfile.TemporaryDirectory() as tmpdir:
             config_path = Path(tmpdir) / "claude_desktop_config.json"
             config_path.write_text(json.dumps({"mcpServers": {}}))
-
-            from cli import install_cmd
 
             original = install_cmd._detect_claude_config_path
 
@@ -127,8 +362,6 @@ class TestInstallRemove:
             config_path = Path(tmpdir) / "claude_desktop_config.json"
             runner.invoke(cli, ["install", "claude", "--config", str(config_path)])
 
-            from cli import install_cmd
-
             original = install_cmd._detect_claude_config_path
 
             try:
@@ -147,8 +380,6 @@ class TestInstallRemove:
         with tempfile.TemporaryDirectory() as tmpdir:
             config_path = Path(tmpdir) / "claude_desktop_config.json"
             config_path.write_text(json.dumps({"mcpServers": {}}))
-
-            from cli import install_cmd
 
             original = install_cmd._detect_claude_config_path
 


### PR DESCRIPTION
## Summary
- `hckg install claude` now runs 3 pre-flight checks before writing config: Python version, server module existence, MCP SDK importability
- Fails with actionable fix commands instead of silently writing a broken config (e.g., `poetry install --extras mcp`)
- New `hckg install doctor` subcommand diagnoses existing registrations without modifying anything
- New `--skip-checks` flag for advanced users who want to bypass validation
- 16 new tests (24 total for install module), all 756 passing

## Root cause this fixes
When users have multiple Python versions (e.g., py3.12 + py3.14) or install without `--extras mcp`, the config would point to a Python that can't import `mcp`, causing `ModuleNotFoundError` in Claude Desktop with no guidance.

## Test plan
- [x] `hckg install claude` blocks on missing `mcp` with fix command
- [x] `hckg install claude --skip-checks` bypasses validation
- [x] `hckg install doctor` validates existing config
- [x] `hckg install doctor` catches missing Python, missing CWD, missing mcp
- [x] All 756 tests pass, ruff clean

Closes #191