### PR TITLE
Disable publish.yml until PyPI is configured

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,11 @@
 name: Publish to PyPI
 
+# Disabled until PyPI trusted publisher (OIDC) is configured.
+# To re-enable: uncomment the 'on' block below and remove 'on: workflow_dispatch'.
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+  # release:
+  #   types: [published]
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
- Switches publish.yml trigger from `release:published` to `workflow_dispatch` so GitHub releases no longer fire a failing PyPI publish
- Original trigger preserved as a comment for easy re-enablement when PyPI trusted publisher (OIDC) is configured

## Test plan
- [x] Verify `gh release create` no longer triggers publish workflow
- [x] Workflow can still be triggered manually via Actions tab when needed

Fixes #196