### PR TITLE
feat: hckg import CLI command with pre-ingest validation

### DIFF
--- a/src/cli/import_cmd.py
+++ b/src/cli/import_cmd.py
@@ -1,0 +1,373 @@
+"""Import real organizational data into the knowledge graph."""
+
+from __future__ import annotations
+
+import click
+
+
+@click.command("import")
+@click.argument("source", type=click.Path(exists=True))
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(),
+    default="graph.json",
+    help="Output graph file path.",
+    show_default=True,
+)
+@click.option(
+    "-t",
+    "--entity-type",
+    "entity_type_str",
+    type=str,
+    default=None,
+    help="Entity type for CSV import (auto-detected if omitted).",
+)
+@click.option(
+    "-m",
+    "--merge",
+    "merge_path",
+    type=click.Path(exists=True),
+    default=None,
+    help="Merge into an existing graph file.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Validate only, do not write output.",
+)
+@click.option(
+    "--strict",
+    is_flag=True,
+    default=False,
+    help="Treat warnings as errors.",
+)
+@click.pass_context
+def import_cmd(
+    ctx: click.Context,
+    source: str,
+    output: str,
+    entity_type_str: str | None,
+    merge_path: str | None,
+    dry_run: bool,
+    strict: bool,
+) -> None:
+    """Import JSON or CSV data into the knowledge graph.
+
+    Validates data before importing and reports any issues.
+    Supports merging into an existing graph.
+
+    \b
+    Examples:
+        hckg import org-data.json -o graph.json
+        hckg import employees.csv -t person -o graph.json
+        hckg import systems.csv -t system -m existing.json -o combined.json
+        hckg import data.json --dry-run --strict
+    """
+    from pathlib import Path
+
+    source_path = Path(source)
+    ext = source_path.suffix.lower()
+
+    if ext == ".json":
+        _import_json(ctx, source_path, output, merge_path, dry_run, strict)
+    elif ext == ".csv":
+        _import_csv(
+            ctx, source_path, output, entity_type_str, merge_path, dry_run, strict
+        )
+    else:
+        click.echo(
+            f"Error: unsupported file format '{ext}'. Use .json or .csv.",
+            err=True,
+        )
+        raise SystemExit(1) from None
+
+
+def _import_json(
+    ctx: click.Context,
+    source_path: object,
+    output: str,
+    merge_path: str | None,
+    dry_run: bool,
+    strict: bool,
+) -> None:
+    """Handle JSON import path."""
+    import json
+    from pathlib import Path
+
+    source_path = Path(source_path)  # type: ignore[arg-type]
+
+    click.echo(f"Importing {source_path.name}...")
+    click.echo()
+
+    # Parse JSON
+    try:
+        with open(source_path) as f:
+            data = json.load(f)
+    except json.JSONDecodeError as exc:
+        click.echo(f"Error: invalid JSON in {source_path.name}: {exc}", err=True)
+        raise SystemExit(1) from None
+    except UnicodeDecodeError:
+        click.echo(
+            f"Error: {source_path.name} contains invalid encoding. Expected UTF-8.",
+            err=True,
+        )
+        raise SystemExit(1) from None
+
+    if not isinstance(data, dict):
+        click.echo("Error: JSON root must be an object with 'entities' key.", err=True)
+        raise SystemExit(1) from None
+
+    # Validate
+    from ingest.validator import validate_json_import
+
+    vr = validate_json_import(data)
+    _display_validation(vr)
+
+    if not vr.is_valid:
+        click.echo("Import aborted due to validation errors.", err=True)
+        raise SystemExit(1) from None
+    if strict and vr.warnings:
+        click.echo("Import aborted: --strict mode and warnings present.", err=True)
+        raise SystemExit(1) from None
+    if dry_run:
+        click.echo("Dry run complete. No output written.")
+        return
+
+    # Ingest
+    from graph.knowledge_graph import KnowledgeGraph
+    from ingest.json_ingestor import JSONIngestor
+
+    backend = ctx.obj.get("backend", "networkx") if ctx.obj else "networkx"
+    kg = KnowledgeGraph(backend=backend)
+
+    # Merge existing graph if requested
+    if merge_path:
+        _merge_existing(kg, merge_path)
+
+    ingestor = JSONIngestor()
+    result = ingestor.ingest(source_path)
+    if not result.entities and result.errors:
+        click.echo(f"Error: could not ingest {source_path.name}", err=True)
+        for err in result.errors[:5]:
+            click.echo(f"  {err}", err=True)
+        raise SystemExit(1) from None
+
+    kg.add_entities_bulk(result.entities)
+    kg.add_relationships_bulk(result.relationships)
+
+    # Export
+    _export_graph(kg, output, vr)
+
+
+def _import_csv(
+    ctx: click.Context,
+    source_path: object,
+    output: str,
+    entity_type_str: str | None,
+    merge_path: str | None,
+    dry_run: bool,
+    strict: bool,
+) -> None:
+    """Handle CSV import path."""
+    import csv
+    from pathlib import Path
+
+    from domain.base import EntityType
+
+    source_path = Path(source_path)  # type: ignore[arg-type]
+
+    click.echo(f"Importing {source_path.name}...")
+    click.echo()
+
+    # Read headers
+    try:
+        with open(source_path, newline="") as f:
+            reader = csv.reader(f)
+            try:
+                headers = next(reader)
+            except StopIteration:
+                click.echo(f"Error: {source_path.name} is empty.", err=True)
+                raise SystemExit(1) from None
+    except UnicodeDecodeError:
+        click.echo(
+            f"Error: {source_path.name} contains invalid encoding. Expected UTF-8.",
+            err=True,
+        )
+        raise SystemExit(1) from None
+
+    # Determine entity type
+    if entity_type_str:
+        try:
+            entity_type = EntityType(entity_type_str)
+        except ValueError:
+            valid = sorted(e.value for e in EntityType)
+            click.echo(
+                f"Error: unknown entity type '{entity_type_str}'.\n"
+                f"Valid types: {', '.join(valid)}",
+                err=True,
+            )
+            raise SystemExit(1) from None
+    else:
+        from auto.schema_inference import infer_entity_type
+
+        entity_type = infer_entity_type(headers)
+        if entity_type is None:
+            valid = sorted(e.value for e in EntityType)
+            click.echo(
+                f"Error: could not auto-detect entity type from CSV columns.\n"
+                f"Use --entity-type to specify. Valid types: {', '.join(valid)}",
+                err=True,
+            )
+            raise SystemExit(1) from None
+        click.echo(f"  Auto-detected entity type: {entity_type.value}")
+
+    # Validate columns
+    from ingest.validator import validate_csv_import
+
+    vr = validate_csv_import(headers, entity_type)
+    _display_validation(vr)
+
+    if not vr.is_valid:
+        click.echo("Import aborted due to validation errors.", err=True)
+        raise SystemExit(1) from None
+    if strict and vr.warnings:
+        click.echo("Import aborted: --strict mode and warnings present.", err=True)
+        raise SystemExit(1) from None
+    if dry_run:
+        click.echo("Dry run complete. No output written.")
+        return
+
+    # Ingest
+    from graph.knowledge_graph import KnowledgeGraph
+    from ingest.csv_ingestor import CSVIngestor
+
+    backend = ctx.obj.get("backend", "networkx") if ctx.obj else "networkx"
+    kg = KnowledgeGraph(backend=backend)
+
+    if merge_path:
+        _merge_existing(kg, merge_path)
+
+    ingestor = CSVIngestor()
+    result = ingestor.ingest(source_path, entity_type=entity_type)
+    if not result.entities and result.errors:
+        click.echo(f"Error: could not ingest {source_path.name}", err=True)
+        for err in result.errors[:5]:
+            click.echo(f"  {err}", err=True)
+        raise SystemExit(1) from None
+
+    kg.add_entities_bulk(result.entities)
+    kg.add_relationships_bulk(result.relationships)
+
+    # Update validation counts from actual ingest
+    vr.entity_count = result.entity_count
+    vr.relationship_count = result.relationship_count
+    vr.entity_type_counts = {entity_type.value: result.entity_count}
+    vr.relationship_type_counts = {}
+
+    _export_graph(kg, output, vr)
+
+
+def _merge_existing(kg: object, merge_path: str) -> None:
+    """Load an existing graph file and add its data to the KG."""
+    from pathlib import Path
+
+    from ingest.json_ingestor import JSONIngestor
+
+    click.echo(f"  Merging with existing graph: {merge_path}")
+    ingestor = JSONIngestor()
+    result = ingestor.ingest(Path(merge_path))
+    if not result.entities and result.errors:
+        click.echo(f"Error: could not load merge file {merge_path}", err=True)
+        for err in result.errors[:5]:
+            click.echo(f"  {err}", err=True)
+        raise SystemExit(1) from None
+
+    kg.add_entities_bulk(result.entities)  # type: ignore[attr-defined]
+    kg.add_relationships_bulk(result.relationships)  # type: ignore[attr-defined]
+    click.echo(
+        f"  Loaded {result.entity_count} entities, "
+        f"{result.relationship_count} relationships from merge file"
+    )
+
+
+def _display_validation(vr: object) -> None:
+    """Display validation results to the user."""
+    from ingest.validator import ValidationResult
+
+    if not isinstance(vr, ValidationResult):  # pragma: no cover
+        return
+
+    click.echo("Validation")
+    if vr.entity_count:
+        click.echo(f"  {vr.entity_count} entities validated")
+    if vr.relationship_count:
+        click.echo(f"  {vr.relationship_count} relationships validated")
+
+    if vr.errors:
+        click.echo(f"  {len(vr.errors)} error(s):")
+        for err in vr.errors:
+            click.echo(f"    {err}")
+
+    if vr.warnings:
+        click.echo(f"  {len(vr.warnings)} warning(s):")
+        for warn in vr.warnings:
+            click.echo(f"    {warn}")
+
+    if not vr.errors and not vr.warnings:
+        click.echo("  No issues found")
+
+    click.echo()
+
+
+def _display_summary(vr: object) -> None:
+    """Display import summary."""
+    from ingest.validator import ValidationResult
+
+    if not isinstance(vr, ValidationResult):  # pragma: no cover
+        return
+
+    click.echo("Import Summary")
+    if vr.entity_type_counts:
+        total = sum(vr.entity_type_counts.values())
+        click.echo(f"  Entities:        {total:>5}")
+        for etype, count in sorted(vr.entity_type_counts.items()):
+            click.echo(f"    {etype:20s} {count:>5}")
+    if vr.relationship_type_counts:
+        total = sum(vr.relationship_type_counts.values())
+        click.echo(f"  Relationships:   {total:>5}")
+        for rtype, count in sorted(vr.relationship_type_counts.items()):
+            click.echo(f"    {rtype:20s} {count:>5}")
+
+
+def _export_graph(kg: object, output: str, vr: object) -> None:
+    """Export the knowledge graph to a file."""
+    from pathlib import Path
+
+    from export.json_export import JSONExporter
+
+    output_path = Path(output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        JSONExporter().export(kg.engine, output_path)  # type: ignore[attr-defined]
+    except PermissionError:
+        click.echo(f"Error: permission denied writing to {output_path}", err=True)
+        raise SystemExit(1) from None
+    except OSError as exc:
+        click.echo(f"Error writing output file: {exc}", err=True)
+        raise SystemExit(1) from None
+
+    _display_summary(vr)
+    click.echo()
+    click.echo(f"Output: {output_path}")
+
+    # Sync Claude Desktop config if registered
+    try:
+        from cli.install_cmd import sync_claude_graph_path
+
+        if sync_claude_graph_path(output_path):
+            click.echo(f"Claude Desktop config updated: {output_path.resolve()}")
+    except Exception:  # noqa: S110
+        pass  # sync is best-effort

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -22,6 +22,7 @@ from cli.charts_cmd import charts  # noqa: E402
 from cli.demo_cmd import demo  # noqa: E402
 from cli.export_cmd import export_cmd  # noqa: E402
 from cli.generate import generate  # noqa: E402
+from cli.import_cmd import import_cmd  # noqa: E402
 from cli.inspect_cmd import inspect_cmd  # noqa: E402
 from cli.install_cmd import install_group  # noqa: E402
 from cli.serve_cmd import serve_cmd  # noqa: E402
@@ -33,6 +34,7 @@ cli.add_command(demo)
 cli.add_command(generate)
 cli.add_command(auto)
 cli.add_command(export_cmd, name="export")
+cli.add_command(import_cmd, name="import")
 cli.add_command(inspect_cmd, name="inspect")
 cli.add_command(visualize_cmd, name="visualize")
 cli.add_command(serve_cmd, name="serve")

--- a/src/ingest/__init__.py
+++ b/src/ingest/__init__.py
@@ -3,5 +3,14 @@
 from ingest.base import AbstractIngestor, IngestResult
 from ingest.csv_ingestor import CSVIngestor
 from ingest.json_ingestor import JSONIngestor
+from ingest.validator import ValidationResult, validate_csv_import, validate_json_import
 
-__all__ = ["AbstractIngestor", "CSVIngestor", "IngestResult", "JSONIngestor"]
+__all__ = [
+    "AbstractIngestor",
+    "CSVIngestor",
+    "IngestResult",
+    "JSONIngestor",
+    "ValidationResult",
+    "validate_csv_import",
+    "validate_json_import",
+]

--- a/src/ingest/validator.py
+++ b/src/ingest/validator.py
@@ -1,0 +1,215 @@
+"""Pre-ingest validation for import data quality."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from domain.base import EntityType
+
+
+@dataclass
+class ValidationResult:
+    """Result of pre-ingest validation."""
+
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    entity_count: int = 0
+    relationship_count: int = 0
+    entity_type_counts: dict[str, int] = field(default_factory=dict)
+    relationship_type_counts: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.errors) == 0
+
+
+def _get_known_fields(entity_type: EntityType) -> set[str]:
+    """Get the set of known field names for an entity type."""
+    from domain.registry import EntityRegistry
+
+    EntityRegistry.auto_discover()
+    entity_class = EntityRegistry.get(entity_type)
+    return set(entity_class.model_fields.keys())
+
+
+def _check_entity_required_fields(
+    raw: dict[str, Any],
+    entity_type_str: str,
+    index: int,
+    errors: list[str],
+) -> None:
+    """Check entity-specific required fields."""
+    name = raw.get("name")
+    if not name or (isinstance(name, str) and not name.strip()):
+        errors.append(f"Entity {index}: missing or empty 'name'")
+
+    if entity_type_str == "person":
+        for req in ("first_name", "last_name", "email"):
+            if req not in raw or not raw[req]:
+                errors.append(
+                    f"Entity {index} ({raw.get('name', '?')}): "
+                    f"missing required field '{req}'"
+                )
+
+
+def validate_json_import(data: dict[str, Any]) -> ValidationResult:
+    """Validate JSON import data before ingestion.
+
+    Checks structure, entity types, required fields, unknown fields,
+    relationship validity, and referential integrity.
+    """
+    from domain.base import EntityType, RelationshipType
+
+    result = ValidationResult()
+
+    # --- Structure checks ---
+    entities_raw = data.get("entities")
+    if entities_raw is None:
+        result.errors.append("Missing 'entities' key in JSON data")
+        return result
+    if not isinstance(entities_raw, list):
+        result.errors.append("'entities' must be a list")
+        return result
+
+    relationships_raw = data.get("relationships", [])
+    if not isinstance(relationships_raw, list):
+        result.errors.append("'relationships' must be a list")
+        relationships_raw = []
+
+    # --- Entity validation ---
+    entity_ids: set[str] = set()
+    valid_et_values = {e.value for e in EntityType}
+
+    for i, raw in enumerate(entities_raw):
+        if not isinstance(raw, dict):
+            result.errors.append(f"Entity {i}: must be a dict, got {type(raw).__name__}")
+            continue
+
+        # entity_type check
+        et_str = raw.get("entity_type")
+        if not et_str:
+            result.errors.append(f"Entity {i}: missing 'entity_type'")
+            continue
+        if et_str not in valid_et_values:
+            result.errors.append(
+                f"Entity {i} ({raw.get('name', '?')}): "
+                f"invalid entity_type '{et_str}'"
+            )
+            continue
+
+        # Required fields
+        _check_entity_required_fields(raw, et_str, i, result.errors)
+
+        # Track entity ID
+        eid = raw.get("id")
+        if eid:
+            entity_ids.add(eid)
+
+        # Count by type
+        result.entity_type_counts[et_str] = result.entity_type_counts.get(et_str, 0) + 1
+        result.entity_count += 1
+
+        # Unknown field detection
+        try:
+            et = EntityType(et_str)
+            known = _get_known_fields(et)
+            provided = set(raw.keys())
+            unknown = provided - known
+            if unknown:
+                result.warnings.append(
+                    f"Entity {i} ({raw.get('name', '?')}): "
+                    f"unknown field(s) {sorted(unknown)} "
+                    f"(not in {et_str} schema)"
+                )
+        except (ValueError, KeyError):
+            pass  # Already reported as invalid entity_type
+
+    # --- Relationship validation ---
+    valid_rt_values = {r.value for r in RelationshipType}
+
+    for i, raw in enumerate(relationships_raw):
+        if not isinstance(raw, dict):
+            result.errors.append(
+                f"Relationship {i}: must be a dict, got {type(raw).__name__}"
+            )
+            continue
+
+        rt_str = raw.get("relationship_type")
+        if not rt_str:
+            result.errors.append(f"Relationship {i}: missing 'relationship_type'")
+            continue
+        if rt_str not in valid_rt_values:
+            result.errors.append(
+                f"Relationship {i}: invalid relationship_type '{rt_str}'"
+            )
+            continue
+
+        source_id = raw.get("source_id")
+        target_id = raw.get("target_id")
+        if not source_id:
+            result.errors.append(f"Relationship {i}: missing 'source_id'")
+        if not target_id:
+            result.errors.append(f"Relationship {i}: missing 'target_id'")
+
+        # Referential integrity (warnings, not errors — merge target may have them)
+        if source_id and entity_ids and source_id not in entity_ids:
+            result.warnings.append(
+                f"Relationship {i}: source_id '{source_id}' "
+                f"not found in imported entities"
+            )
+        if target_id and entity_ids and target_id not in entity_ids:
+            result.warnings.append(
+                f"Relationship {i}: target_id '{target_id}' "
+                f"not found in imported entities"
+            )
+
+        # Count by type
+        result.relationship_type_counts[rt_str] = (
+            result.relationship_type_counts.get(rt_str, 0) + 1
+        )
+        result.relationship_count += 1
+
+    return result
+
+
+def validate_csv_import(
+    headers: list[str],
+    entity_type: EntityType,
+) -> ValidationResult:
+    """Validate CSV column names against entity model fields.
+
+    Checks that headers are non-empty, flags unknown columns,
+    and verifies entity-specific required fields are present.
+    """
+    result = ValidationResult()
+
+    if not headers:
+        result.errors.append("CSV has no column headers")
+        return result
+
+    known = _get_known_fields(entity_type)
+    header_set = set(headers)
+
+    # Unknown columns
+    unknown = header_set - known
+    if unknown:
+        result.warnings.append(
+            f"Unknown column(s) for {entity_type.value}: {sorted(unknown)} "
+            f"(will be stored as extra fields)"
+        )
+
+    # Entity-specific required fields
+    if entity_type.value == "person":
+        for req in ("first_name", "last_name", "email"):
+            if req not in header_set:
+                result.errors.append(
+                    f"CSV missing required column '{req}' for person import"
+                )
+
+    # Summary
+    result.entity_count = 0  # Can't know row count from headers alone
+    result.entity_type_counts[entity_type.value] = 0
+
+    return result

--- a/tests/unit/cli/test_import_cmd.py
+++ b/tests/unit/cli/test_import_cmd.py
@@ -1,0 +1,310 @@
+"""Tests for the hckg import CLI command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from cli.main import cli
+
+SAMPLE_ENTITIES_JSON = Path(__file__).parent.parent.parent / "fixtures" / "sample_entities.json"
+SAMPLE_ORG_CSV = Path(__file__).parent.parent.parent / "fixtures" / "sample_org.csv"
+
+
+def _minimal_json(tmp_path: Path) -> Path:
+    """Create a minimal valid JSON import file."""
+    data = {
+        "entities": [
+            {"entity_type": "department", "name": "Engineering", "code": "ENG"},
+            {"entity_type": "department", "name": "Marketing", "code": "MKT"},
+        ],
+        "relationships": [],
+    }
+    path = tmp_path / "minimal.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+def _minimal_csv(tmp_path: Path) -> Path:
+    """Create a minimal valid CSV for system import."""
+    path = tmp_path / "systems.csv"
+    path.write_text(
+        "name,system_type,hostname,ip_address\n"
+        "Web Server,application,web-01,10.0.1.1\n"
+        "DB Server,database,db-01,10.0.1.2\n"
+    )
+    return path
+
+
+def _make_graph_file(tmp_path: Path) -> Path:
+    """Create a small graph JSON file for merge tests."""
+    from export.json_export import JSONExporter
+    from graph.knowledge_graph import KnowledgeGraph
+    from synthetic.orchestrator import SyntheticOrchestrator
+    from synthetic.profiles.tech_company import mid_size_tech_company
+
+    kg = KnowledgeGraph()
+    profile = mid_size_tech_company(10)
+    SyntheticOrchestrator(kg, profile, seed=42).generate()
+    path = tmp_path / "existing.json"
+    JSONExporter().export(kg.engine, path)
+    return path
+
+
+class TestImportHelp:
+    def test_help_shows_options(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", "--help"])
+        assert result.exit_code == 0
+        assert "--output" in result.output
+        assert "--entity-type" in result.output
+        assert "--merge" in result.output
+        assert "--dry-run" in result.output
+        assert "--strict" in result.output
+        assert "SOURCE" in result.output
+
+
+class TestImportJsonValid:
+    def test_import_minimal_json(self, tmp_path: Path) -> None:
+        src = _minimal_json(tmp_path)
+        out = tmp_path / "result.json"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", str(src), "-o", str(out)])
+        assert result.exit_code == 0
+        assert out.exists()
+        assert "2 entities validated" in result.output
+
+    def test_import_sample_entities_json(self, tmp_path: Path) -> None:
+        out = tmp_path / "result.json"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", str(SAMPLE_ENTITIES_JSON), "-o", str(out)])
+        assert result.exit_code == 0
+        assert out.exists()
+        assert "Import Summary" in result.output
+
+    def test_output_contains_summary(self, tmp_path: Path) -> None:
+        src = _minimal_json(tmp_path)
+        out = tmp_path / "result.json"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", str(src), "-o", str(out)])
+        assert result.exit_code == 0
+        assert "department" in result.output
+        assert "Output:" in result.output
+
+
+class TestImportJsonErrors:
+    def test_malformed_json(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.json"
+        bad.write_text("not json {{{")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", str(bad)])
+        assert result.exit_code != 0
+        assert "invalid JSON" in result.output.lower() or "invalid json" in (result.output + str(result.exception or "")).lower()
+
+    def test_missing_entities_key(self, tmp_path: Path) -> None:
+        src = tmp_path / "no_entities.json"
+        src.write_text('{"relationships": []}')
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", str(src)])
+        assert result.exit_code != 0
+
+    def test_empty_json_file(self, tmp_path: Path) -> None:
+        src = tmp_path / "empty.json"
+        src.write_text("{}")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", str(src)])
+        assert result.exit_code != 0
+
+    def test_invalid_entity_type(self, tmp_path: Path) -> None:
+        src = tmp_path / "bad_type.json"
+        src.write_text(json.dumps({
+            "entities": [{"entity_type": "bogus", "name": "Test"}]
+        }))
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", str(src)])
+        assert result.exit_code != 0
+        assert "bogus" in result.output
+
+
+class TestImportCsvValid:
+    def test_import_csv_with_auto_detection(self, tmp_path: Path) -> None:
+        out = tmp_path / "result.json"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", str(SAMPLE_ORG_CSV), "-o", str(out)])
+        assert result.exit_code == 0
+        assert out.exists()
+        assert "Auto-detected" in result.output
+
+    def test_import_csv_with_entity_type(self, tmp_path: Path) -> None:
+        src = _minimal_csv(tmp_path)
+        out = tmp_path / "result.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["import", str(src), "-t", "system", "-o", str(out)]
+        )
+        assert result.exit_code == 0
+        assert out.exists()
+
+
+class TestImportCsvErrors:
+    def test_invalid_entity_type(self, tmp_path: Path) -> None:
+        src = _minimal_csv(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", str(src), "-t", "bogus_type"])
+        assert result.exit_code != 0
+        assert "bogus_type" in result.output
+
+    def test_no_detection_unrecognizable_csv(self, tmp_path: Path) -> None:
+        src = tmp_path / "weird.csv"
+        src.write_text("col_a,col_b,col_c\n1,2,3\n")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", str(src)])
+        assert result.exit_code != 0
+        assert "could not auto-detect" in result.output.lower()
+
+    def test_empty_csv(self, tmp_path: Path) -> None:
+        src = tmp_path / "empty.csv"
+        src.write_text("")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", str(src)])
+        assert result.exit_code != 0
+
+
+class TestImportDryRun:
+    def test_dry_run_validates_only(self, tmp_path: Path) -> None:
+        src = _minimal_json(tmp_path)
+        out = tmp_path / "should_not_exist.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["import", str(src), "-o", str(out), "--dry-run"]
+        )
+        assert result.exit_code == 0
+        assert not out.exists()
+        assert "Dry run complete" in result.output
+
+    def test_dry_run_csv(self, tmp_path: Path) -> None:
+        out = tmp_path / "nope.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["import", str(SAMPLE_ORG_CSV), "-o", str(out), "--dry-run"]
+        )
+        assert result.exit_code == 0
+        assert not out.exists()
+
+
+class TestImportStrict:
+    def test_strict_fails_on_warnings(self, tmp_path: Path) -> None:
+        src = tmp_path / "with_typo.json"
+        src.write_text(json.dumps({
+            "entities": [
+                {
+                    "entity_type": "department",
+                    "name": "Eng",
+                    "typo_field": "oops",
+                }
+            ]
+        }))
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", str(src), "--strict"])
+        assert result.exit_code != 0
+        assert "strict" in result.output.lower()
+
+    def test_no_warnings_passes_strict(self, tmp_path: Path) -> None:
+        src = _minimal_json(tmp_path)
+        out = tmp_path / "result.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["import", str(src), "-o", str(out), "--strict"]
+        )
+        assert result.exit_code == 0
+        assert out.exists()
+
+
+class TestImportMerge:
+    def test_merge_into_existing(self, tmp_path: Path) -> None:
+        existing = _make_graph_file(tmp_path)
+        new_data = _minimal_json(tmp_path)
+        out = tmp_path / "merged.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["import", str(new_data), "-m", str(existing), "-o", str(out)],
+        )
+        assert result.exit_code == 0
+        assert out.exists()
+        assert "Merging" in result.output
+
+        # Verify merged graph has more entities than the new data alone
+        with open(out) as f:
+            merged = json.load(f)
+        assert len(merged["entities"]) > 2  # more than the 2 departments we added
+
+
+class TestImportOutput:
+    def test_creates_parent_dirs(self, tmp_path: Path) -> None:
+        src = _minimal_json(tmp_path)
+        nested = tmp_path / "a" / "b" / "result.json"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", str(src), "-o", str(nested)])
+        assert result.exit_code == 0
+        assert nested.exists()
+
+    def test_permission_error(self, tmp_path: Path) -> None:
+        src = _minimal_json(tmp_path)
+        with patch(
+            "export.json_export.JSONExporter.export",
+            side_effect=PermissionError("denied"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["import", str(src), "-o", str(tmp_path / "out.json")]
+            )
+            assert result.exit_code != 0
+            assert "permission denied" in result.output.lower()
+
+
+class TestImportClaudeSync:
+    def test_sync_called_on_success(self, tmp_path: Path) -> None:
+        src = _minimal_json(tmp_path)
+        out = tmp_path / "result.json"
+        with patch("cli.install_cmd.sync_claude_graph_path", return_value=True) as mock_sync:
+            runner = CliRunner()
+            result = runner.invoke(cli, ["import", str(src), "-o", str(out)])
+            assert result.exit_code == 0
+            mock_sync.assert_called_once()
+
+
+class TestImportEdgeCases:
+    def test_unsupported_format(self, tmp_path: Path) -> None:
+        src = tmp_path / "data.xml"
+        src.write_text("<root/>")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", str(src)])
+        assert result.exit_code != 0
+        assert "unsupported file format" in result.output.lower()
+
+    def test_file_not_found(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", "/nonexistent/file.json"])
+        assert result.exit_code != 0
+
+    def test_default_output_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Default output is graph.json in current directory."""
+        monkeypatch.chdir(tmp_path)
+        src = _minimal_json(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", str(src)])
+        assert result.exit_code == 0
+        assert (tmp_path / "graph.json").exists()
+
+    def test_json_root_not_object(self, tmp_path: Path) -> None:
+        src = tmp_path / "array.json"
+        src.write_text("[1, 2, 3]")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["import", str(src)])
+        assert result.exit_code != 0
+        assert "object" in result.output.lower()

--- a/tests/unit/ingest/test_validator.py
+++ b/tests/unit/ingest/test_validator.py
@@ -1,0 +1,307 @@
+"""Tests for pre-ingest validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.base import EntityType
+from ingest.validator import ValidationResult, validate_csv_import, validate_json_import
+
+
+class TestValidationResult:
+    def test_is_valid_no_errors(self) -> None:
+        vr = ValidationResult()
+        assert vr.is_valid is True
+
+    def test_is_valid_with_errors(self) -> None:
+        vr = ValidationResult(errors=["some error"])
+        assert vr.is_valid is False
+
+    def test_warnings_dont_invalidate(self) -> None:
+        vr = ValidationResult(warnings=["some warning"])
+        assert vr.is_valid is True
+
+
+class TestValidateJsonImport:
+    def test_valid_data(self) -> None:
+        data = {
+            "entities": [
+                {
+                    "entity_type": "department",
+                    "name": "Engineering",
+                    "code": "ENG",
+                }
+            ],
+            "relationships": [],
+        }
+        vr = validate_json_import(data)
+        assert vr.is_valid
+        assert vr.entity_count == 1
+        assert vr.entity_type_counts == {"department": 1}
+        assert not vr.errors
+        assert not vr.warnings
+
+    def test_valid_data_with_relationships(self) -> None:
+        data = {
+            "entities": [
+                {"entity_type": "person", "id": "p1", "name": "Alice", "first_name": "Alice", "last_name": "Smith", "email": "a@b.com"},
+                {"entity_type": "department", "id": "d1", "name": "Eng"},
+            ],
+            "relationships": [
+                {"relationship_type": "works_in", "source_id": "p1", "target_id": "d1"},
+            ],
+        }
+        vr = validate_json_import(data)
+        assert vr.is_valid
+        assert vr.entity_count == 2
+        assert vr.relationship_count == 1
+        assert vr.relationship_type_counts == {"works_in": 1}
+
+    def test_missing_entities_key(self) -> None:
+        data = {"relationships": []}
+        vr = validate_json_import(data)
+        assert not vr.is_valid
+        assert "Missing 'entities' key" in vr.errors[0]
+
+    def test_entities_not_a_list(self) -> None:
+        data = {"entities": "not a list"}
+        vr = validate_json_import(data)
+        assert not vr.is_valid
+        assert "'entities' must be a list" in vr.errors[0]
+
+    def test_relationships_not_a_list(self) -> None:
+        data = {"entities": [], "relationships": "bad"}
+        vr = validate_json_import(data)
+        assert not vr.is_valid
+        assert "'relationships' must be a list" in vr.errors[0]
+
+    def test_empty_entities_list(self) -> None:
+        data = {"entities": []}
+        vr = validate_json_import(data)
+        assert vr.is_valid
+        assert vr.entity_count == 0
+
+    def test_entity_not_a_dict(self) -> None:
+        data = {"entities": ["not a dict"]}
+        vr = validate_json_import(data)
+        assert not vr.is_valid
+        assert "must be a dict" in vr.errors[0]
+
+    def test_missing_entity_type(self) -> None:
+        data = {"entities": [{"name": "Test"}]}
+        vr = validate_json_import(data)
+        assert not vr.is_valid
+        assert "missing 'entity_type'" in vr.errors[0]
+
+    def test_invalid_entity_type(self) -> None:
+        data = {"entities": [{"entity_type": "bogus", "name": "Test"}]}
+        vr = validate_json_import(data)
+        assert not vr.is_valid
+        assert "invalid entity_type 'bogus'" in vr.errors[0]
+
+    def test_missing_name(self) -> None:
+        data = {"entities": [{"entity_type": "department"}]}
+        vr = validate_json_import(data)
+        assert not vr.is_valid
+        assert "missing or empty 'name'" in vr.errors[0]
+
+    def test_empty_name(self) -> None:
+        data = {"entities": [{"entity_type": "department", "name": "  "}]}
+        vr = validate_json_import(data)
+        assert not vr.is_valid
+        assert "missing or empty 'name'" in vr.errors[0]
+
+    def test_person_missing_required_fields(self) -> None:
+        data = {
+            "entities": [{"entity_type": "person", "name": "Alice"}]
+        }
+        vr = validate_json_import(data)
+        assert not vr.is_valid
+        assert any("first_name" in e for e in vr.errors)
+        assert any("last_name" in e for e in vr.errors)
+        assert any("email" in e for e in vr.errors)
+
+    def test_person_with_all_required(self) -> None:
+        data = {
+            "entities": [
+                {
+                    "entity_type": "person",
+                    "name": "Alice Smith",
+                    "first_name": "Alice",
+                    "last_name": "Smith",
+                    "email": "alice@acme.com",
+                }
+            ]
+        }
+        vr = validate_json_import(data)
+        assert vr.is_valid
+        assert not vr.errors
+
+    def test_unknown_fields_detected(self) -> None:
+        data = {
+            "entities": [
+                {
+                    "entity_type": "department",
+                    "name": "Engineering",
+                    "bogus_field": "value",
+                    "another_typo": 42,
+                }
+            ]
+        }
+        vr = validate_json_import(data)
+        assert vr.is_valid  # warnings, not errors
+        assert len(vr.warnings) == 1
+        assert "unknown field" in vr.warnings[0].lower()
+        assert "bogus_field" in vr.warnings[0]
+
+    def test_invalid_relationship_type(self) -> None:
+        data = {
+            "entities": [{"entity_type": "department", "name": "Eng"}],
+            "relationships": [
+                {"relationship_type": "fake_rel", "source_id": "a", "target_id": "b"}
+            ],
+        }
+        vr = validate_json_import(data)
+        assert not vr.is_valid
+        assert "invalid relationship_type 'fake_rel'" in vr.errors[0]
+
+    def test_relationship_missing_source_id(self) -> None:
+        data = {
+            "entities": [],
+            "relationships": [
+                {"relationship_type": "works_in", "target_id": "d1"}
+            ],
+        }
+        vr = validate_json_import(data)
+        assert not vr.is_valid
+        assert any("missing 'source_id'" in e for e in vr.errors)
+
+    def test_relationship_missing_target_id(self) -> None:
+        data = {
+            "entities": [],
+            "relationships": [
+                {"relationship_type": "works_in", "source_id": "p1"}
+            ],
+        }
+        vr = validate_json_import(data)
+        assert not vr.is_valid
+        assert any("missing 'target_id'" in e for e in vr.errors)
+
+    def test_relationship_missing_type(self) -> None:
+        data = {
+            "entities": [],
+            "relationships": [
+                {"source_id": "p1", "target_id": "d1"}
+            ],
+        }
+        vr = validate_json_import(data)
+        assert not vr.is_valid
+        assert "missing 'relationship_type'" in vr.errors[0]
+
+    def test_dangling_reference_warning(self) -> None:
+        data = {
+            "entities": [
+                {"entity_type": "department", "id": "d1", "name": "Eng"}
+            ],
+            "relationships": [
+                {
+                    "relationship_type": "works_in",
+                    "source_id": "missing-person",
+                    "target_id": "d1",
+                }
+            ],
+        }
+        vr = validate_json_import(data)
+        assert vr.is_valid  # dangling refs are warnings
+        assert any("missing-person" in w for w in vr.warnings)
+
+    def test_mixed_errors_and_warnings(self) -> None:
+        data = {
+            "entities": [
+                {"entity_type": "department", "id": "d1", "name": "Eng", "typo_field": 1},
+                {"entity_type": "bogus", "name": "Bad"},
+            ],
+            "relationships": [
+                {
+                    "relationship_type": "works_in",
+                    "source_id": "missing",
+                    "target_id": "d1",
+                }
+            ],
+        }
+        vr = validate_json_import(data)
+        assert not vr.is_valid  # has errors from bogus type
+        assert len(vr.errors) >= 1
+        assert len(vr.warnings) >= 1
+
+    def test_multiple_entity_types_counted(self) -> None:
+        data = {
+            "entities": [
+                {"entity_type": "department", "name": "A"},
+                {"entity_type": "department", "name": "B"},
+                {"entity_type": "system", "name": "C"},
+            ]
+        }
+        vr = validate_json_import(data)
+        assert vr.is_valid
+        assert vr.entity_type_counts == {"department": 2, "system": 1}
+        assert vr.entity_count == 3
+
+    def test_relationship_not_a_dict(self) -> None:
+        data = {
+            "entities": [],
+            "relationships": ["not a dict"],
+        }
+        vr = validate_json_import(data)
+        assert not vr.is_valid
+        assert "must be a dict" in vr.errors[0]
+
+    def test_statistics_key_ignored(self) -> None:
+        """Exported JSON includes 'statistics' — validator should ignore it."""
+        data = {
+            "entities": [{"entity_type": "department", "name": "Eng"}],
+            "relationships": [],
+            "statistics": {"entity_count": 1},
+        }
+        vr = validate_json_import(data)
+        assert vr.is_valid
+
+
+class TestValidateCsvImport:
+    def test_valid_person_headers(self) -> None:
+        headers = ["name", "first_name", "last_name", "email", "title"]
+        vr = validate_csv_import(headers, EntityType.PERSON)
+        assert vr.is_valid
+        assert not vr.errors
+
+    def test_valid_system_headers(self) -> None:
+        headers = ["name", "system_type", "hostname", "ip_address", "os"]
+        vr = validate_csv_import(headers, EntityType.SYSTEM)
+        assert vr.is_valid
+
+    def test_empty_headers(self) -> None:
+        vr = validate_csv_import([], EntityType.DEPARTMENT)
+        assert not vr.is_valid
+        assert "no column headers" in vr.errors[0]
+
+    def test_unknown_columns_detected(self) -> None:
+        headers = ["name", "code", "bogus_column", "typo_field"]
+        vr = validate_csv_import(headers, EntityType.DEPARTMENT)
+        assert vr.is_valid  # warnings, not errors
+        assert len(vr.warnings) == 1
+        assert "bogus_column" in vr.warnings[0]
+        assert "typo_field" in vr.warnings[0]
+
+    def test_person_missing_required_columns(self) -> None:
+        headers = ["name", "title"]
+        vr = validate_csv_import(headers, EntityType.PERSON)
+        assert not vr.is_valid
+        assert any("first_name" in e for e in vr.errors)
+        assert any("last_name" in e for e in vr.errors)
+        assert any("email" in e for e in vr.errors)
+
+    def test_non_person_no_required_columns(self) -> None:
+        """Non-person entities only require 'name' (from BaseEntity, always present)."""
+        headers = ["name", "description"]
+        vr = validate_csv_import(headers, EntityType.DEPARTMENT)
+        assert vr.is_valid


### PR DESCRIPTION
## Summary

- Add `hckg import` CLI command for importing real organizational data (JSON/CSV)
- Add `src/ingest/validator.py` with pre-ingest validation that catches the `extra="allow"` pitfall
- Support `--merge`, `--dry-run`, `--strict`, `--entity-type`, `--output` options
- 57 new tests (32 validator + 25 CLI)

Closes #230