### PR TITLE
feat: import template files with validation tests

### DIFF
--- a/examples/import-templates/controls.csv
+++ b/examples/import-templates/controls.csv
@@ -1,0 +1,6 @@
+name,control_id,control_type,control_domain,control_status,control_owner,description
+Multi-Factor Authentication,CTL-001,Preventive,Access Control,Implemented,Identity Team,MFA required for all privileged and remote access
+Endpoint Detection and Response,CTL-002,Detective,Endpoint Security,Implemented,SOC Team,EDR agents deployed on all managed endpoints
+Network Segmentation,CTL-003,Preventive,Network Security,Implemented,Network Team,Microsegmentation between production zones
+Data Loss Prevention,CTL-004,Detective,Data Security,Partially Implemented,Data Security Team,DLP monitoring on email and cloud storage
+Vulnerability Scanning,CTL-005,Detective,Vulnerability Management,Implemented,Security Engineering,Weekly automated vulnerability scans of all assets

--- a/examples/import-templates/departments.csv
+++ b/examples/import-templates/departments.csv
@@ -1,0 +1,6 @@
+name,description,code,headcount,head_id,parent_department_id
+Engineering,Software engineering and platform development,ENG,45,,
+Information Security,Cybersecurity and risk management,SEC,12,,
+Product Management,Product strategy and roadmap,PROD,8,,
+Human Resources,People operations and talent management,HR,10,,
+Finance,Financial planning and accounting,FIN,15,,

--- a/examples/import-templates/incidents.csv
+++ b/examples/import-templates/incidents.csv
@@ -1,0 +1,6 @@
+name,incident_type,severity,status,detection_method,occurred_at,detected_at,resolved_at,impact_description,description
+Phishing Campaign Detected,phishing,high,resolved,email gateway,2024-11-15T08:30:00Z,2024-11-15T09:15:00Z,2024-11-15T14:00:00Z,3 users clicked malicious links,Targeted phishing emails sent to finance department
+Unauthorized Access Attempt,unauthorized_access,medium,resolved,SIEM,2024-10-22T03:00:00Z,2024-10-22T03:12:00Z,2024-10-22T06:00:00Z,No data exfiltration confirmed,Brute force login attempts against VPN gateway
+Malware Detection on Endpoint,malware,high,resolved,EDR,2024-09-10T14:20:00Z,2024-09-10T14:22:00Z,2024-09-11T10:00:00Z,One workstation isolated and reimaged,Trojan detected on developer workstation
+Data Exposure via Misconfiguration,data_exposure,critical,resolved,external report,2024-08-05T00:00:00Z,2024-08-06T09:00:00Z,2024-08-06T15:00:00Z,S3 bucket with internal docs was publicly accessible,Cloud storage bucket left publicly accessible
+DDoS Attack on Web Services,ddos,medium,resolved,WAF,2024-07-18T11:00:00Z,2024-07-18T11:05:00Z,2024-07-18T13:30:00Z,Customer portal intermittent for 2.5 hours,Volumetric DDoS attack against customer portal

--- a/examples/import-templates/organization.json
+++ b/examples/import-templates/organization.json
@@ -1,0 +1,490 @@
+{
+  "entities": [
+    {
+      "id": "person-001",
+      "entity_type": "person",
+      "name": "Jane Doe",
+      "first_name": "Jane",
+      "last_name": "Doe",
+      "email": "jane.doe@example.com",
+      "title": "Senior Software Engineer",
+      "employee_id": "EMP-001",
+      "is_active": true,
+      "hire_date": "2021-03-15",
+      "department_id": "dept-eng"
+    },
+    {
+      "id": "person-002",
+      "entity_type": "person",
+      "name": "John Smith",
+      "first_name": "John",
+      "last_name": "Smith",
+      "email": "john.smith@example.com",
+      "title": "CISO",
+      "employee_id": "EMP-002",
+      "is_active": true,
+      "hire_date": "2019-01-10"
+    },
+    {
+      "id": "dept-eng",
+      "entity_type": "department",
+      "name": "Engineering",
+      "description": "Software engineering and platform development",
+      "code": "ENG",
+      "headcount": 45
+    },
+    {
+      "id": "dept-sec",
+      "entity_type": "department",
+      "name": "Information Security",
+      "description": "Cybersecurity and risk management",
+      "code": "SEC",
+      "headcount": 12
+    },
+    {
+      "id": "role-swe",
+      "entity_type": "role",
+      "name": "Software Engineer",
+      "description": "Designs, develops, and maintains software systems"
+    },
+    {
+      "id": "role-ciso",
+      "entity_type": "role",
+      "name": "Chief Information Security Officer",
+      "description": "Executive responsible for information security strategy"
+    },
+    {
+      "id": "sys-webapp",
+      "entity_type": "system",
+      "name": "Customer Portal",
+      "system_type": "application",
+      "hostname": "portal-prod-01",
+      "ip_address": "10.1.1.100",
+      "os": "Linux",
+      "criticality": "high",
+      "environment": "production",
+      "is_internet_facing": true
+    },
+    {
+      "id": "sys-erp",
+      "entity_type": "system",
+      "name": "ERP System",
+      "system_type": "application",
+      "hostname": "erp-prod-01",
+      "ip_address": "10.1.2.50",
+      "os": "Windows Server 2022",
+      "criticality": "critical",
+      "environment": "production",
+      "is_internet_facing": false
+    },
+    {
+      "id": "net-corp",
+      "entity_type": "network",
+      "name": "Corporate LAN",
+      "description": "Primary corporate network",
+      "zone": "internal",
+      "cidr": "10.1.0.0/16"
+    },
+    {
+      "id": "net-dmz",
+      "entity_type": "network",
+      "name": "DMZ",
+      "description": "Demilitarized zone for internet-facing services",
+      "zone": "dmz",
+      "cidr": "172.16.0.0/24"
+    },
+    {
+      "id": "da-custdb",
+      "entity_type": "data_asset",
+      "name": "Customer Database",
+      "description": "Primary customer records database",
+      "classification": "confidential",
+      "is_encrypted": true,
+      "retention_days": 2555
+    },
+    {
+      "id": "pol-access",
+      "entity_type": "policy",
+      "name": "Access Control Policy",
+      "description": "Defines access control requirements across all systems"
+    },
+    {
+      "id": "pol-ir",
+      "entity_type": "policy",
+      "name": "Incident Response Policy",
+      "description": "Procedures for detecting and responding to security incidents"
+    },
+    {
+      "id": "loc-hq",
+      "entity_type": "location",
+      "name": "Headquarters",
+      "description": "Corporate headquarters",
+      "address": "100 Main Street",
+      "city": "New York",
+      "state": "NY",
+      "country": "US"
+    },
+    {
+      "id": "vuln-001",
+      "entity_type": "vulnerability",
+      "name": "CVE-2024-29847",
+      "description": "Remote code execution in web framework",
+      "cve_id": "CVE-2024-29847",
+      "cvss_score": 9.8,
+      "severity": "critical",
+      "status": "open",
+      "exploit_available": true,
+      "patch_available": true
+    },
+    {
+      "id": "ta-apt29",
+      "entity_type": "threat_actor",
+      "name": "APT29",
+      "description": "State-sponsored threat group targeting government and technology sectors"
+    },
+    {
+      "id": "inc-001",
+      "entity_type": "incident",
+      "name": "Phishing Campaign Detected",
+      "description": "Targeted phishing emails sent to finance department",
+      "incident_type": "phishing",
+      "severity": "high",
+      "status": "resolved",
+      "detection_method": "email gateway",
+      "occurred_at": "2024-11-15T08:30:00Z",
+      "detected_at": "2024-11-15T09:15:00Z",
+      "resolved_at": "2024-11-15T14:00:00Z"
+    },
+    {
+      "id": "vnd-cloud",
+      "entity_type": "vendor",
+      "name": "CloudProvider Inc",
+      "vendor_type": "Cloud Services",
+      "risk_tier": "critical",
+      "has_data_access": true,
+      "primary_contact": "vendor-mgmt@cloudprovider.example.com"
+    },
+    {
+      "id": "reg-gdpr",
+      "entity_type": "regulation",
+      "name": "General Data Protection Regulation",
+      "regulation_id": "REG-001",
+      "regulation_category": "Data Privacy",
+      "description": "EU data protection and privacy regulation"
+    },
+    {
+      "id": "ctl-mfa",
+      "entity_type": "control",
+      "name": "Multi-Factor Authentication",
+      "control_id": "CTL-001",
+      "control_type": "Preventive",
+      "control_domain": "Access Control",
+      "control_status": "Implemented",
+      "control_owner": "Identity Team"
+    },
+    {
+      "id": "rsk-breach",
+      "entity_type": "risk",
+      "name": "Customer Data Breach",
+      "risk_id": "RSK-001",
+      "risk_category": "Cybersecurity",
+      "inherent_risk_level": "High",
+      "residual_risk_level": "Medium",
+      "risk_status": "Open",
+      "risk_owner": "CISO",
+      "risk_treatment": "Mitigate"
+    },
+    {
+      "id": "thr-ransom",
+      "entity_type": "threat",
+      "name": "Ransomware",
+      "threat_id": "THR-001",
+      "threat_category": "Cyber",
+      "description": "Ransomware attack targeting enterprise systems"
+    },
+    {
+      "id": "int-crm-erp",
+      "entity_type": "integration",
+      "name": "CRM to ERP Integration",
+      "integration_id": "INT-001",
+      "integration_type": "API",
+      "integration_pattern": "Request-Response",
+      "description": "Synchronizes customer data between CRM and ERP"
+    },
+    {
+      "id": "dd-customer",
+      "entity_type": "data_domain",
+      "name": "Customer Data Domain",
+      "domain_id": "DD-001",
+      "domain_owner": "Data Governance Lead",
+      "maturity_level": "Managed",
+      "description": "All customer-related data assets"
+    },
+    {
+      "id": "df-crm-dw",
+      "entity_type": "data_flow",
+      "name": "CRM to Data Warehouse",
+      "flow_id": "DF-001",
+      "frequency": "Daily",
+      "data_classification_in_flow": "Confidential",
+      "description": "Nightly batch load of customer data to analytics warehouse"
+    },
+    {
+      "id": "ou-tech",
+      "entity_type": "organizational_unit",
+      "name": "Technology Division",
+      "unit_id": "OU-001",
+      "unit_type": "Division",
+      "unit_leader": "VP Engineering",
+      "description": "All technology and engineering functions"
+    },
+    {
+      "id": "bc-crm",
+      "entity_type": "business_capability",
+      "name": "Customer Relationship Management",
+      "capability_id": "BC-001",
+      "tier": "Strategic",
+      "maturity_composite_score": 3.5,
+      "business_criticality": "Business Critical",
+      "description": "Ability to manage customer relationships end-to-end"
+    },
+    {
+      "id": "site-hq",
+      "entity_type": "site",
+      "name": "New York Headquarters",
+      "site_id": "SITE-001",
+      "site_type": "Headquarters",
+      "site_status": "Active",
+      "description": "Primary corporate office"
+    },
+    {
+      "id": "geo-na",
+      "entity_type": "geography",
+      "name": "North America",
+      "geography_id": "GEO-001",
+      "geography_type": "Region",
+      "description": "North American operating region"
+    },
+    {
+      "id": "jur-us",
+      "entity_type": "jurisdiction",
+      "name": "United States Federal",
+      "jurisdiction_id": "JUR-001",
+      "jurisdiction_type": "Federal",
+      "jurisdiction_code": "US",
+      "description": "US federal regulatory jurisdiction"
+    },
+    {
+      "id": "pf-enterprise",
+      "entity_type": "product_portfolio",
+      "name": "Enterprise Solutions",
+      "portfolio_id": "PF-001",
+      "portfolio_type": "Product",
+      "description": "Enterprise software product line"
+    },
+    {
+      "id": "prd-platform",
+      "entity_type": "product",
+      "name": "Enterprise Platform",
+      "product_id": "PRD-001",
+      "offering_type": "SaaS",
+      "lifecycle_stage": "Growth",
+      "description": "Core enterprise SaaS platform"
+    },
+    {
+      "id": "seg-enterprise",
+      "entity_type": "market_segment",
+      "name": "Enterprise",
+      "segment_id": "SEG-001",
+      "segment_type": "Company Size",
+      "description": "Large enterprise customers (1000+ employees)"
+    },
+    {
+      "id": "cust-acme",
+      "entity_type": "customer",
+      "name": "Acme Corp",
+      "customer_id": "CUST-001",
+      "customer_type": "Enterprise",
+      "account_tier": "Strategic",
+      "relationship_status": "Active",
+      "description": "Strategic enterprise customer"
+    },
+    {
+      "id": "ctr-cloud",
+      "entity_type": "contract",
+      "name": "Cloud Services Agreement",
+      "contract_id": "CTR-001",
+      "contract_type": "Master Services Agreement",
+      "contract_status": "Active",
+      "total_contract_value": 2500000.00,
+      "description": "MSA with CloudProvider Inc for cloud infrastructure"
+    },
+    {
+      "id": "init-cloud",
+      "entity_type": "initiative",
+      "name": "Cloud Migration Program",
+      "initiative_id": "SI-001",
+      "initiative_type": "Digital Transformation",
+      "current_status": "In Progress",
+      "executive_sponsor": "CTO",
+      "description": "Multi-year cloud migration for core business systems"
+    }
+  ],
+  "relationships": [
+    {
+      "relationship_type": "works_in",
+      "source_id": "person-001",
+      "target_id": "dept-eng"
+    },
+    {
+      "relationship_type": "works_in",
+      "source_id": "person-002",
+      "target_id": "dept-sec"
+    },
+    {
+      "relationship_type": "has_role",
+      "source_id": "person-001",
+      "target_id": "role-swe"
+    },
+    {
+      "relationship_type": "has_role",
+      "source_id": "person-002",
+      "target_id": "role-ciso"
+    },
+    {
+      "relationship_type": "responsible_for",
+      "source_id": "dept-eng",
+      "target_id": "sys-webapp"
+    },
+    {
+      "relationship_type": "responsible_for",
+      "source_id": "dept-eng",
+      "target_id": "sys-erp"
+    },
+    {
+      "relationship_type": "connects_to",
+      "source_id": "sys-webapp",
+      "target_id": "net-dmz"
+    },
+    {
+      "relationship_type": "connects_to",
+      "source_id": "sys-erp",
+      "target_id": "net-corp"
+    },
+    {
+      "relationship_type": "stores",
+      "source_id": "sys-webapp",
+      "target_id": "da-custdb"
+    },
+    {
+      "relationship_type": "governs",
+      "source_id": "pol-access",
+      "target_id": "sys-webapp"
+    },
+    {
+      "relationship_type": "governs",
+      "source_id": "pol-ir",
+      "target_id": "inc-001"
+    },
+    {
+      "relationship_type": "located_at",
+      "source_id": "dept-eng",
+      "target_id": "loc-hq"
+    },
+    {
+      "relationship_type": "affects",
+      "source_id": "vuln-001",
+      "target_id": "sys-webapp"
+    },
+    {
+      "relationship_type": "targets",
+      "source_id": "ta-apt29",
+      "target_id": "inc-001"
+    },
+    {
+      "relationship_type": "supplies",
+      "source_id": "vnd-cloud",
+      "target_id": "sys-webapp"
+    },
+    {
+      "relationship_type": "subject_to",
+      "source_id": "da-custdb",
+      "target_id": "reg-gdpr"
+    },
+    {
+      "relationship_type": "implements",
+      "source_id": "ctl-mfa",
+      "target_id": "pol-access"
+    },
+    {
+      "relationship_type": "mitigates",
+      "source_id": "ctl-mfa",
+      "target_id": "rsk-breach"
+    },
+    {
+      "relationship_type": "exploits",
+      "source_id": "thr-ransom",
+      "target_id": "vuln-001"
+    },
+    {
+      "relationship_type": "integrates_with",
+      "source_id": "int-crm-erp",
+      "target_id": "sys-erp"
+    },
+    {
+      "relationship_type": "belongs_to",
+      "source_id": "da-custdb",
+      "target_id": "dd-customer"
+    },
+    {
+      "relationship_type": "flows_to",
+      "source_id": "df-crm-dw",
+      "target_id": "da-custdb"
+    },
+    {
+      "relationship_type": "contains",
+      "source_id": "ou-tech",
+      "target_id": "dept-eng"
+    },
+    {
+      "relationship_type": "supports",
+      "source_id": "sys-webapp",
+      "target_id": "bc-crm"
+    },
+    {
+      "relationship_type": "located_at",
+      "source_id": "site-hq",
+      "target_id": "geo-na"
+    },
+    {
+      "relationship_type": "governed_by",
+      "source_id": "geo-na",
+      "target_id": "jur-us"
+    },
+    {
+      "relationship_type": "contains",
+      "source_id": "pf-enterprise",
+      "target_id": "prd-platform"
+    },
+    {
+      "relationship_type": "targets",
+      "source_id": "prd-platform",
+      "target_id": "seg-enterprise"
+    },
+    {
+      "relationship_type": "buys",
+      "source_id": "cust-acme",
+      "target_id": "prd-platform"
+    },
+    {
+      "relationship_type": "contracts_with",
+      "source_id": "ctr-cloud",
+      "target_id": "vnd-cloud"
+    },
+    {
+      "relationship_type": "impacts",
+      "source_id": "init-cloud",
+      "target_id": "sys-erp"
+    }
+  ]
+}

--- a/examples/import-templates/people.csv
+++ b/examples/import-templates/people.csv
@@ -1,0 +1,6 @@
+name,first_name,last_name,email,title,employee_id,is_active,hire_date,department_id
+Jane Doe,Jane,Doe,jane.doe@example.com,Senior Software Engineer,EMP-001,true,2021-03-15,dept-eng
+John Smith,John,Smith,john.smith@example.com,CISO,EMP-002,true,2019-01-10,dept-sec
+Maria Garcia,Maria,Garcia,maria.garcia@example.com,Product Manager,EMP-003,true,2022-06-01,dept-product
+David Chen,David,Chen,david.chen@example.com,Security Analyst,EMP-004,true,2023-02-20,dept-sec
+Sarah Johnson,Sarah,Johnson,sarah.johnson@example.com,DevOps Engineer,EMP-005,true,2020-09-12,dept-eng

--- a/examples/import-templates/risks.csv
+++ b/examples/import-templates/risks.csv
@@ -1,0 +1,6 @@
+name,risk_id,risk_category,inherent_risk_level,residual_risk_level,risk_status,risk_owner,risk_treatment,description
+Customer Data Breach,RSK-001,Cybersecurity,High,Medium,Open,CISO,Mitigate,Unauthorized access to customer PII
+Ransomware Attack,RSK-002,Cybersecurity,Critical,High,Open,CISO,Mitigate,Encryption of critical business systems by ransomware
+Third-Party Data Leak,RSK-003,Third Party,High,Medium,Open,Vendor Manager,Transfer,Data exposure through vendor compromise
+Regulatory Non-Compliance,RSK-004,Compliance,Medium,Low,Monitoring,Compliance Officer,Mitigate,Failure to meet GDPR or SOX requirements
+Key Person Dependency,RSK-005,Operational,Medium,Medium,Open,HR Director,Accept,Critical knowledge concentrated in single individuals

--- a/examples/import-templates/systems.csv
+++ b/examples/import-templates/systems.csv
@@ -1,0 +1,6 @@
+name,system_type,hostname,ip_address,os,criticality,environment,is_internet_facing,description
+Customer Portal,application,portal-prod-01,10.1.1.100,Linux,high,production,true,Customer-facing web application
+ERP System,application,erp-prod-01,10.1.2.50,Windows Server 2022,critical,production,false,Enterprise resource planning system
+CI/CD Pipeline,infrastructure,cicd-prod-01,10.1.3.10,Linux,high,production,false,Build and deployment automation
+Email Gateway,application,mail-gw-01,172.16.0.10,Linux,high,production,true,Inbound and outbound email filtering
+Data Warehouse,database,dw-prod-01,10.1.4.20,Linux,high,production,false,Central analytics data warehouse

--- a/examples/import-templates/vendors.csv
+++ b/examples/import-templates/vendors.csv
@@ -1,0 +1,6 @@
+name,vendor_type,risk_tier,has_data_access,primary_contact,description
+CloudProvider Inc,Cloud Services,critical,true,vendor-mgmt@cloudprovider.example.com,Primary cloud infrastructure provider
+SecureSoft Ltd,Security Tools,high,true,support@securesoft.example.com,SIEM and endpoint detection vendor
+OfficeSupply Co,Office Supplies,low,false,orders@officesupply.example.com,Office equipment and supplies
+ConsultCorp,Professional Services,medium,true,engage@consultcorp.example.com,IT consulting and staff augmentation
+DataAnalytics Inc,Analytics,high,true,sales@dataanalytics.example.com,Business intelligence and analytics platform

--- a/examples/import-templates/vulnerabilities.csv
+++ b/examples/import-templates/vulnerabilities.csv
@@ -1,0 +1,6 @@
+name,cve_id,cvss_score,severity,status,exploit_available,patch_available,affected_component,description
+CVE-2024-29847,CVE-2024-29847,9.8,critical,open,true,true,Web Framework,Remote code execution in web framework dependency
+CVE-2024-21762,CVE-2024-21762,9.6,critical,remediated,true,true,VPN Gateway,Out-of-bounds write in SSL VPN
+CVE-2024-3400,CVE-2024-3400,10.0,critical,open,true,false,Firewall,Command injection in firewall management interface
+CVE-2024-1234,CVE-2024-1234,7.5,high,remediated,false,true,Database,SQL injection in stored procedure
+CVE-2024-5678,CVE-2024-5678,5.3,medium,open,false,true,Web Server,Information disclosure via error messages

--- a/tests/integration/test_import_templates.py
+++ b/tests/integration/test_import_templates.py
@@ -1,0 +1,252 @@
+"""Integration tests for import template files.
+
+Validates that all template files in examples/import-templates/ are
+syntactically correct and import successfully via the CLI.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+from domain.base import EntityType
+
+TEMPLATES_DIR = Path(__file__).parent.parent.parent / "examples" / "import-templates"
+
+
+class TestJsonTemplate:
+    """Tests for the organization.json template."""
+
+    def test_valid_json(self) -> None:
+        path = TEMPLATES_DIR / "organization.json"
+        data = json.loads(path.read_text())
+        assert "entities" in data
+        assert "relationships" in data
+
+    def test_contains_all_30_entity_types(self) -> None:
+        path = TEMPLATES_DIR / "organization.json"
+        data = json.loads(path.read_text())
+        types_found = {e["entity_type"] for e in data["entities"]}
+        all_types = {et.value for et in EntityType}
+        missing = all_types - types_found
+        assert not missing, f"Missing entity types in template: {missing}"
+
+    def test_all_entities_have_required_fields(self) -> None:
+        path = TEMPLATES_DIR / "organization.json"
+        data = json.loads(path.read_text())
+        for entity in data["entities"]:
+            assert "id" in entity, f"Entity missing id: {entity}"
+            assert "entity_type" in entity, f"Entity missing entity_type: {entity}"
+            assert "name" in entity, f"Entity missing name: {entity}"
+
+    def test_all_relationships_reference_valid_entities(self) -> None:
+        path = TEMPLATES_DIR / "organization.json"
+        data = json.loads(path.read_text())
+        entity_ids = {e["id"] for e in data["entities"]}
+        for rel in data["relationships"]:
+            assert rel["source_id"] in entity_ids, (
+                f"Relationship references unknown source: {rel['source_id']}"
+            )
+            assert rel["target_id"] in entity_ids, (
+                f"Relationship references unknown target: {rel['target_id']}"
+            )
+
+    def test_dry_run_succeeds(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["import", str(TEMPLATES_DIR / "organization.json"), "--dry-run"]
+        )
+        assert result.exit_code == 0, f"Dry run failed: {result.output}"
+
+    def test_import_succeeds(self, tmp_path: Path) -> None:
+        output = tmp_path / "graph.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["import", str(TEMPLATES_DIR / "organization.json"), "-o", str(output)],
+        )
+        assert result.exit_code == 0, f"Import failed: {result.output}"
+        assert output.exists()
+        data = json.loads(output.read_text())
+        assert len(data["entities"]) >= 30
+
+    def test_round_trip(self, tmp_path: Path) -> None:
+        """Import → export → re-import produces consistent entity count."""
+        output1 = tmp_path / "first.json"
+        output2 = tmp_path / "second.json"
+        runner = CliRunner()
+
+        # First import
+        result1 = runner.invoke(
+            cli,
+            ["import", str(TEMPLATES_DIR / "organization.json"), "-o", str(output1)],
+        )
+        assert result1.exit_code == 0
+
+        # Re-import the exported file
+        result2 = runner.invoke(
+            cli, ["import", str(output1), "-o", str(output2)]
+        )
+        assert result2.exit_code == 0
+
+        data1 = json.loads(output1.read_text())
+        data2 = json.loads(output2.read_text())
+        assert len(data1["entities"]) == len(data2["entities"])
+
+
+CSV_TEMPLATES = [
+    "people.csv",
+    "departments.csv",
+    "systems.csv",
+    "vendors.csv",
+    "vulnerabilities.csv",
+    "risks.csv",
+    "controls.csv",
+    "incidents.csv",
+]
+
+
+class TestCsvTemplates:
+    """Tests for CSV template files."""
+
+    def test_all_csv_templates_exist(self) -> None:
+        for filename in CSV_TEMPLATES:
+            path = TEMPLATES_DIR / filename
+            assert path.exists(), f"Missing CSV template: {filename}"
+
+    def test_all_csv_templates_have_headers_and_data(self) -> None:
+        for filename in CSV_TEMPLATES:
+            path = TEMPLATES_DIR / filename
+            lines = path.read_text().strip().splitlines()
+            assert len(lines) >= 2, f"{filename} needs at least header + 1 data row"
+
+    def test_people_csv_import(self, tmp_path: Path) -> None:
+        output = tmp_path / "graph.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "import",
+                str(TEMPLATES_DIR / "people.csv"),
+                "-t", "person",
+                "-o", str(output),
+            ],
+        )
+        assert result.exit_code == 0, f"Import failed: {result.output}"
+        data = json.loads(output.read_text())
+        assert len(data["entities"]) == 5
+
+    def test_departments_csv_import(self, tmp_path: Path) -> None:
+        output = tmp_path / "graph.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "import",
+                str(TEMPLATES_DIR / "departments.csv"),
+                "-t", "department",
+                "-o", str(output),
+            ],
+        )
+        assert result.exit_code == 0, f"Import failed: {result.output}"
+        data = json.loads(output.read_text())
+        assert len(data["entities"]) == 5
+
+    def test_systems_csv_import(self, tmp_path: Path) -> None:
+        output = tmp_path / "graph.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "import",
+                str(TEMPLATES_DIR / "systems.csv"),
+                "-t", "system",
+                "-o", str(output),
+            ],
+        )
+        assert result.exit_code == 0, f"Import failed: {result.output}"
+        data = json.loads(output.read_text())
+        assert len(data["entities"]) == 5
+
+    def test_vendors_csv_import(self, tmp_path: Path) -> None:
+        output = tmp_path / "graph.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "import",
+                str(TEMPLATES_DIR / "vendors.csv"),
+                "-t", "vendor",
+                "-o", str(output),
+            ],
+        )
+        assert result.exit_code == 0, f"Import failed: {result.output}"
+        data = json.loads(output.read_text())
+        assert len(data["entities"]) == 5
+
+    def test_vulnerabilities_csv_import(self, tmp_path: Path) -> None:
+        output = tmp_path / "graph.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "import",
+                str(TEMPLATES_DIR / "vulnerabilities.csv"),
+                "-t", "vulnerability",
+                "-o", str(output),
+            ],
+        )
+        assert result.exit_code == 0, f"Import failed: {result.output}"
+        data = json.loads(output.read_text())
+        assert len(data["entities"]) == 5
+
+    def test_risks_csv_import(self, tmp_path: Path) -> None:
+        output = tmp_path / "graph.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "import",
+                str(TEMPLATES_DIR / "risks.csv"),
+                "-t", "risk",
+                "-o", str(output),
+            ],
+        )
+        assert result.exit_code == 0, f"Import failed: {result.output}"
+        data = json.loads(output.read_text())
+        assert len(data["entities"]) == 5
+
+    def test_controls_csv_import(self, tmp_path: Path) -> None:
+        output = tmp_path / "graph.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "import",
+                str(TEMPLATES_DIR / "controls.csv"),
+                "-t", "control",
+                "-o", str(output),
+            ],
+        )
+        assert result.exit_code == 0, f"Import failed: {result.output}"
+        data = json.loads(output.read_text())
+        assert len(data["entities"]) == 5
+
+    def test_incidents_csv_import(self, tmp_path: Path) -> None:
+        output = tmp_path / "graph.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "import",
+                str(TEMPLATES_DIR / "incidents.csv"),
+                "-t", "incident",
+                "-o", str(output),
+            ],
+        )
+        assert result.exit_code == 0, f"Import failed: {result.output}"
+        data = json.loads(output.read_text())
+        assert len(data["entities"]) == 5


### PR DESCRIPTION
## Summary
- `examples/import-templates/organization.json` — comprehensive JSON template covering all 30 entity types with 31 relationships
- 8 CSV templates: people, departments, systems, vendors, vulnerabilities, risks, controls, incidents (5 rows each)
- All entity fields validated against actual model schemas (no `extra="allow"` pitfalls)
- All relationship types validated against RelationshipType enum
- 17 integration tests: JSON structure, 30-type coverage, field validation, referential integrity, dry-run, import, round-trip, CSV import per template

Closes #236

## Test plan
- [x] All 1012 tests pass, 0 failures
- [x] Ruff lint clean
- [x] JSON template imports cleanly (`hckg import --dry-run`)
- [x] JSON template round-trips (import → export → re-import)
- [x] All 8 CSV templates import successfully
- [x] All 30 entity types present in JSON template