### PR TITLE
Harden benchmark command error handling

### DIFF
--- a/src/cli/benchmark_cmd.py
+++ b/src/cli/benchmark_cmd.py
@@ -72,7 +72,13 @@ def benchmark(
         scale_list = [100, 500, 1000, 5000, 10000, 20000]
     else:
         profile_list = [p.strip() for p in profiles.split(",")]
-        scale_list = [int(s.strip()) for s in scales.split(",")]
+        try:
+            scale_list = [int(s.strip()) for s in scales.split(",")]
+        except ValueError:
+            raise click.BadParameter(
+                f"Invalid scale values '{scales}'. Must be comma-separated integers.",
+                param_hint="--scales",
+            ) from None
 
     valid_profiles = {"tech", "financial", "healthcare"}
     for p in profile_list:
@@ -100,7 +106,12 @@ def benchmark(
 
     if output:
         out_path = Path(output)
-        out_path.write_text(content)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            out_path.write_text(content)
+        except (PermissionError, OSError) as exc:
+            click.echo(f"Error writing report: {exc}", err=True)
+            raise SystemExit(1) from None
         click.echo(f"Report saved to {out_path}")
     else:
         click.echo(content)

--- a/tests/unit/cli/test_benchmark_cmd.py
+++ b/tests/unit/cli/test_benchmark_cmd.py
@@ -1,0 +1,51 @@
+"""Tests for the hckg benchmark CLI command."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+
+class TestBenchmarkHelp:
+    def test_help_shows_options(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["benchmark", "--help"])
+        assert result.exit_code == 0
+        assert "--profiles" in result.output
+        assert "--scales" in result.output
+        assert "--full" in result.output
+
+
+class TestBenchmarkValidation:
+    def test_invalid_scale_string(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["benchmark", "--scales", "abc"])
+        assert result.exit_code != 0
+        assert "Invalid scale" in result.output or "comma-separated integers" in result.output
+
+    def test_mixed_valid_invalid_scales(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["benchmark", "--scales", "100,abc,500"])
+        assert result.exit_code != 0
+
+    def test_invalid_profile(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["benchmark", "--profiles", "invalid"])
+        assert result.exit_code != 0
+        assert "Unknown profile" in result.output
+
+
+class TestBenchmarkRuns:
+    def test_default_run(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["benchmark", "--scales", "10"])
+        assert result.exit_code == 0
+        assert "Completed" in result.output
+
+    def test_output_creates_parent_dirs(self, tmp_path):
+        output = tmp_path / "a" / "b" / "report.md"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["benchmark", "--scales", "10", "--output", str(output)])
+        assert result.exit_code == 0
+        assert output.exists()


### PR DESCRIPTION
## Summary
- Wrap scale parsing in try/except ValueError with click.BadParameter
- Validate output parent directory, catch write errors
- Add 6 tests: help, invalid scales, invalid profile, default run, output dir

Fixes #213