### PR TITLE
feat: declarative column mapping files for CSV import

### DIFF
--- a/examples/import-mappings/qualys-vulns.mapping.json
+++ b/examples/import-mappings/qualys-vulns.mapping.json
@@ -1,0 +1,17 @@
+{
+  "name": "Qualys Vulnerability Export",
+  "description": "Maps a Qualys vulnerability scan export CSV to Vulnerability entities. Adjust column names to match your Qualys report format.",
+  "entity_type": "vulnerability",
+  "name_field": "Title",
+  "columns": {
+    "CVE_ID": "cve_id",
+    "CVSS_Score": "cvss_score",
+    "CVSS_Vector": "cvss_vector",
+    "Severity_Level": "severity",
+    "Vuln_Status": "status",
+    "Affected_Software": "affected_component",
+    "First_Detected": "discovery_date",
+    "Exploit_Available": "exploit_available",
+    "Patch_Available": "patch_available"
+  }
+}

--- a/examples/import-mappings/servicenow-cmdb.mapping.json
+++ b/examples/import-mappings/servicenow-cmdb.mapping.json
@@ -1,0 +1,18 @@
+{
+  "name": "ServiceNow CMDB CI Export",
+  "description": "Maps a ServiceNow Configuration Item (CI) export CSV to System entities. Adjust column names to match your ServiceNow instance.",
+  "entity_type": "system",
+  "name_field": "Name",
+  "columns": {
+    "CI_Class": "system_type",
+    "IP_Address": "ip_address",
+    "DNS_Host_Name": "hostname",
+    "Operating_System": "os",
+    "Environment": "environment",
+    "Business_Criticality": "criticality",
+    "Operational_Status": "system_status",
+    "Managed_By": "system_owner",
+    "Department": "department_id",
+    "Vendor": "vendor_id"
+  }
+}

--- a/examples/import-mappings/workday-hr.mapping.json
+++ b/examples/import-mappings/workday-hr.mapping.json
@@ -1,0 +1,18 @@
+{
+  "name": "Workday HR Export",
+  "description": "Maps a typical Workday People report CSV to Person entities. Adjust column names to match your specific Workday report configuration.",
+  "entity_type": "person",
+  "name_field": "Legal_Name",
+  "columns": {
+    "Worker_ID": "employee_id",
+    "Legal_First_Name": "first_name",
+    "Legal_Last_Name": "last_name",
+    "Email_Primary_Work": "email",
+    "Job_Title": "title",
+    "Hire_Date": "hire_date",
+    "Worker_Type": "employment_type",
+    "Location": "location_primary",
+    "Cost_Center": "cost_center",
+    "Manager_Name": "mentored_by"
+  }
+}

--- a/src/ingest/__init__.py
+++ b/src/ingest/__init__.py
@@ -3,14 +3,18 @@
 from ingest.base import AbstractIngestor, IngestResult
 from ingest.csv_ingestor import CSVIngestor
 from ingest.json_ingestor import JSONIngestor
+from ingest.mapping_loader import ColumnMapping, load_column_mapping, to_schema_mapping
 from ingest.validator import ValidationResult, validate_csv_import, validate_json_import
 
 __all__ = [
     "AbstractIngestor",
     "CSVIngestor",
+    "ColumnMapping",
     "IngestResult",
     "JSONIngestor",
     "ValidationResult",
+    "load_column_mapping",
+    "to_schema_mapping",
     "validate_csv_import",
     "validate_json_import",
 ]

--- a/src/ingest/mapping_loader.py
+++ b/src/ingest/mapping_loader.py
@@ -1,0 +1,149 @@
+"""Load declarative column mapping files for CSV import."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from domain.base import EntityType
+    from ingest.mapping import SchemaMapping
+
+
+@dataclass
+class ColumnMapping:
+    """A declarative column mapping loaded from a .mapping.json file."""
+
+    name: str
+    description: str
+    entity_type: EntityType
+    name_field: str
+    columns: dict[str, str]  # source_column → target_field
+
+
+@dataclass
+class MappingLoadResult:
+    """Result of loading a mapping file."""
+
+    mapping: ColumnMapping | None = None
+    warnings: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def is_valid(self) -> bool:
+        return self.mapping is not None and len(self.errors) == 0
+
+
+def load_column_mapping(path: Path) -> MappingLoadResult:
+    """Load and validate a .mapping.json file.
+
+    Returns a MappingLoadResult with the parsed mapping, warnings, and errors.
+    """
+    from pathlib import Path as PathClass
+
+    from domain.base import EntityType
+    from domain.registry import EntityRegistry
+
+    result = MappingLoadResult()
+    path = PathClass(path)
+
+    if not path.exists():
+        result.errors.append(f"Mapping file not found: {path}")
+        return result
+
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except json.JSONDecodeError as exc:
+        result.errors.append(f"Invalid JSON in mapping file: {exc}")
+        return result
+
+    if not isinstance(data, dict):
+        result.errors.append("Mapping file must be a JSON object")
+        return result
+
+    # Validate required fields
+    et_str = data.get("entity_type")
+    if not et_str:
+        result.errors.append("Mapping file missing required 'entity_type'")
+        return result
+
+    try:
+        entity_type = EntityType(et_str)
+    except ValueError:
+        valid = sorted(e.value for e in EntityType)
+        result.errors.append(
+            f"Invalid entity_type '{et_str}'. Valid types: {', '.join(valid)}"
+        )
+        return result
+
+    name_field = data.get("name_field")
+    if not name_field:
+        result.errors.append("Mapping file missing required 'name_field'")
+        return result
+
+    columns = data.get("columns", {})
+    if not isinstance(columns, dict):
+        result.errors.append("'columns' must be a dict mapping source → target fields")
+        return result
+
+    # Validate target fields against entity model
+    EntityRegistry.auto_discover()
+    entity_class = EntityRegistry.get(entity_type)
+    known_fields = set(entity_class.model_fields.keys())
+
+    for source_col, target_field in columns.items():
+        if not isinstance(target_field, str):
+            result.errors.append(
+                f"Column mapping value for '{source_col}' must be a string, "
+                f"got {type(target_field).__name__}"
+            )
+            continue
+        if target_field not in known_fields:
+            result.warnings.append(
+                f"Target field '{target_field}' (from column '{source_col}') "
+                f"is not in {et_str} schema"
+            )
+
+    if result.errors:
+        return result
+
+    result.mapping = ColumnMapping(
+        name=data.get("name", path.stem),
+        description=data.get("description", ""),
+        entity_type=entity_type,
+        name_field=name_field,
+        columns=columns,
+    )
+    return result
+
+
+def to_schema_mapping(mapping: ColumnMapping) -> SchemaMapping:
+    """Convert a ColumnMapping to the existing SchemaMapping objects.
+
+    Bridges declarative column mappings to the CSVIngestor API.
+    """
+    from ingest.mapping import EntityMapping, FieldMapping, SchemaMapping
+
+    field_mappings = [
+        FieldMapping(
+            source_field=source_col,
+            target_attribute=target_field,
+        )
+        for source_col, target_field in mapping.columns.items()
+    ]
+
+    entity_mapping = EntityMapping(
+        source_type="csv",
+        target_entity_type=mapping.entity_type,
+        name_field=mapping.name_field,
+        field_mappings=field_mappings,
+    )
+
+    return SchemaMapping(
+        entity_mappings=[entity_mapping],
+        relationship_mappings=[],
+    )

--- a/tests/unit/ingest/test_mapping_loader.py
+++ b/tests/unit/ingest/test_mapping_loader.py
@@ -1,0 +1,225 @@
+"""Tests for declarative column mapping loader."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from domain.base import EntityType
+from ingest.mapping_loader import (
+    ColumnMapping,
+    load_column_mapping,
+    to_schema_mapping,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_mapping(tmp_path: Path, data: dict) -> Path:
+    """Write a mapping dict to a temp JSON file."""
+    path = tmp_path / "test.mapping.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+VALID_MAPPING = {
+    "name": "Test Mapping",
+    "description": "Maps test columns",
+    "entity_type": "person",
+    "name_field": "Full_Name",
+    "columns": {
+        "First": "first_name",
+        "Last": "last_name",
+        "Mail": "email",
+        "Job": "title",
+    },
+}
+
+
+class TestLoadColumnMapping:
+    def test_valid_mapping(self, tmp_path: Path) -> None:
+        path = _write_mapping(tmp_path, VALID_MAPPING)
+        result = load_column_mapping(path)
+        assert result.is_valid
+        assert result.mapping is not None
+        assert result.mapping.name == "Test Mapping"
+        assert result.mapping.entity_type == EntityType.PERSON
+        assert result.mapping.name_field == "Full_Name"
+        assert result.mapping.columns["First"] == "first_name"
+        assert len(result.mapping.columns) == 4
+
+    def test_file_not_found(self, tmp_path: Path) -> None:
+        result = load_column_mapping(tmp_path / "nonexistent.json")
+        assert not result.is_valid
+        assert "not found" in result.errors[0]
+
+    def test_invalid_json(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.json"
+        path.write_text("not json {{{")
+        result = load_column_mapping(path)
+        assert not result.is_valid
+        assert "Invalid JSON" in result.errors[0]
+
+    def test_not_a_dict(self, tmp_path: Path) -> None:
+        path = tmp_path / "array.json"
+        path.write_text("[1, 2, 3]")
+        result = load_column_mapping(path)
+        assert not result.is_valid
+        assert "JSON object" in result.errors[0]
+
+    def test_missing_entity_type(self, tmp_path: Path) -> None:
+        data = {**VALID_MAPPING}
+        del data["entity_type"]
+        path = _write_mapping(tmp_path, data)
+        result = load_column_mapping(path)
+        assert not result.is_valid
+        assert "entity_type" in result.errors[0]
+
+    def test_invalid_entity_type(self, tmp_path: Path) -> None:
+        data = {**VALID_MAPPING, "entity_type": "bogus"}
+        path = _write_mapping(tmp_path, data)
+        result = load_column_mapping(path)
+        assert not result.is_valid
+        assert "bogus" in result.errors[0]
+
+    def test_missing_name_field(self, tmp_path: Path) -> None:
+        data = {**VALID_MAPPING}
+        del data["name_field"]
+        path = _write_mapping(tmp_path, data)
+        result = load_column_mapping(path)
+        assert not result.is_valid
+        assert "name_field" in result.errors[0]
+
+    def test_columns_not_a_dict(self, tmp_path: Path) -> None:
+        data = {**VALID_MAPPING, "columns": ["not", "a", "dict"]}
+        path = _write_mapping(tmp_path, data)
+        result = load_column_mapping(path)
+        assert not result.is_valid
+        assert "dict" in result.errors[0]
+
+    def test_empty_columns_ok(self, tmp_path: Path) -> None:
+        data = {**VALID_MAPPING, "columns": {}}
+        path = _write_mapping(tmp_path, data)
+        result = load_column_mapping(path)
+        assert result.is_valid
+        assert result.mapping is not None
+        assert len(result.mapping.columns) == 0
+
+    def test_default_name_from_filename(self, tmp_path: Path) -> None:
+        data = {**VALID_MAPPING}
+        del data["name"]
+        path = _write_mapping(tmp_path, data)
+        result = load_column_mapping(path)
+        assert result.is_valid
+        assert result.mapping is not None
+        assert result.mapping.name == "test.mapping"
+
+
+class TestColumnValidation:
+    def test_unknown_target_field_warns(self, tmp_path: Path) -> None:
+        data = {
+            **VALID_MAPPING,
+            "columns": {"Source_Col": "totally_bogus_field"},
+        }
+        path = _write_mapping(tmp_path, data)
+        result = load_column_mapping(path)
+        assert result.is_valid  # warnings, not errors
+        assert len(result.warnings) == 1
+        assert "totally_bogus_field" in result.warnings[0]
+
+    def test_non_string_target_value_errors(self, tmp_path: Path) -> None:
+        data = {
+            **VALID_MAPPING,
+            "columns": {"Source_Col": 42},
+        }
+        path = _write_mapping(tmp_path, data)
+        result = load_column_mapping(path)
+        assert not result.is_valid
+        assert "string" in result.errors[0].lower()
+
+
+class TestToSchemaMapping:
+    def test_converts_to_schema_mapping(self) -> None:
+        cm = ColumnMapping(
+            name="Test",
+            description="",
+            entity_type=EntityType.PERSON,
+            name_field="Full_Name",
+            columns={"First": "first_name", "Last": "last_name"},
+        )
+        sm = to_schema_mapping(cm)
+        assert len(sm.entity_mappings) == 1
+        em = sm.entity_mappings[0]
+        assert em.target_entity_type == EntityType.PERSON
+        assert em.name_field == "Full_Name"
+        assert len(em.field_mappings) == 2
+        assert em.field_mappings[0].source_field == "First"
+        assert em.field_mappings[0].target_attribute == "first_name"
+
+    def test_empty_columns(self) -> None:
+        cm = ColumnMapping(
+            name="Test",
+            description="",
+            entity_type=EntityType.DEPARTMENT,
+            name_field="Name",
+            columns={},
+        )
+        sm = to_schema_mapping(cm)
+        assert len(sm.entity_mappings) == 1
+        assert len(sm.entity_mappings[0].field_mappings) == 0
+
+    def test_no_relationship_mappings(self) -> None:
+        cm = ColumnMapping(
+            name="Test",
+            description="",
+            entity_type=EntityType.SYSTEM,
+            name_field="CI_Name",
+            columns={"IP": "ip_address"},
+        )
+        sm = to_schema_mapping(cm)
+        assert len(sm.relationship_mappings) == 0
+
+
+class TestMappingWithCsvIngestor:
+    def test_end_to_end_csv_with_mapping(self, tmp_path: Path) -> None:
+        """Full round-trip: mapping file + CSV -> entities."""
+        from ingest.csv_ingestor import CSVIngestor
+
+        # Create a CSV with non-canonical column names
+        csv_path = tmp_path / "hr_export.csv"
+        csv_path.write_text(
+            "Full_Name,First,Last,Mail\n"
+            "Alice Smith,Alice,Smith,alice@acme.com\n"
+            "Bob Jones,Bob,Jones,bob@acme.com\n"
+        )
+
+        # Create mapping
+        mapping_data = {
+            "entity_type": "person",
+            "name_field": "Full_Name",
+            "columns": {
+                "First": "first_name",
+                "Last": "last_name",
+                "Mail": "email",
+            },
+        }
+        mapping_path = _write_mapping(tmp_path, mapping_data)
+
+        # Load mapping and convert
+        load_result = load_column_mapping(mapping_path)
+        assert load_result.is_valid
+        sm = to_schema_mapping(load_result.mapping)  # type: ignore[arg-type]
+
+        # Ingest with mapping
+        ingestor = CSVIngestor()
+        result = ingestor.ingest(csv_path, mapping=sm)
+        assert result.entity_count == 2
+        assert not result.errors
+
+        # Verify entity fields were mapped correctly
+        alice = result.entities[0]
+        assert alice.name == "Alice Smith"
+        assert alice.first_name == "Alice"  # type: ignore[attr-defined]
+        assert alice.last_name == "Smith"  # type: ignore[attr-defined]
+        assert alice.email == "alice@acme.com"  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- Adds `.mapping.json` format for declaring how vendor CSV columns map to canonical entity fields
- New `--mapping` CLI option on `hckg import` (mutually exclusive with `--entity-type`)
- `mapping_loader.py`: loads/validates mapping files, converts to `SchemaMapping` for `CSVIngestor`
- 3 example mappings: Workday HR, ServiceNow CMDB, Qualys vulnerability exports
- 21 new tests (16 unit for mapping_loader, 5 CLI integration)

Closes #232

## Test plan
- [x] All 954 tests pass, 0 failures
- [x] Ruff lint clean
- [x] End-to-end: CSV + mapping file produces correct entities
- [x] Mutual exclusion: `--mapping` + `--entity-type` errors correctly
- [x] Invalid mapping formats caught with clear error messages