### PR TITLE
Fix ruff formatting on install_cmd.py and test_mcp_cmd.py

### DIFF
--- a/src/cli/install_cmd.py
+++ b/src/cli/install_cmd.py
@@ -59,9 +59,7 @@ def _write_config(path: Path, data: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(data, indent=2) + "\n"
     try:
-        fd, tmp = tempfile.mkstemp(
-            dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
-        )
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
         try:
             os.write(fd, payload.encode("utf-8"))
         finally:
@@ -160,7 +158,7 @@ def _check_python_version(python_path: str) -> tuple[bool, str]:
     except subprocess.TimeoutExpired:
         return False, f"timed out checking: {python_path}"
 
-    version_str = (result.stdout.strip() or result.stderr.strip())
+    version_str = result.stdout.strip() or result.stderr.strip()
     match = re.search(r"(\d+)\.(\d+)", version_str)
     if not match:
         return False, f"could not parse version from: {version_str}"
@@ -324,20 +322,26 @@ def install_group() -> None:
 
 @install_group.command("claude")
 @click.option(
-    "--config", "config_path", type=click.Path(), default=None,
+    "--config",
+    "config_path",
+    type=click.Path(),
+    default=None,
     help="Path to claude_desktop_config.json. Auto-detected if omitted.",
 )
 @click.option(
-    "--graph", "graph_path", type=click.Path(), default=None,
+    "--graph",
+    "graph_path",
+    type=click.Path(),
+    default=None,
     help="Default graph file to auto-load on startup.",
 )
 @click.option(
-    "--skip-checks", is_flag=True, default=False,
+    "--skip-checks",
+    is_flag=True,
+    default=False,
     help="Skip pre-flight validation checks.",
 )
-def install_claude(
-    config_path: str | None, graph_path: str | None, skip_checks: bool
-) -> None:
+def install_claude(config_path: str | None, graph_path: str | None, skip_checks: bool) -> None:
     """Register hc-enterprise-kg with Claude Desktop.
 
     Runs pre-flight validation to ensure the MCP server will start
@@ -487,12 +491,14 @@ def install_doctor() -> None:
     if not python_path:
         checks.append(("Command", False, "no 'command' field in registration"))
     elif not Path(python_path).exists():
-        checks.append((
-            "Command",
-            False,
-            f"interpreter not found: {python_path}\n"
-            "  The virtualenv may have been deleted. Re-run: hckg install claude",
-        ))
+        checks.append(
+            (
+                "Command",
+                False,
+                f"interpreter not found: {python_path}\n"
+                "  The virtualenv may have been deleted. Re-run: hckg install claude",
+            )
+        )
     else:
         checks.append(("Command", True, python_path))
 
@@ -501,25 +507,29 @@ def install_doctor() -> None:
     if args == expected_args:
         checks.append(("Args", True, str(args)))
     else:
-        checks.append((
-            "Args",
-            False,
-            f"unexpected args: {args}\n"
-            f"  Expected: {expected_args}\n"
-            "  Re-run: hckg install claude",
-        ))
+        checks.append(
+            (
+                "Args",
+                False,
+                f"unexpected args: {args}\n"
+                f"  Expected: {expected_args}\n"
+                "  Re-run: hckg install claude",
+            )
+        )
 
     # 3. cwd (if present) exists
     if cwd:
         if Path(cwd).is_dir():
             checks.append(("Working dir", True, cwd))
         else:
-            checks.append((
-                "Working dir",
-                False,
-                f"directory not found: {cwd}\n"
-                "  The project may have been moved. Re-run: hckg install claude",
-            ))
+            checks.append(
+                (
+                    "Working dir",
+                    False,
+                    f"directory not found: {cwd}\n"
+                    "  The project may have been moved. Re-run: hckg install claude",
+                )
+            )
 
     # 4. Graph file (if configured)
     env = entry.get("env", {})
@@ -528,12 +538,13 @@ def install_doctor() -> None:
         if Path(graph).exists():
             checks.append(("Graph file", True, graph))
         else:
-            checks.append((
-                "Graph file",
-                False,
-                f"not found: {graph}\n"
-                "  Re-generate: hckg demo --clean",
-            ))
+            checks.append(
+                (
+                    "Graph file",
+                    False,
+                    f"not found: {graph}\n  Re-generate: hckg demo --clean",
+                )
+            )
 
     # 5-7. Python version, MCP SDK, server module (only if command exists)
     if python_path and Path(python_path).exists():

--- a/tests/unit/cli/test_mcp_cmd.py
+++ b/tests/unit/cli/test_mcp_cmd.py
@@ -187,7 +187,10 @@ class TestCheckPythonVersion:
 
     def test_old_python_fails(self):
         fake = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout="Python 3.9.7\n", stderr="",
+            args=[],
+            returncode=0,
+            stdout="Python 3.9.7\n",
+            stderr="",
         )
         with patch("cli.install_cmd.subprocess.run", return_value=fake):
             ok, detail = install_cmd._check_python_version(sys.executable)
@@ -221,7 +224,9 @@ class TestCheckMcpImportable:
 
     def test_missing_module_shows_fix(self):
         fake = subprocess.CompletedProcess(
-            args=[], returncode=1, stdout="",
+            args=[],
+            returncode=1,
+            stdout="",
             stderr="ModuleNotFoundError: No module named 'mcp'",
         )
         with patch("cli.install_cmd.subprocess.run", return_value=fake):
@@ -232,7 +237,9 @@ class TestCheckMcpImportable:
 
     def test_other_import_error(self):
         fake = subprocess.CompletedProcess(
-            args=[], returncode=1, stdout="",
+            args=[],
+            returncode=1,
+            stdout="",
             stderr="ImportError: cannot import name 'Foo'",
         )
         with patch("cli.install_cmd.subprocess.run", return_value=fake):
@@ -259,7 +266,9 @@ class TestCheckServerImportable:
 
     def test_missing_mcp_server_shows_fix(self):
         fake = subprocess.CompletedProcess(
-            args=[], returncode=1, stdout="",
+            args=[],
+            returncode=1,
+            stdout="",
             stderr="ModuleNotFoundError: No module named 'mcp_server'",
         )
         with patch("cli.install_cmd.subprocess.run", return_value=fake):
@@ -270,7 +279,9 @@ class TestCheckServerImportable:
 
     def test_missing_mcp_dependency_shows_fix(self):
         fake = subprocess.CompletedProcess(
-            args=[], returncode=1, stdout="",
+            args=[],
+            returncode=1,
+            stdout="",
             stderr="ModuleNotFoundError: No module named 'mcp'",
         )
         with patch("cli.install_cmd.subprocess.run", return_value=fake):
@@ -363,9 +374,9 @@ class TestInstallClaude:
 
     def test_preserves_existing_servers(self, tmp_path: Path):
         config_path = tmp_path / "config.json"
-        config_path.write_text(json.dumps({
-            "mcpServers": {"other": {"command": "node", "args": ["s.js"]}}
-        }))
+        config_path.write_text(
+            json.dumps({"mcpServers": {"other": {"command": "node", "args": ["s.js"]}}})
+        )
         result = CliRunner().invoke(cli, ["install", "claude", "--config", str(config_path)])
         assert result.exit_code == 0, result.output
         config = json.loads(config_path.read_text())
@@ -390,7 +401,9 @@ class TestInstallClaude:
     def test_fails_on_preflight_failure(self, tmp_path: Path):
         config_path = tmp_path / "config.json"
         fake = subprocess.CompletedProcess(
-            args=[], returncode=1, stdout="",
+            args=[],
+            returncode=1,
+            stdout="",
             stderr="ModuleNotFoundError: No module named 'mcp'",
         )
         with patch("cli.install_cmd.subprocess.run", return_value=fake):
@@ -409,8 +422,15 @@ class TestInstallClaude:
     def test_graph_warning_on_missing_file(self, tmp_path: Path):
         config_path = tmp_path / "config.json"
         result = CliRunner().invoke(
-            cli, ["install", "claude", "--config", str(config_path),
-                  "--graph", "/nonexistent/graph.json"]
+            cli,
+            [
+                "install",
+                "claude",
+                "--config",
+                str(config_path),
+                "--graph",
+                "/nonexistent/graph.json",
+            ],
         )
         assert result.exit_code == 0, result.output
         assert "Warning" in result.output
@@ -510,9 +530,7 @@ class TestInstallDoctor:
 
     def test_invalid_entry_type(self, tmp_path: Path):
         config_path = tmp_path / "config.json"
-        config_path.write_text(json.dumps({
-            "mcpServers": {"hc-enterprise-kg": "not-a-dict"}
-        }))
+        config_path.write_text(json.dumps({"mcpServers": {"hc-enterprise-kg": "not-a-dict"}}))
         result = self._run_doctor(config_path)
         assert result.exit_code != 0
         assert "not a valid" in result.output
@@ -612,15 +630,19 @@ class TestInstallRemove:
 
     def test_remove_preserves_other_servers(self, tmp_path: Path):
         config_path = tmp_path / "config.json"
-        config_path.write_text(json.dumps({
-            "mcpServers": {
-                "other": {"command": "node"},
-                "hc-enterprise-kg": {
-                    "command": sys.executable,
-                    "args": ["-m", "mcp_server.server"],
-                },
-            }
-        }))
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "other": {"command": "node"},
+                        "hc-enterprise-kg": {
+                            "command": sys.executable,
+                            "args": ["-m", "mcp_server.server"],
+                        },
+                    }
+                }
+            )
+        )
         original = install_cmd._detect_claude_config_path
         try:
             install_cmd._detect_claude_config_path = lambda: config_path


### PR DESCRIPTION
## Summary
- Applies `ruff format` to `install_cmd.py` and `test_mcp_cmd.py` to fix CI format check failures introduced in v0.20.12 rewrite

## Test plan
- [x] `ruff format --check` passes
- [x] `ruff check` passes
- [x] All 67 tests pass

Fixes #195