### PR TITLE
feat: expand schema inference to all 30 entity types

### DIFF
--- a/src/auto/schema_inference.py
+++ b/src/auto/schema_inference.py
@@ -8,14 +8,18 @@ from domain.base import EntityType
 
 # Patterns that hint at entity types based on column names or values
 COLUMN_PATTERNS: dict[EntityType, list[str]] = {
+    # --- v0.1 original types ---
     EntityType.PERSON: [
         r"(?i)(first.?name|last.?name|employee|email|hire.?date|title|staff)",
     ],
     EntityType.DEPARTMENT: [
         r"(?i)(department|dept|division|business.?unit|team)",
     ],
+    EntityType.ROLE: [
+        r"(?i)(role.?type|role.?family|access.?level|is.?privileged|role.?id|permissions)",
+    ],
     EntityType.SYSTEM: [
-        r"(?i)(hostname|ip.?address|server|system|application|service|os|port)",
+        r"(?i)(hostname|ip.?address|server|system|application|service|\bos\b|\bport\b)",
     ],
     EntityType.NETWORK: [
         r"(?i)(cidr|subnet|vlan|network|gateway|dns)",
@@ -30,16 +34,82 @@ COLUMN_PATTERNS: dict[EntityType, list[str]] = {
         r"(?i)(data.?asset|database|dataset|classification|retention|encryption)",
     ],
     EntityType.POLICY: [
-        r"(?i)(policy|control|framework|compliance|regulation)",
+        r"(?i)(policy|policy.?id|policy.?type|policy.?status|policy.?owner|framework)",
     ],
     EntityType.LOCATION: [
-        r"(?i)(location|address|city|state|country|zip|facility|site)",
+        r"(?i)(location|address|city|state|country|zip|facility)",
     ],
     EntityType.THREAT_ACTOR: [
         r"(?i)(threat.?actor|apt|adversary|attacker|campaign)",
     ],
     EntityType.INCIDENT: [
         r"(?i)(incident|breach|alert|detection|response|forensic)",
+    ],
+    # --- Enterprise types ---
+    EntityType.REGULATION: [
+        r"(?i)(regulation.?id|regulation.?category|issuing.?body|regulation.?type"
+        r"|compliance.?status|regulatory)",
+    ],
+    EntityType.CONTROL: [
+        r"(?i)(control.?id|control.?type|control.?domain|control.?category"
+        r"|control.?status|control.?owner)",
+    ],
+    EntityType.RISK: [
+        r"(?i)(risk.?id|risk.?category|risk.?level|risk.?owner|risk.?status"
+        r"|risk.?treatment|inherent.?risk|residual.?risk)",
+    ],
+    EntityType.THREAT: [
+        r"(?i)(threat.?id|threat.?category|threat.?group|threat.?source|threat.?trend)",
+    ],
+    EntityType.INTEGRATION: [
+        r"(?i)(integration.?id|integration.?type|protocol|middleware"
+        r"|source.?system|target.?system)",
+    ],
+    EntityType.DATA_DOMAIN: [
+        r"(?i)(domain.?id|domain.?type|domain.?owner|domain.?steward"
+        r"|data.?domain|governance.?status)",
+    ],
+    EntityType.DATA_FLOW: [
+        r"(?i)(flow.?id|flow.?type|transfer.?method|data.?flow"
+        r"|source.?asset|target.?asset)",
+    ],
+    EntityType.ORGANIZATIONAL_UNIT: [
+        r"(?i)(unit.?id|unit.?type|operating.?model|org.?unit"
+        r"|organizational.?unit|unit.?leader)",
+    ],
+    EntityType.BUSINESS_CAPABILITY: [
+        r"(?i)(capability.?id|capability.?level|maturity.?level"
+        r"|business.?capability|strategic.?importance)",
+    ],
+    EntityType.SITE: [
+        r"(?i)(site.?id|site.?type|site.?status|building|campus|facility.?type)",
+    ],
+    EntityType.GEOGRAPHY: [
+        r"(?i)(geography.?id|geography.?type|geography|region.?code)",
+    ],
+    EntityType.JURISDICTION: [
+        r"(?i)(jurisdiction.?id|jurisdiction.?type|jurisdiction.?code|governing.?body)",
+    ],
+    EntityType.PRODUCT_PORTFOLIO: [
+        r"(?i)(portfolio.?id|portfolio.?type|product.?portfolio)",
+    ],
+    EntityType.PRODUCT: [
+        r"(?i)(product.?id|product.?type|offering.?type|lifecycle.?stage|product.?name)",
+    ],
+    EntityType.MARKET_SEGMENT: [
+        r"(?i)(segment.?id|segment.?type|market.?segment|segment.?criteria)",
+    ],
+    EntityType.CUSTOMER: [
+        r"(?i)(customer.?id|customer.?type|account.?tier|customer.?name"
+        r"|relationship.?status)",
+    ],
+    EntityType.CONTRACT: [
+        r"(?i)(contract.?id|contract.?type|contract.?status|contract.?value"
+        r"|contract.?owner)",
+    ],
+    EntityType.INITIATIVE: [
+        r"(?i)(initiative.?id|initiative.?type|initiative.?tier"
+        r"|initiative.?category|executive.?sponsor)",
     ],
 }
 
@@ -52,6 +122,15 @@ RELATIONSHIP_COLUMN_PATTERNS = [
     (r"(?i)(vendor.?id|supplier.?id)", "entity_to_vendor"),
     (r"(?i)(location.?id|site.?id)", "entity_to_location"),
     (r"(?i)(owner.?id|assigned.?to)", "entity_to_person"),
+    (r"(?i)(regulation.?id)", "entity_to_regulation"),
+    (r"(?i)(control.?id)", "entity_to_control"),
+    (r"(?i)(risk.?id)", "entity_to_risk"),
+    (r"(?i)(contract.?id)", "entity_to_contract"),
+    (r"(?i)(initiative.?id)", "entity_to_initiative"),
+    (r"(?i)(product.?id)", "entity_to_product"),
+    (r"(?i)(customer.?id)", "entity_to_customer"),
+    (r"(?i)(capability.?id)", "entity_to_capability"),
+    (r"(?i)(portfolio.?id)", "entity_to_portfolio"),
 ]
 
 

--- a/tests/unit/auto/test_schema_inference.py
+++ b/tests/unit/auto/test_schema_inference.py
@@ -1,0 +1,209 @@
+"""Tests for schema inference across all 30 entity types."""
+
+from __future__ import annotations
+
+from auto.schema_inference import infer_entity_type, infer_relationships
+from domain.base import EntityType
+
+
+class TestInferEntityTypeOriginal:
+    """Regression tests for the original 11 entity types."""
+
+    def test_person(self) -> None:
+        cols = ["first_name", "last_name", "email", "hire_date"]
+        assert infer_entity_type(cols) == EntityType.PERSON
+
+    def test_department(self) -> None:
+        cols = ["department", "dept_code", "business_unit"]
+        assert infer_entity_type(cols) == EntityType.DEPARTMENT
+
+    def test_system(self) -> None:
+        cols = ["hostname", "ip_address", "os", "port"]
+        assert infer_entity_type(cols) == EntityType.SYSTEM
+
+    def test_network(self) -> None:
+        cols = ["cidr", "subnet", "vlan", "gateway"]
+        assert infer_entity_type(cols) == EntityType.NETWORK
+
+    def test_vulnerability(self) -> None:
+        cols = ["cve", "cvss", "severity", "exploit"]
+        assert infer_entity_type(cols) == EntityType.VULNERABILITY
+
+    def test_vendor(self) -> None:
+        cols = ["vendor", "supplier", "sla"]
+        assert infer_entity_type(cols) == EntityType.VENDOR
+
+    def test_data_asset(self) -> None:
+        cols = ["data_asset", "classification", "retention", "encryption"]
+        assert infer_entity_type(cols) == EntityType.DATA_ASSET
+
+    def test_policy(self) -> None:
+        cols = ["policy", "policy_type", "policy_status", "framework"]
+        assert infer_entity_type(cols) == EntityType.POLICY
+
+    def test_location(self) -> None:
+        cols = ["location", "address", "city", "country"]
+        assert infer_entity_type(cols) == EntityType.LOCATION
+
+    def test_threat_actor(self) -> None:
+        cols = ["threat_actor", "apt", "adversary", "campaign"]
+        assert infer_entity_type(cols) == EntityType.THREAT_ACTOR
+
+    def test_incident(self) -> None:
+        cols = ["incident", "breach", "detection", "forensic"]
+        assert infer_entity_type(cols) == EntityType.INCIDENT
+
+
+class TestInferEntityTypeEnterprise:
+    """Tests for the 19 enterprise entity types."""
+
+    def test_role(self) -> None:
+        cols = ["role_type", "role_family", "access_level", "permissions"]
+        assert infer_entity_type(cols) == EntityType.ROLE
+
+    def test_regulation(self) -> None:
+        cols = ["regulation_id", "regulation_category", "issuing_body"]
+        assert infer_entity_type(cols) == EntityType.REGULATION
+
+    def test_control(self) -> None:
+        cols = ["control_id", "control_type", "control_domain", "control_status"]
+        assert infer_entity_type(cols) == EntityType.CONTROL
+
+    def test_risk(self) -> None:
+        cols = ["risk_id", "risk_category", "risk_level", "risk_owner"]
+        assert infer_entity_type(cols) == EntityType.RISK
+
+    def test_threat(self) -> None:
+        cols = ["threat_id", "threat_category", "threat_group", "threat_source"]
+        assert infer_entity_type(cols) == EntityType.THREAT
+
+    def test_integration(self) -> None:
+        cols = ["integration_id", "integration_type", "protocol", "middleware"]
+        assert infer_entity_type(cols) == EntityType.INTEGRATION
+
+    def test_data_domain(self) -> None:
+        cols = ["domain_id", "domain_type", "domain_owner", "data_domain"]
+        assert infer_entity_type(cols) == EntityType.DATA_DOMAIN
+
+    def test_data_flow(self) -> None:
+        cols = ["flow_id", "flow_type", "transfer_method", "data_flow"]
+        assert infer_entity_type(cols) == EntityType.DATA_FLOW
+
+    def test_organizational_unit(self) -> None:
+        cols = ["unit_id", "unit_type", "operating_model", "org_unit"]
+        assert infer_entity_type(cols) == EntityType.ORGANIZATIONAL_UNIT
+
+    def test_business_capability(self) -> None:
+        cols = ["capability_id", "capability_level", "maturity_level"]
+        assert infer_entity_type(cols) == EntityType.BUSINESS_CAPABILITY
+
+    def test_site(self) -> None:
+        cols = ["site_id", "site_type", "site_status", "building"]
+        assert infer_entity_type(cols) == EntityType.SITE
+
+    def test_geography(self) -> None:
+        cols = ["geography_id", "geography_type", "region_code"]
+        assert infer_entity_type(cols) == EntityType.GEOGRAPHY
+
+    def test_jurisdiction(self) -> None:
+        cols = ["jurisdiction_id", "jurisdiction_type", "governing_body"]
+        assert infer_entity_type(cols) == EntityType.JURISDICTION
+
+    def test_product_portfolio(self) -> None:
+        cols = ["portfolio_id", "portfolio_type", "product_portfolio"]
+        assert infer_entity_type(cols) == EntityType.PRODUCT_PORTFOLIO
+
+    def test_product(self) -> None:
+        cols = ["product_id", "product_type", "lifecycle_stage"]
+        assert infer_entity_type(cols) == EntityType.PRODUCT
+
+    def test_market_segment(self) -> None:
+        cols = ["segment_id", "segment_type", "market_segment"]
+        assert infer_entity_type(cols) == EntityType.MARKET_SEGMENT
+
+    def test_customer(self) -> None:
+        cols = ["customer_id", "customer_type", "account_tier"]
+        assert infer_entity_type(cols) == EntityType.CUSTOMER
+
+    def test_contract(self) -> None:
+        cols = ["contract_id", "contract_type", "contract_status", "contract_value"]
+        assert infer_entity_type(cols) == EntityType.CONTRACT
+
+    def test_initiative(self) -> None:
+        cols = ["initiative_id", "initiative_type", "executive_sponsor"]
+        assert infer_entity_type(cols) == EntityType.INITIATIVE
+
+
+class TestInferEntityTypeEdgeCases:
+    """Edge cases and ambiguity tests."""
+
+    def test_no_match_returns_none(self) -> None:
+        cols = ["col_a", "col_b", "col_c"]
+        assert infer_entity_type(cols) is None
+
+    def test_empty_columns_returns_none(self) -> None:
+        assert infer_entity_type([]) is None
+
+    def test_highest_score_wins(self) -> None:
+        # 3 person signals vs 1 system signal
+        cols = ["first_name", "last_name", "email", "hostname"]
+        assert infer_entity_type(cols) == EntityType.PERSON
+
+    def test_policy_no_longer_matches_control(self) -> None:
+        # "control" was removed from POLICY patterns
+        cols = ["control_id", "control_type", "control_domain"]
+        result = infer_entity_type(cols)
+        assert result == EntityType.CONTROL
+        assert result != EntityType.POLICY
+
+    def test_policy_no_longer_matches_regulation(self) -> None:
+        cols = ["regulation_id", "regulation_category", "issuing_body"]
+        result = infer_entity_type(cols)
+        assert result == EntityType.REGULATION
+        assert result != EntityType.POLICY
+
+    def test_location_no_longer_matches_site(self) -> None:
+        # "site" was moved from LOCATION to SITE type
+        cols = ["site_id", "site_type", "site_status"]
+        result = infer_entity_type(cols)
+        assert result == EntityType.SITE
+
+
+class TestInferRelationships:
+    """Tests for relationship column detection."""
+
+    def test_original_patterns(self) -> None:
+        cols = ["name", "department_id", "manager_id", "system_id"]
+        rels = infer_relationships(cols)
+        hints = {r[1] for r in rels}
+        assert "entity_to_department" in hints
+        assert "person_to_manager" in hints
+        assert "entity_to_system" in hints
+
+    def test_new_enterprise_patterns(self) -> None:
+        cols = ["regulation_id", "control_id", "risk_id", "contract_id"]
+        rels = infer_relationships(cols)
+        hints = {r[1] for r in rels}
+        assert "entity_to_regulation" in hints
+        assert "entity_to_control" in hints
+        assert "entity_to_risk" in hints
+        assert "entity_to_contract" in hints
+
+    def test_initiative_product_customer_patterns(self) -> None:
+        cols = ["initiative_id", "product_id", "customer_id"]
+        rels = infer_relationships(cols)
+        hints = {r[1] for r in rels}
+        assert "entity_to_initiative" in hints
+        assert "entity_to_product" in hints
+        assert "entity_to_customer" in hints
+
+    def test_capability_portfolio_patterns(self) -> None:
+        cols = ["capability_id", "portfolio_id"]
+        rels = infer_relationships(cols)
+        hints = {r[1] for r in rels}
+        assert "entity_to_capability" in hints
+        assert "entity_to_portfolio" in hints
+
+    def test_no_matches(self) -> None:
+        cols = ["col_a", "col_b"]
+        assert infer_relationships(cols) == []


### PR DESCRIPTION
## Summary
- Adds COLUMN_PATTERNS entries for all 19 missing enterprise entity types (was 11, now 30)
- Fixes POLICY pattern ambiguity: removed `control` and `regulation` (now belong to CONTROL and REGULATION types)
- Adds word boundaries to SYSTEM `port`/`os` patterns to prevent false matches (e.g., `portfolio_type`)
- Adds 9 new RELATIONSHIP_COLUMN_PATTERNS for enterprise entity cross-references
- 41 new tests covering all 30 types, edge cases, and relationship detection

Closes #234

## Test plan
- [x] All 995 tests pass, 0 failures
- [x] Ruff lint clean
- [x] Original 11 types still infer correctly (regression)
- [x] All 19 new types infer correctly
- [x] Pattern ambiguity resolved (control ≠ policy, regulation ≠ policy, site ≠ location)