### PR TITLE
demo/generate: auto-update Claude Desktop config on graph export

### DIFF
--- a/src/cli/demo_cmd.py
+++ b/src/cli/demo_cmd.py
@@ -107,6 +107,12 @@ def demo(
         click.echo(f"Error writing output file: {exc}", err=True)
         raise SystemExit(1) from None
 
+    # Sync Claude Desktop config if registered
+    from cli.install_cmd import sync_claude_graph_path
+
+    if sync_claude_graph_path(output_path):
+        click.echo(f"Claude Desktop config updated: {output_path.resolve()}")
+
     # Print summary
     stats = kg.statistics
     click.echo("")

--- a/src/cli/generate.py
+++ b/src/cli/generate.py
@@ -99,3 +99,9 @@ def org(
         click.echo(f"Error writing output file: {exc}", err=True)
         raise SystemExit(1) from None
     click.echo(f"\nExported to {output}")
+
+    # Sync Claude Desktop config if registered
+    from cli.install_cmd import sync_claude_graph_path
+
+    if sync_claude_graph_path(output_path):
+        click.echo(f"Claude Desktop config updated: {output_path.resolve()}")

--- a/tests/unit/cli/test_demo_cmd.py
+++ b/tests/unit/cli/test_demo_cmd.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import json
+from typing import TYPE_CHECKING
 from unittest.mock import patch
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 from click.testing import CliRunner
 
@@ -100,3 +105,45 @@ class TestDemoGeneration:
         )
         assert result.exit_code == 0
         assert output.exists()
+
+
+class TestDemoClaudeSync:
+    def test_syncs_claude_config_when_registered(self, tmp_path: Path):
+        """Demo updates Claude Desktop config with new graph path."""
+        config_path = tmp_path / "claude_config.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "hc-enterprise-kg": {
+                            "command": "python",
+                            "args": ["-m", "mcp_server.server"],
+                            "env": {"HCKG_DEFAULT_GRAPH": "/old/graph.json"},
+                        }
+                    }
+                }
+            )
+        )
+        output = tmp_path / "graph.json"
+        with patch("cli.install_cmd._detect_claude_config_path", return_value=config_path):
+            result = CliRunner().invoke(
+                cli, ["demo", "--employees", "10", "--output", str(output)]
+            )
+        assert result.exit_code == 0, result.output
+        assert "Claude Desktop config updated" in result.output
+        config = json.loads(config_path.read_text())
+        assert config["mcpServers"]["hc-enterprise-kg"]["env"]["HCKG_DEFAULT_GRAPH"] == str(
+            output.resolve()
+        )
+
+    def test_no_sync_when_not_registered(self, tmp_path: Path):
+        """Demo does not crash or print sync message when not registered."""
+        config_path = tmp_path / "claude_config.json"
+        config_path.write_text(json.dumps({"mcpServers": {}}))
+        output = tmp_path / "graph.json"
+        with patch("cli.install_cmd._detect_claude_config_path", return_value=config_path):
+            result = CliRunner().invoke(
+                cli, ["demo", "--employees", "10", "--output", str(output)]
+            )
+        assert result.exit_code == 0, result.output
+        assert "Claude Desktop config updated" not in result.output


### PR DESCRIPTION
## Summary
- After graph export, `demo` and `generate` commands auto-update Claude Desktop's `HCKG_DEFAULT_GRAPH` if registered
- No re-install or restart needed when regenerating graphs
- New `sync_claude_graph_path()` helper in install_cmd.py, called from both commands
- Silent no-op when Claude Desktop is not registered

Closes #221

## Test plan
- [x] 6 unit tests for `sync_claude_graph_path()` — update, not registered, missing config, preserves other env vars
- [x] 2 demo integration tests — syncs when registered, no-op when not
- [x] 2 generate integration tests — same
- [x] 876 tests pass, ruff clean