### PR TITLE
Harden generate command error handling

### DIFF
--- a/src/cli/generate.py
+++ b/src/cli/generate.py
@@ -88,5 +88,14 @@ def org(
 
     from export.json_export import JSONExporter
 
-    JSONExporter().export(kg.engine, Path(output))
+    output_path = Path(output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        JSONExporter().export(kg.engine, output_path)
+    except PermissionError:
+        click.echo(f"Error: permission denied writing to {output_path}", err=True)
+        raise SystemExit(1) from None
+    except OSError as exc:
+        click.echo(f"Error writing output file: {exc}", err=True)
+        raise SystemExit(1) from None
     click.echo(f"\nExported to {output}")

--- a/tests/unit/cli/test_generate_cmd.py
+++ b/tests/unit/cli/test_generate_cmd.py
@@ -1,0 +1,73 @@
+"""Tests for the hckg generate CLI command."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+
+class TestGenerateHelp:
+    def test_help_shows_options(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["generate", "org", "--help"])
+        assert result.exit_code == 0
+        assert "--profile" in result.output
+        assert "--employees" in result.output
+        assert "--output" in result.output
+
+
+class TestGenerateOutput:
+    def test_output_creates_parent_dirs(self, tmp_path):
+        nested = tmp_path / "a" / "b" / "graph.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["generate", "org", "--employees", "10", "--output", str(nested)]
+        )
+        assert result.exit_code == 0
+        assert nested.exists()
+
+    def test_output_permission_error(self, tmp_path):
+        output = tmp_path / "graph.json"
+        runner = CliRunner()
+        with patch(
+            "export.json_export.JSONExporter.export",
+            side_effect=PermissionError("denied"),
+        ):
+            result = runner.invoke(
+                cli, ["generate", "org", "--employees", "10", "--output", str(output)]
+            )
+            assert result.exit_code != 0
+
+
+class TestGenerateRuns:
+    def test_default_generation(self, tmp_path):
+        output = tmp_path / "graph.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["generate", "org", "--employees", "10", "--output", str(output)]
+        )
+        assert result.exit_code == 0
+        assert output.exists()
+        assert "Generation complete" in result.output
+
+    def test_all_profiles(self, tmp_path):
+        for profile in ("tech", "healthcare", "financial"):
+            output = tmp_path / f"{profile}.json"
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "generate",
+                    "org",
+                    "--profile",
+                    profile,
+                    "--employees",
+                    "10",
+                    "--output",
+                    str(output),
+                ],
+            )
+            assert result.exit_code == 0, f"{profile} failed: {result.output}"


### PR DESCRIPTION
## Summary
- Validate output parent directory exists before export (create if missing)
- Catch PermissionError/OSError on export with clean error message
- Add 5 tests: help, output dir creation, permission error, profiles

Fixes #201