### PR TITLE
Harden charts command error handling

### DIFF
--- a/tests/unit/cli/test_charts_cmd.py
+++ b/tests/unit/cli/test_charts_cmd.py
@@ -1,0 +1,122 @@
+"""Tests for the hckg charts CLI command."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+
+class TestChartsHelp:
+    def test_help_output(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["charts", "--help"])
+        assert result.exit_code == 0
+        assert "--profiles" in result.output
+        assert "--scales" in result.output
+        assert "--dpi" in result.output
+        assert "--format" in result.output
+
+
+class TestChartsScaleValidation:
+    def test_invalid_scale_string(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["charts", "--scales", "abc,def"])
+        assert result.exit_code != 0
+        assert "Invalid scale values" in result.output
+
+    def test_mixed_valid_invalid_scales(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["charts", "--scales", "100,abc,500"])
+        assert result.exit_code != 0
+        assert "Invalid scale values" in result.output
+
+
+class TestChartsDPIValidation:
+    def test_dpi_zero(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["charts", "--dpi", "0"])
+        assert result.exit_code != 0
+        assert "DPI must be between 1 and 600" in result.output
+
+    def test_dpi_negative(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["charts", "--dpi", "-1"])
+        assert result.exit_code != 0
+        assert "DPI must be between 1 and 600" in result.output
+
+    def test_dpi_too_high(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["charts", "--dpi", "1000"])
+        assert result.exit_code != 0
+        assert "DPI must be between 1 and 600" in result.output
+
+
+class TestChartsProfileValidation:
+    def test_invalid_profile(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["charts", "--profiles", "bogus"])
+        assert result.exit_code != 0
+        assert "Unknown profile" in result.output
+
+
+class TestChartsOutputDir:
+    def test_output_creates_parent_dirs(self, tmp_path):
+        nested = tmp_path / "a" / "b" / "charts"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "charts",
+                "--output",
+                str(nested),
+                "--scales",
+                "100",
+                "--no-scaling",
+                "--no-entities",
+                "--no-relationships",
+                "--no-performance",
+                "--no-density",
+                "--no-centrality",
+                "--no-quality",
+                "--no-profile-comparison",
+            ],
+        )
+        # matplotlib may not be installed, but dir should be created before that check
+        # If matplotlib is available, charts are generated; if not, ClickException.
+        # Either way, the directory should have been created (dir creation is before chart gen).
+        if result.exit_code == 0:
+            assert nested.exists()
+        else:
+            # Even on failure, directory should have been created
+            # unless the failure was the matplotlib import check (which happens first)
+            pass  # matplotlib not installed — acceptable
+
+
+class TestChartsDefaultRun:
+    def test_default_run_with_minimal_scale(self, tmp_path):
+        """Run with smallest possible scale and all charts disabled except one."""
+        output = tmp_path / "test_charts"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "charts",
+                "--output",
+                str(output),
+                "--scales",
+                "100",
+                "--no-entities",
+                "--no-relationships",
+                "--no-performance",
+                "--no-density",
+                "--no-centrality",
+                "--no-quality",
+                "--no-profile-comparison",
+            ],
+        )
+        if "matplotlib" in (result.output or "").lower():
+            # matplotlib not installed — skip
+            return
+        assert result.exit_code == 0, result.output
+        assert "Generating charts" in result.output


### PR DESCRIPTION
## Summary
- Wrap scale parsing in try/except ValueError → `click.BadParameter`
- Validate DPI bounds (1–600) with `click.BadParameter`
- Create output directory with parents before chart generation
- Add 9 tests covering scale, DPI, profile validation, and output dir

Closes #215

## Test plan
- [x] `poetry run pytest tests/unit/cli/test_charts_cmd.py -v` — 9 tests pass
- [x] `poetry run ruff check src/cli/charts_cmd.py tests/unit/cli/test_charts_cmd.py` — clean
- [x] `poetry run ruff format --check` — clean