### PR TITLE
feat: complete import templates for all 30 entity types

### DIFF
--- a/examples/import-templates/business_capability.csv
+++ b/examples/import-templates/business_capability.csv
@@ -1,0 +1,6 @@
+name,description,capability_id,tier,capability_type,business_criticality,lifecycle_state
+Customer Relationship Management,End-to-end customer lifecycle management,BC-001,Strategic,Business,Business Critical,Active
+Identity and Access Management,Authentication and authorization services,BC-002,Component,Technology,Mission Critical,Active
+Financial Reporting,Regulatory and management financial reporting,BC-003,Strategic,Business,Business Critical,Active
+Software Development,"Application build, test, and deploy",BC-004,Component,Technology,Business Operational,Active
+Talent Acquisition,Recruiting and onboarding,BC-005,Business,Business,Business Operational,Active

--- a/examples/import-templates/business_capability.json
+++ b/examples/import-templates/business_capability.json
@@ -1,0 +1,37 @@
+{
+  "entities": [
+    {
+      "id": "bc-001",
+      "entity_type": "business_capability",
+      "name": "Customer Relationship Management",
+      "description": "End-to-end customer lifecycle management",
+      "capability_id": "BC-001",
+      "tier": "Strategic",
+      "capability_type": "Business",
+      "business_criticality": "Business Critical",
+      "lifecycle_state": "Active"
+    },
+    {
+      "id": "bc-002",
+      "entity_type": "business_capability",
+      "name": "Identity and Access Management",
+      "description": "Authentication and authorization services",
+      "capability_id": "BC-002",
+      "tier": "Component",
+      "capability_type": "Technology",
+      "business_criticality": "Mission Critical",
+      "lifecycle_state": "Active"
+    },
+    {
+      "id": "bc-003",
+      "entity_type": "business_capability",
+      "name": "Financial Reporting",
+      "description": "Regulatory and management financial reporting",
+      "capability_id": "BC-003",
+      "tier": "Strategic",
+      "capability_type": "Business",
+      "business_criticality": "Business Critical",
+      "lifecycle_state": "Active"
+    }
+  ]
+}

--- a/examples/import-templates/contract.csv
+++ b/examples/import-templates/contract.csv
@@ -1,0 +1,6 @@
+name,description,contract_id,contract_type,contract_status,total_contract_value,currency,start_date,end_date
+Cloud Services MSA,Cloud infrastructure master agreement,CTR-001,Master Services Agreement,Active,2500000,USD,2023-01-01,2026-01-01
+Security Tools License,SIEM and EDR annual license,CTR-002,Software License,Active,450000,USD,2024-03-01,2025-03-01
+Consulting Engagement,IT transformation consulting,CTR-003,Statement of Work,Active,800000,USD,2024-06-01,2025-06-01
+Office Lease NYC,Headquarters office lease,CTR-004,Lease,Active,3600000,USD,2020-01-01,2030-01-01
+Data Center Colocation,Ashburn DC colocation agreement,CTR-005,Colocation Agreement,Active,1200000,USD,2022-07-01,2027-07-01

--- a/examples/import-templates/contract.json
+++ b/examples/import-templates/contract.json
@@ -1,0 +1,43 @@
+{
+  "entities": [
+    {
+      "id": "ctr-001",
+      "entity_type": "contract",
+      "name": "Cloud Services MSA",
+      "description": "Cloud infrastructure master agreement",
+      "contract_id": "CTR-001",
+      "contract_type": "Master Services Agreement",
+      "contract_status": "Active",
+      "total_contract_value": 2500000.0,
+      "currency": "USD",
+      "start_date": "2023-01-01",
+      "end_date": "2026-01-01"
+    },
+    {
+      "id": "ctr-002",
+      "entity_type": "contract",
+      "name": "Security Tools License",
+      "description": "SIEM and EDR annual license",
+      "contract_id": "CTR-002",
+      "contract_type": "Software License",
+      "contract_status": "Active",
+      "total_contract_value": 450000.0,
+      "currency": "USD",
+      "start_date": "2024-03-01",
+      "end_date": "2025-03-01"
+    },
+    {
+      "id": "ctr-003",
+      "entity_type": "contract",
+      "name": "Consulting Engagement",
+      "description": "IT transformation consulting",
+      "contract_id": "CTR-003",
+      "contract_type": "Statement of Work",
+      "contract_status": "Active",
+      "total_contract_value": 800000.0,
+      "currency": "USD",
+      "start_date": "2024-06-01",
+      "end_date": "2025-06-01"
+    }
+  ]
+}

--- a/examples/import-templates/control.csv
+++ b/examples/import-templates/control.csv
@@ -1,0 +1,6 @@
+name,description,control_id,control_type,control_domain,control_status,control_owner
+Multi-Factor Authentication,MFA for all privileged and remote access,CTL-001,Preventive,Access Control,Implemented,Identity Team
+Endpoint Detection and Response,EDR on all managed endpoints,CTL-002,Detective,Endpoint Security,Implemented,SOC Team
+Network Segmentation,Microsegmentation between production zones,CTL-003,Preventive,Network Security,Implemented,Network Team
+Data Loss Prevention,DLP on email and cloud storage,CTL-004,Detective,Data Security,Partially Implemented,Data Security Team
+Vulnerability Scanning,Weekly automated scans of all assets,CTL-005,Detective,Vulnerability Management,Implemented,Security Engineering

--- a/examples/import-templates/control.json
+++ b/examples/import-templates/control.json
@@ -1,0 +1,37 @@
+{
+  "entities": [
+    {
+      "id": "ctl-001",
+      "entity_type": "control",
+      "name": "Multi-Factor Authentication",
+      "description": "MFA for all privileged and remote access",
+      "control_id": "CTL-001",
+      "control_type": "Preventive",
+      "control_domain": "Access Control",
+      "control_status": "Implemented",
+      "control_owner": "Identity Team"
+    },
+    {
+      "id": "ctl-002",
+      "entity_type": "control",
+      "name": "Endpoint Detection and Response",
+      "description": "EDR on all managed endpoints",
+      "control_id": "CTL-002",
+      "control_type": "Detective",
+      "control_domain": "Endpoint Security",
+      "control_status": "Implemented",
+      "control_owner": "SOC Team"
+    },
+    {
+      "id": "ctl-003",
+      "entity_type": "control",
+      "name": "Network Segmentation",
+      "description": "Microsegmentation between production zones",
+      "control_id": "CTL-003",
+      "control_type": "Preventive",
+      "control_domain": "Network Security",
+      "control_status": "Implemented",
+      "control_owner": "Network Team"
+    }
+  ]
+}

--- a/examples/import-templates/controls.csv
+++ b/examples/import-templates/controls.csv
@@ -1,6 +1,0 @@
-name,control_id,control_type,control_domain,control_status,control_owner,description
-Multi-Factor Authentication,CTL-001,Preventive,Access Control,Implemented,Identity Team,MFA required for all privileged and remote access
-Endpoint Detection and Response,CTL-002,Detective,Endpoint Security,Implemented,SOC Team,EDR agents deployed on all managed endpoints
-Network Segmentation,CTL-003,Preventive,Network Security,Implemented,Network Team,Microsegmentation between production zones
-Data Loss Prevention,CTL-004,Detective,Data Security,Partially Implemented,Data Security Team,DLP monitoring on email and cloud storage
-Vulnerability Scanning,CTL-005,Detective,Vulnerability Management,Implemented,Security Engineering,Weekly automated vulnerability scans of all assets

--- a/examples/import-templates/customer.csv
+++ b/examples/import-templates/customer.csv
@@ -1,0 +1,6 @@
+name,description,customer_id,customer_type,account_tier,relationship_status
+Acme Corp,Strategic enterprise customer,CUST-001,Enterprise,Strategic,Active
+Global Bank,Major financial services client,CUST-002,Enterprise,Strategic,Active
+HealthCo,Regional healthcare provider,CUST-003,Mid-Market,Growth,Active
+TechStart Inc,Growing technology startup,CUST-004,SMB,Standard,Active
+RetailMax,National retail chain,CUST-005,Enterprise,Key,At Risk

--- a/examples/import-templates/customer.json
+++ b/examples/import-templates/customer.json
@@ -1,0 +1,34 @@
+{
+  "entities": [
+    {
+      "id": "cust-001",
+      "entity_type": "customer",
+      "name": "Acme Corp",
+      "description": "Strategic enterprise customer",
+      "customer_id": "CUST-001",
+      "customer_type": "Enterprise",
+      "account_tier": "Strategic",
+      "relationship_status": "Active"
+    },
+    {
+      "id": "cust-002",
+      "entity_type": "customer",
+      "name": "Global Bank",
+      "description": "Major financial services client",
+      "customer_id": "CUST-002",
+      "customer_type": "Enterprise",
+      "account_tier": "Strategic",
+      "relationship_status": "Active"
+    },
+    {
+      "id": "cust-003",
+      "entity_type": "customer",
+      "name": "HealthCo",
+      "description": "Regional healthcare provider",
+      "customer_id": "CUST-003",
+      "customer_type": "Mid-Market",
+      "account_tier": "Growth",
+      "relationship_status": "Active"
+    }
+  ]
+}

--- a/examples/import-templates/data_asset.csv
+++ b/examples/import-templates/data_asset.csv
@@ -1,0 +1,6 @@
+name,description,data_type,classification,format,is_encrypted,retention_days
+Customer Database,Primary customer records,structured,confidential,PostgreSQL,true,2555
+Employee Records,HR personnel data,structured,restricted,Oracle,true,3650
+Transaction Logs,Payment processing logs,semi-structured,confidential,JSON,true,365
+Marketing Analytics,Campaign performance data,structured,internal,Snowflake,false,730
+Audit Trail,System access and change logs,semi-structured,confidential,Elasticsearch,true,2555

--- a/examples/import-templates/data_asset.json
+++ b/examples/import-templates/data_asset.json
@@ -1,0 +1,37 @@
+{
+  "entities": [
+    {
+      "id": "da-001",
+      "entity_type": "data_asset",
+      "name": "Customer Database",
+      "description": "Primary customer records",
+      "data_type": "structured",
+      "classification": "confidential",
+      "format": "PostgreSQL",
+      "is_encrypted": true,
+      "retention_days": 2555
+    },
+    {
+      "id": "da-002",
+      "entity_type": "data_asset",
+      "name": "Employee Records",
+      "description": "HR personnel data",
+      "data_type": "structured",
+      "classification": "restricted",
+      "format": "Oracle",
+      "is_encrypted": true,
+      "retention_days": 3650
+    },
+    {
+      "id": "da-003",
+      "entity_type": "data_asset",
+      "name": "Transaction Logs",
+      "description": "Payment processing logs",
+      "data_type": "semi-structured",
+      "classification": "confidential",
+      "format": "JSON",
+      "is_encrypted": true,
+      "retention_days": 365
+    }
+  ]
+}

--- a/examples/import-templates/data_domain.csv
+++ b/examples/import-templates/data_domain.csv
@@ -1,0 +1,6 @@
+name,description,domain_id,domain_type,domain_owner,data_classification,maturity_level,strategic_value
+Customer Data,All customer-related data assets,DD-001,Business,Data Governance Lead,Confidential,Managed,High
+Financial Data,Accounting and financial reporting data,DD-002,Business,CFO,Restricted,Optimized,Critical
+Employee Data,HR and personnel records,DD-003,Business,CHRO,Restricted,Managed,High
+Product Data,Product catalog and engineering data,DD-004,Technical,VP Product,Internal,Developing,Medium
+Security Data,"Logs, alerts, and threat intelligence",DD-005,Technical,CISO,Confidential,Managed,High

--- a/examples/import-templates/data_domain.json
+++ b/examples/import-templates/data_domain.json
@@ -1,0 +1,40 @@
+{
+  "entities": [
+    {
+      "id": "dd-001",
+      "entity_type": "data_domain",
+      "name": "Customer Data",
+      "description": "All customer-related data assets",
+      "domain_id": "DD-001",
+      "domain_type": "Business",
+      "domain_owner": "Data Governance Lead",
+      "data_classification": "Confidential",
+      "maturity_level": "Managed",
+      "strategic_value": "High"
+    },
+    {
+      "id": "dd-002",
+      "entity_type": "data_domain",
+      "name": "Financial Data",
+      "description": "Accounting and financial reporting data",
+      "domain_id": "DD-002",
+      "domain_type": "Business",
+      "domain_owner": "CFO",
+      "data_classification": "Restricted",
+      "maturity_level": "Optimized",
+      "strategic_value": "Critical"
+    },
+    {
+      "id": "dd-003",
+      "entity_type": "data_domain",
+      "name": "Employee Data",
+      "description": "HR and personnel records",
+      "domain_id": "DD-003",
+      "domain_type": "Business",
+      "domain_owner": "CHRO",
+      "data_classification": "Restricted",
+      "maturity_level": "Managed",
+      "strategic_value": "High"
+    }
+  ]
+}

--- a/examples/import-templates/data_flow.csv
+++ b/examples/import-templates/data_flow.csv
@@ -1,0 +1,6 @@
+name,description,flow_id,flow_type,data_classification_in_flow,frequency,operational_status,monitoring_status
+CRM to Data Warehouse,Nightly customer data ETL,DF-001,ETL,Confidential,Daily,Active,Monitored
+HRIS to IAM,Employee provisioning feed,DF-002,Event-Driven,Restricted,Real-Time,Active,Monitored
+Payment Processing,Transaction data to payment gateway,DF-003,API,Restricted,Real-Time,Active,Monitored
+Log Aggregation,Security logs to SIEM,DF-004,Streaming,Internal,Real-Time,Active,Monitored
+Reporting Feed,Analytics data to BI platform,DF-005,ETL,Internal,Hourly,Active,Unmonitored

--- a/examples/import-templates/data_flow.json
+++ b/examples/import-templates/data_flow.json
@@ -1,0 +1,40 @@
+{
+  "entities": [
+    {
+      "id": "df-001",
+      "entity_type": "data_flow",
+      "name": "CRM to Data Warehouse",
+      "description": "Nightly customer data ETL",
+      "flow_id": "DF-001",
+      "flow_type": "ETL",
+      "data_classification_in_flow": "Confidential",
+      "frequency": "Daily",
+      "operational_status": "Active",
+      "monitoring_status": "Monitored"
+    },
+    {
+      "id": "df-002",
+      "entity_type": "data_flow",
+      "name": "HRIS to IAM",
+      "description": "Employee provisioning feed",
+      "flow_id": "DF-002",
+      "flow_type": "Event-Driven",
+      "data_classification_in_flow": "Restricted",
+      "frequency": "Real-Time",
+      "operational_status": "Active",
+      "monitoring_status": "Monitored"
+    },
+    {
+      "id": "df-003",
+      "entity_type": "data_flow",
+      "name": "Payment Processing",
+      "description": "Transaction data to payment gateway",
+      "flow_id": "DF-003",
+      "flow_type": "API",
+      "data_classification_in_flow": "Restricted",
+      "frequency": "Real-Time",
+      "operational_status": "Active",
+      "monitoring_status": "Monitored"
+    }
+  ]
+}

--- a/examples/import-templates/department.csv
+++ b/examples/import-templates/department.csv
@@ -1,0 +1,6 @@
+name,description,code,headcount,budget
+Engineering,Software engineering and platform development,ENG,45,5000000
+Information Security,Cybersecurity and risk management,SEC,12,2000000
+Product Management,Product strategy and roadmap,PROD,8,1500000
+Human Resources,People operations and talent management,HR,10,1200000
+Finance,Financial planning and accounting,FIN,15,1800000

--- a/examples/import-templates/department.json
+++ b/examples/import-templates/department.json
@@ -1,0 +1,31 @@
+{
+  "entities": [
+    {
+      "id": "dept-001",
+      "entity_type": "department",
+      "name": "Engineering",
+      "description": "Software engineering and platform development",
+      "code": "ENG",
+      "headcount": 45,
+      "budget": 5000000.0
+    },
+    {
+      "id": "dept-002",
+      "entity_type": "department",
+      "name": "Information Security",
+      "description": "Cybersecurity and risk management",
+      "code": "SEC",
+      "headcount": 12,
+      "budget": 2000000.0
+    },
+    {
+      "id": "dept-003",
+      "entity_type": "department",
+      "name": "Product Management",
+      "description": "Product strategy and roadmap",
+      "code": "PROD",
+      "headcount": 8,
+      "budget": 1500000.0
+    }
+  ]
+}

--- a/examples/import-templates/departments.csv
+++ b/examples/import-templates/departments.csv
@@ -1,6 +1,0 @@
-name,description,code,headcount,head_id,parent_department_id
-Engineering,Software engineering and platform development,ENG,45,,
-Information Security,Cybersecurity and risk management,SEC,12,,
-Product Management,Product strategy and roadmap,PROD,8,,
-Human Resources,People operations and talent management,HR,10,,
-Finance,Financial planning and accounting,FIN,15,,

--- a/examples/import-templates/geography.csv
+++ b/examples/import-templates/geography.csv
@@ -1,0 +1,6 @@
+name,description,geography_id,geography_type,parent_geography
+North America,North American operating region,GEO-001,Region,
+Europe,European operating region,GEO-002,Region,
+Asia Pacific,APAC operating region,GEO-003,Region,
+United States,US market,GEO-004,Country,North America
+United Kingdom,UK market,GEO-005,Country,Europe

--- a/examples/import-templates/geography.json
+++ b/examples/import-templates/geography.json
@@ -1,0 +1,28 @@
+{
+  "entities": [
+    {
+      "id": "geo-001",
+      "entity_type": "geography",
+      "name": "North America",
+      "description": "North American operating region",
+      "geography_id": "GEO-001",
+      "geography_type": "Region"
+    },
+    {
+      "id": "geo-002",
+      "entity_type": "geography",
+      "name": "Europe",
+      "description": "European operating region",
+      "geography_id": "GEO-002",
+      "geography_type": "Region"
+    },
+    {
+      "id": "geo-003",
+      "entity_type": "geography",
+      "name": "Asia Pacific",
+      "description": "APAC operating region",
+      "geography_id": "GEO-003",
+      "geography_type": "Region"
+    }
+  ]
+}

--- a/examples/import-templates/incident.csv
+++ b/examples/import-templates/incident.csv
@@ -1,0 +1,6 @@
+name,description,incident_type,severity,status,detection_method,occurred_at,detected_at,resolved_at
+Phishing Campaign Detected,Targeted phishing emails to finance dept,phishing,high,resolved,email gateway,2024-11-15T08:30:00Z,2024-11-15T09:15:00Z,2024-11-15T14:00:00Z
+Unauthorized Access Attempt,Brute force login attempts on VPN,unauthorized_access,medium,resolved,SIEM,2024-10-22T03:00:00Z,2024-10-22T03:12:00Z,2024-10-22T06:00:00Z
+Malware Detection,Trojan on developer workstation,malware,high,resolved,EDR,2024-09-10T14:20:00Z,2024-09-10T14:22:00Z,2024-09-11T10:00:00Z
+Data Exposure,Cloud storage bucket publicly accessible,data_exposure,critical,resolved,external report,2024-08-05T00:00:00Z,2024-08-06T09:00:00Z,2024-08-06T15:00:00Z
+DDoS Attack,Volumetric attack on customer portal,ddos,medium,resolved,WAF,2024-07-18T11:00:00Z,2024-07-18T11:05:00Z,2024-07-18T13:30:00Z

--- a/examples/import-templates/incident.json
+++ b/examples/import-templates/incident.json
@@ -1,0 +1,43 @@
+{
+  "entities": [
+    {
+      "id": "inc-001",
+      "entity_type": "incident",
+      "name": "Phishing Campaign Detected",
+      "description": "Targeted phishing emails to finance dept",
+      "incident_type": "phishing",
+      "severity": "high",
+      "status": "resolved",
+      "detection_method": "email gateway",
+      "occurred_at": "2024-11-15T08:30:00Z",
+      "detected_at": "2024-11-15T09:15:00Z",
+      "resolved_at": "2024-11-15T14:00:00Z"
+    },
+    {
+      "id": "inc-002",
+      "entity_type": "incident",
+      "name": "Unauthorized Access Attempt",
+      "description": "Brute force login attempts on VPN",
+      "incident_type": "unauthorized_access",
+      "severity": "medium",
+      "status": "resolved",
+      "detection_method": "SIEM",
+      "occurred_at": "2024-10-22T03:00:00Z",
+      "detected_at": "2024-10-22T03:12:00Z",
+      "resolved_at": "2024-10-22T06:00:00Z"
+    },
+    {
+      "id": "inc-003",
+      "entity_type": "incident",
+      "name": "Malware Detection",
+      "description": "Trojan on developer workstation",
+      "incident_type": "malware",
+      "severity": "high",
+      "status": "resolved",
+      "detection_method": "EDR",
+      "occurred_at": "2024-09-10T14:20:00Z",
+      "detected_at": "2024-09-10T14:22:00Z",
+      "resolved_at": "2024-09-11T10:00:00Z"
+    }
+  ]
+}

--- a/examples/import-templates/incidents.csv
+++ b/examples/import-templates/incidents.csv
@@ -1,6 +1,0 @@
-name,incident_type,severity,status,detection_method,occurred_at,detected_at,resolved_at,impact_description,description
-Phishing Campaign Detected,phishing,high,resolved,email gateway,2024-11-15T08:30:00Z,2024-11-15T09:15:00Z,2024-11-15T14:00:00Z,3 users clicked malicious links,Targeted phishing emails sent to finance department
-Unauthorized Access Attempt,unauthorized_access,medium,resolved,SIEM,2024-10-22T03:00:00Z,2024-10-22T03:12:00Z,2024-10-22T06:00:00Z,No data exfiltration confirmed,Brute force login attempts against VPN gateway
-Malware Detection on Endpoint,malware,high,resolved,EDR,2024-09-10T14:20:00Z,2024-09-10T14:22:00Z,2024-09-11T10:00:00Z,One workstation isolated and reimaged,Trojan detected on developer workstation
-Data Exposure via Misconfiguration,data_exposure,critical,resolved,external report,2024-08-05T00:00:00Z,2024-08-06T09:00:00Z,2024-08-06T15:00:00Z,S3 bucket with internal docs was publicly accessible,Cloud storage bucket left publicly accessible
-DDoS Attack on Web Services,ddos,medium,resolved,WAF,2024-07-18T11:00:00Z,2024-07-18T11:05:00Z,2024-07-18T13:30:00Z,Customer portal intermittent for 2.5 hours,Volumetric DDoS attack against customer portal

--- a/examples/import-templates/initiative.csv
+++ b/examples/import-templates/initiative.csv
@@ -1,0 +1,6 @@
+name,description,initiative_id,initiative_type,initiative_tier,current_status,executive_sponsor,planned_start_date,planned_end_date
+Cloud Migration,Multi-year cloud migration program,SI-001,Digital Transformation,Tier 1,In Progress,CTO,2024-01-01,2026-12-31
+Zero Trust Architecture,Network security modernization,SI-002,Security,Tier 1,In Progress,CISO,2024-06-01,2025-12-31
+Data Platform Modernization,Unified data lake and analytics,SI-003,Digital Transformation,Tier 2,Planning,CDO,2025-01-01,2026-06-30
+ERP Upgrade,Major ERP version upgrade,SI-004,Infrastructure,Tier 2,In Progress,CFO,2024-03-01,2025-03-01
+Customer Experience Redesign,Digital customer journey overhaul,SI-005,Business,Tier 1,Planning,CMO,2025-03-01,2026-03-01

--- a/examples/import-templates/initiative.json
+++ b/examples/import-templates/initiative.json
@@ -1,0 +1,43 @@
+{
+  "entities": [
+    {
+      "id": "init-001",
+      "entity_type": "initiative",
+      "name": "Cloud Migration",
+      "description": "Multi-year cloud migration program",
+      "initiative_id": "SI-001",
+      "initiative_type": "Digital Transformation",
+      "initiative_tier": "Tier 1",
+      "current_status": "In Progress",
+      "executive_sponsor": "CTO",
+      "planned_start_date": "2024-01-01",
+      "planned_end_date": "2026-12-31"
+    },
+    {
+      "id": "init-002",
+      "entity_type": "initiative",
+      "name": "Zero Trust Architecture",
+      "description": "Network security modernization",
+      "initiative_id": "SI-002",
+      "initiative_type": "Security",
+      "initiative_tier": "Tier 1",
+      "current_status": "In Progress",
+      "executive_sponsor": "CISO",
+      "planned_start_date": "2024-06-01",
+      "planned_end_date": "2025-12-31"
+    },
+    {
+      "id": "init-003",
+      "entity_type": "initiative",
+      "name": "Data Platform Modernization",
+      "description": "Unified data lake and analytics",
+      "initiative_id": "SI-003",
+      "initiative_type": "Digital Transformation",
+      "initiative_tier": "Tier 2",
+      "current_status": "Planning",
+      "executive_sponsor": "CDO",
+      "planned_start_date": "2025-01-01",
+      "planned_end_date": "2026-06-30"
+    }
+  ]
+}

--- a/examples/import-templates/integration.csv
+++ b/examples/import-templates/integration.csv
@@ -1,0 +1,6 @@
+name,description,integration_id,integration_type,integration_pattern,direction,frequency,operational_status
+CRM to ERP Integration,Customer data sync between CRM and ERP,INT-001,API,Request-Response,Bidirectional,Real-Time,Active
+HRIS to IAM Sync,Employee lifecycle provisioning,INT-002,ETL,Batch,Unidirectional,Daily,Active
+SIEM Log Ingestion,Security log aggregation from all sources,INT-003,Streaming,Publish-Subscribe,Unidirectional,Real-Time,Active
+Payment Gateway,Payment processing integration,INT-004,API,Request-Response,Bidirectional,Real-Time,Active
+Data Warehouse Load,Nightly load from operational systems,INT-005,ETL,Batch,Unidirectional,Daily,Active

--- a/examples/import-templates/integration.json
+++ b/examples/import-templates/integration.json
@@ -1,0 +1,40 @@
+{
+  "entities": [
+    {
+      "id": "int-001",
+      "entity_type": "integration",
+      "name": "CRM to ERP Integration",
+      "description": "Customer data sync between CRM and ERP",
+      "integration_id": "INT-001",
+      "integration_type": "API",
+      "integration_pattern": "Request-Response",
+      "direction": "Bidirectional",
+      "frequency": "Real-Time",
+      "operational_status": "Active"
+    },
+    {
+      "id": "int-002",
+      "entity_type": "integration",
+      "name": "HRIS to IAM Sync",
+      "description": "Employee lifecycle provisioning",
+      "integration_id": "INT-002",
+      "integration_type": "ETL",
+      "integration_pattern": "Batch",
+      "direction": "Unidirectional",
+      "frequency": "Daily",
+      "operational_status": "Active"
+    },
+    {
+      "id": "int-003",
+      "entity_type": "integration",
+      "name": "SIEM Log Ingestion",
+      "description": "Security log aggregation",
+      "integration_id": "INT-003",
+      "integration_type": "Streaming",
+      "integration_pattern": "Publish-Subscribe",
+      "direction": "Unidirectional",
+      "frequency": "Real-Time",
+      "operational_status": "Active"
+    }
+  ]
+}

--- a/examples/import-templates/jurisdiction.csv
+++ b/examples/import-templates/jurisdiction.csv
@@ -1,0 +1,6 @@
+name,description,jurisdiction_id,jurisdiction_type,jurisdiction_code,parent_jurisdiction
+United States Federal,US federal regulatory jurisdiction,JUR-001,Federal,US,
+European Union,EU regulatory jurisdiction,JUR-002,Supranational,EU,
+State of California,California state jurisdiction,JUR-003,State,US-CA,United States Federal
+State of New York,New York state jurisdiction,JUR-004,State,US-NY,United States Federal
+United Kingdom,UK regulatory jurisdiction,JUR-005,National,GB,

--- a/examples/import-templates/jurisdiction.json
+++ b/examples/import-templates/jurisdiction.json
@@ -1,0 +1,32 @@
+{
+  "entities": [
+    {
+      "id": "jur-001",
+      "entity_type": "jurisdiction",
+      "name": "United States Federal",
+      "description": "US federal regulatory jurisdiction",
+      "jurisdiction_id": "JUR-001",
+      "jurisdiction_type": "Federal",
+      "jurisdiction_code": "US"
+    },
+    {
+      "id": "jur-002",
+      "entity_type": "jurisdiction",
+      "name": "European Union",
+      "description": "EU regulatory jurisdiction",
+      "jurisdiction_id": "JUR-002",
+      "jurisdiction_type": "Supranational",
+      "jurisdiction_code": "EU"
+    },
+    {
+      "id": "jur-003",
+      "entity_type": "jurisdiction",
+      "name": "State of California",
+      "description": "California state jurisdiction",
+      "jurisdiction_id": "JUR-003",
+      "jurisdiction_type": "State",
+      "jurisdiction_code": "US-CA",
+      "parent_jurisdiction": "United States Federal"
+    }
+  ]
+}

--- a/examples/import-templates/location.csv
+++ b/examples/import-templates/location.csv
@@ -1,0 +1,6 @@
+name,description,address,city,state,country,location_type,is_primary
+Headquarters,Corporate headquarters,100 Main Street,New York,NY,US,office,true
+West Coast Office,San Francisco engineering hub,500 Market Street,San Francisco,CA,US,office,false
+Data Center East,Primary data center,200 Industrial Park,Ashburn,VA,US,data_center,true
+London Office,EMEA headquarters,10 Finsbury Square,London,,GB,office,false
+Singapore Office,APAC headquarters,1 Raffles Place,Singapore,,SG,office,false

--- a/examples/import-templates/location.json
+++ b/examples/import-templates/location.json
@@ -1,0 +1,40 @@
+{
+  "entities": [
+    {
+      "id": "loc-001",
+      "entity_type": "location",
+      "name": "Headquarters",
+      "description": "Corporate headquarters",
+      "address": "100 Main Street",
+      "city": "New York",
+      "state": "NY",
+      "country": "US",
+      "location_type": "office",
+      "is_primary": true
+    },
+    {
+      "id": "loc-002",
+      "entity_type": "location",
+      "name": "West Coast Office",
+      "description": "San Francisco engineering hub",
+      "address": "500 Market Street",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "US",
+      "location_type": "office",
+      "is_primary": false
+    },
+    {
+      "id": "loc-003",
+      "entity_type": "location",
+      "name": "Data Center East",
+      "description": "Primary data center",
+      "address": "200 Industrial Park",
+      "city": "Ashburn",
+      "state": "VA",
+      "country": "US",
+      "location_type": "data_center",
+      "is_primary": true
+    }
+  ]
+}

--- a/examples/import-templates/market_segment.csv
+++ b/examples/import-templates/market_segment.csv
@@ -1,0 +1,6 @@
+name,description,segment_id,segment_type,competitive_intensity,strategic_priority
+Enterprise,Large enterprise customers 1000+ employees,SEG-001,Company Size,High,Primary
+Mid-Market,Mid-size companies 100-999 employees,SEG-002,Company Size,Medium,Secondary
+Financial Services,Banking and insurance vertical,SEG-003,Industry,High,Primary
+Healthcare,Hospitals and health systems,SEG-004,Industry,Medium,Emerging
+Government,Federal and state government agencies,SEG-005,Industry,Low,Opportunistic

--- a/examples/import-templates/market_segment.json
+++ b/examples/import-templates/market_segment.json
@@ -1,0 +1,34 @@
+{
+  "entities": [
+    {
+      "id": "seg-001",
+      "entity_type": "market_segment",
+      "name": "Enterprise",
+      "description": "Large enterprise customers 1000+ employees",
+      "segment_id": "SEG-001",
+      "segment_type": "Company Size",
+      "competitive_intensity": "High",
+      "strategic_priority": "Primary"
+    },
+    {
+      "id": "seg-002",
+      "entity_type": "market_segment",
+      "name": "Mid-Market",
+      "description": "Mid-size companies 100-999 employees",
+      "segment_id": "SEG-002",
+      "segment_type": "Company Size",
+      "competitive_intensity": "Medium",
+      "strategic_priority": "Secondary"
+    },
+    {
+      "id": "seg-003",
+      "entity_type": "market_segment",
+      "name": "Financial Services",
+      "description": "Banking and insurance vertical",
+      "segment_id": "SEG-003",
+      "segment_type": "Industry",
+      "competitive_intensity": "High",
+      "strategic_priority": "Primary"
+    }
+  ]
+}

--- a/examples/import-templates/network.csv
+++ b/examples/import-templates/network.csv
@@ -1,0 +1,6 @@
+name,description,zone,cidr,vlan_id,gateway,is_monitored
+Corporate LAN,Primary corporate network,internal,10.1.0.0/16,100,10.1.0.1,true
+DMZ,Internet-facing services zone,dmz,172.16.0.0/24,200,172.16.0.1,true
+Guest WiFi,Isolated guest network,guest,192.168.100.0/24,300,192.168.100.1,true
+Development,Developer and CI/CD network,internal,10.2.0.0/16,400,10.2.0.1,false
+Restricted,PCI and regulated workloads,restricted,10.3.0.0/24,500,10.3.0.1,true

--- a/examples/import-templates/network.json
+++ b/examples/import-templates/network.json
@@ -1,0 +1,37 @@
+{
+  "entities": [
+    {
+      "id": "net-001",
+      "entity_type": "network",
+      "name": "Corporate LAN",
+      "description": "Primary corporate network",
+      "zone": "internal",
+      "cidr": "10.1.0.0/16",
+      "vlan_id": 100,
+      "gateway": "10.1.0.1",
+      "is_monitored": true
+    },
+    {
+      "id": "net-002",
+      "entity_type": "network",
+      "name": "DMZ",
+      "description": "Internet-facing services zone",
+      "zone": "dmz",
+      "cidr": "172.16.0.0/24",
+      "vlan_id": 200,
+      "gateway": "172.16.0.1",
+      "is_monitored": true
+    },
+    {
+      "id": "net-003",
+      "entity_type": "network",
+      "name": "Restricted",
+      "description": "PCI and regulated workloads",
+      "zone": "restricted",
+      "cidr": "10.3.0.0/24",
+      "vlan_id": 500,
+      "gateway": "10.3.0.1",
+      "is_monitored": true
+    }
+  ]
+}

--- a/examples/import-templates/organizational_unit.csv
+++ b/examples/import-templates/organizational_unit.csv
@@ -1,0 +1,6 @@
+name,description,unit_id,unit_type,operating_model,functional_domain_primary
+Technology Division,All engineering and IT functions,OU-001,Division,Hybrid,Technology
+Commercial Division,"Sales, marketing, and customer success",OU-002,Division,Centralized,Commercial
+Risk & Compliance,Enterprise risk and regulatory compliance,OU-003,Department Group,Centralized,Governance
+Product Engineering,Product development and platform teams,OU-004,Department Group,Agile,Technology
+Shared Services,"Finance, HR, and legal functions",OU-005,Division,Centralized,Corporate

--- a/examples/import-templates/organizational_unit.json
+++ b/examples/import-templates/organizational_unit.json
@@ -1,0 +1,34 @@
+{
+  "entities": [
+    {
+      "id": "ou-001",
+      "entity_type": "organizational_unit",
+      "name": "Technology Division",
+      "description": "All engineering and IT functions",
+      "unit_id": "OU-001",
+      "unit_type": "Division",
+      "operating_model": "Hybrid",
+      "functional_domain_primary": "Technology"
+    },
+    {
+      "id": "ou-002",
+      "entity_type": "organizational_unit",
+      "name": "Commercial Division",
+      "description": "Sales, marketing, and customer success",
+      "unit_id": "OU-002",
+      "unit_type": "Division",
+      "operating_model": "Centralized",
+      "functional_domain_primary": "Commercial"
+    },
+    {
+      "id": "ou-003",
+      "entity_type": "organizational_unit",
+      "name": "Risk & Compliance",
+      "description": "Enterprise risk and regulatory compliance",
+      "unit_id": "OU-003",
+      "unit_type": "Department Group",
+      "operating_model": "Centralized",
+      "functional_domain_primary": "Governance"
+    }
+  ]
+}

--- a/examples/import-templates/people.csv
+++ b/examples/import-templates/people.csv
@@ -1,6 +1,0 @@
-name,first_name,last_name,email,title,employee_id,is_active,hire_date,department_id
-Jane Doe,Jane,Doe,jane.doe@example.com,Senior Software Engineer,EMP-001,true,2021-03-15,dept-eng
-John Smith,John,Smith,john.smith@example.com,CISO,EMP-002,true,2019-01-10,dept-sec
-Maria Garcia,Maria,Garcia,maria.garcia@example.com,Product Manager,EMP-003,true,2022-06-01,dept-product
-David Chen,David,Chen,david.chen@example.com,Security Analyst,EMP-004,true,2023-02-20,dept-sec
-Sarah Johnson,Sarah,Johnson,sarah.johnson@example.com,DevOps Engineer,EMP-005,true,2020-09-12,dept-eng

--- a/examples/import-templates/person.csv
+++ b/examples/import-templates/person.csv
@@ -1,0 +1,6 @@
+name,first_name,last_name,email,title,employee_id,is_active,hire_date
+Jane Doe,Jane,Doe,jane.doe@example.com,Senior Software Engineer,EMP-001,true,2021-03-15
+John Smith,John,Smith,john.smith@example.com,CISO,EMP-002,true,2019-01-10
+Maria Garcia,Maria,Garcia,maria.garcia@example.com,Product Manager,EMP-003,true,2022-06-01
+David Chen,David,Chen,david.chen@example.com,Security Analyst,EMP-004,true,2023-02-20
+Sarah Johnson,Sarah,Johnson,sarah.johnson@example.com,DevOps Engineer,EMP-005,true,2020-09-12

--- a/examples/import-templates/person.json
+++ b/examples/import-templates/person.json
@@ -1,0 +1,40 @@
+{
+  "entities": [
+    {
+      "id": "person-001",
+      "entity_type": "person",
+      "name": "Jane Doe",
+      "first_name": "Jane",
+      "last_name": "Doe",
+      "email": "jane.doe@example.com",
+      "title": "Senior Software Engineer",
+      "employee_id": "EMP-001",
+      "is_active": true,
+      "hire_date": "2021-03-15"
+    },
+    {
+      "id": "person-002",
+      "entity_type": "person",
+      "name": "John Smith",
+      "first_name": "John",
+      "last_name": "Smith",
+      "email": "john.smith@example.com",
+      "title": "CISO",
+      "employee_id": "EMP-002",
+      "is_active": true,
+      "hire_date": "2019-01-10"
+    },
+    {
+      "id": "person-003",
+      "entity_type": "person",
+      "name": "Maria Garcia",
+      "first_name": "Maria",
+      "last_name": "Garcia",
+      "email": "maria.garcia@example.com",
+      "title": "Product Manager",
+      "employee_id": "EMP-003",
+      "is_active": true,
+      "hire_date": "2022-06-01"
+    }
+  ]
+}

--- a/examples/import-templates/policy.csv
+++ b/examples/import-templates/policy.csv
@@ -1,0 +1,6 @@
+name,description,policy_id,policy_type,framework,severity,is_enforced
+Access Control Policy,Requirements for system access controls,POL-001,Technical,NIST 800-53,high,true
+Incident Response Policy,Procedures for security incident handling,POL-002,Operational,NIST CSF,high,true
+Data Classification Policy,Rules for classifying and handling data,POL-003,Administrative,ISO 27001,medium,true
+Acceptable Use Policy,Guidelines for acceptable technology use,POL-004,Administrative,Internal,low,true
+Vendor Risk Management Policy,Third-party risk assessment requirements,POL-005,Administrative,NIST 800-53,medium,true

--- a/examples/import-templates/policy.json
+++ b/examples/import-templates/policy.json
@@ -1,0 +1,37 @@
+{
+  "entities": [
+    {
+      "id": "pol-001",
+      "entity_type": "policy",
+      "name": "Access Control Policy",
+      "description": "Requirements for system access controls",
+      "policy_id": "POL-001",
+      "policy_type": "Technical",
+      "framework": "NIST 800-53",
+      "severity": "high",
+      "is_enforced": true
+    },
+    {
+      "id": "pol-002",
+      "entity_type": "policy",
+      "name": "Incident Response Policy",
+      "description": "Procedures for security incident handling",
+      "policy_id": "POL-002",
+      "policy_type": "Operational",
+      "framework": "NIST CSF",
+      "severity": "high",
+      "is_enforced": true
+    },
+    {
+      "id": "pol-003",
+      "entity_type": "policy",
+      "name": "Data Classification Policy",
+      "description": "Rules for classifying and handling data",
+      "policy_id": "POL-003",
+      "policy_type": "Administrative",
+      "framework": "ISO 27001",
+      "severity": "medium",
+      "is_enforced": true
+    }
+  ]
+}

--- a/examples/import-templates/product.csv
+++ b/examples/import-templates/product.csv
@@ -1,0 +1,6 @@
+name,description,product_id,offering_type,offering_subtype,lifecycle_stage
+Enterprise Platform,Core enterprise SaaS platform,PRD-001,SaaS,Platform,Growth
+Mobile App,Customer-facing mobile application,PRD-002,SaaS,Application,Growth
+Analytics Dashboard,Business intelligence and reporting,PRD-003,SaaS,Application,Maturity
+API Gateway,Developer API access and management,PRD-004,PaaS,Platform,Introduction
+Legacy CRM,On-premise CRM being sunset,PRD-005,On-Premise,Application,Decline

--- a/examples/import-templates/product.json
+++ b/examples/import-templates/product.json
@@ -1,0 +1,34 @@
+{
+  "entities": [
+    {
+      "id": "prd-001",
+      "entity_type": "product",
+      "name": "Enterprise Platform",
+      "description": "Core enterprise SaaS platform",
+      "product_id": "PRD-001",
+      "offering_type": "SaaS",
+      "offering_subtype": "Platform",
+      "lifecycle_stage": "Growth"
+    },
+    {
+      "id": "prd-002",
+      "entity_type": "product",
+      "name": "Mobile App",
+      "description": "Customer-facing mobile application",
+      "product_id": "PRD-002",
+      "offering_type": "SaaS",
+      "offering_subtype": "Application",
+      "lifecycle_stage": "Growth"
+    },
+    {
+      "id": "prd-003",
+      "entity_type": "product",
+      "name": "Analytics Dashboard",
+      "description": "Business intelligence and reporting",
+      "product_id": "PRD-003",
+      "offering_type": "SaaS",
+      "offering_subtype": "Application",
+      "lifecycle_stage": "Maturity"
+    }
+  ]
+}

--- a/examples/import-templates/product_portfolio.csv
+++ b/examples/import-templates/product_portfolio.csv
@@ -1,0 +1,6 @@
+name,description,portfolio_id,portfolio_type,portfolio_level,strategic_role,lifecycle_stage
+Enterprise Solutions,Enterprise software product line,PF-001,Product,L1,Core,Growth
+SMB Solutions,Small business product line,PF-002,Product,L1,Growth,Maturity
+Platform Services,Infrastructure and platform APIs,PF-003,Service,L1,Core,Growth
+Data Products,Analytics and data services,PF-004,Product,L2,Innovation,Introduction
+Legacy Products,Products scheduled for sunset,PF-005,Product,L1,Harvest,Decline

--- a/examples/import-templates/product_portfolio.json
+++ b/examples/import-templates/product_portfolio.json
@@ -1,0 +1,37 @@
+{
+  "entities": [
+    {
+      "id": "pf-001",
+      "entity_type": "product_portfolio",
+      "name": "Enterprise Solutions",
+      "description": "Enterprise software product line",
+      "portfolio_id": "PF-001",
+      "portfolio_type": "Product",
+      "portfolio_level": "L1",
+      "strategic_role": "Core",
+      "lifecycle_stage": "Growth"
+    },
+    {
+      "id": "pf-002",
+      "entity_type": "product_portfolio",
+      "name": "SMB Solutions",
+      "description": "Small business product line",
+      "portfolio_id": "PF-002",
+      "portfolio_type": "Product",
+      "portfolio_level": "L1",
+      "strategic_role": "Growth",
+      "lifecycle_stage": "Maturity"
+    },
+    {
+      "id": "pf-003",
+      "entity_type": "product_portfolio",
+      "name": "Platform Services",
+      "description": "Infrastructure and platform APIs",
+      "portfolio_id": "PF-003",
+      "portfolio_type": "Service",
+      "portfolio_level": "L1",
+      "strategic_role": "Core",
+      "lifecycle_stage": "Growth"
+    }
+  ]
+}

--- a/examples/import-templates/regulation.csv
+++ b/examples/import-templates/regulation.csv
@@ -1,0 +1,6 @@
+name,description,regulation_id,short_name,regulation_type,regulation_category,applicability_status,effective_date
+General Data Protection Regulation,EU data protection and privacy regulation,REG-001,GDPR,Legislative,Data Privacy,Applicable,2018-05-25
+SOX Act,US financial reporting requirements,REG-002,SOX,Legislative,Financial,Applicable,2002-07-30
+HIPAA,US health information privacy and security,REG-003,HIPAA,Legislative,Healthcare,Not Applicable,1996-08-21
+PCI DSS v4.0,Payment card industry data security standard,REG-004,PCI DSS,Industry Standard,Payment Security,Applicable,2024-03-31
+NIST CSF 2.0,Cybersecurity framework for critical infrastructure,REG-005,NIST CSF,Framework,Cybersecurity,Adopted,2024-02-26

--- a/examples/import-templates/regulation.json
+++ b/examples/import-templates/regulation.json
@@ -1,0 +1,40 @@
+{
+  "entities": [
+    {
+      "id": "reg-001",
+      "entity_type": "regulation",
+      "name": "General Data Protection Regulation",
+      "description": "EU data protection and privacy regulation",
+      "regulation_id": "REG-001",
+      "short_name": "GDPR",
+      "regulation_type": "Legislative",
+      "regulation_category": "Data Privacy",
+      "applicability_status": "Applicable",
+      "effective_date": "2018-05-25"
+    },
+    {
+      "id": "reg-002",
+      "entity_type": "regulation",
+      "name": "SOX Act",
+      "description": "US financial reporting requirements",
+      "regulation_id": "REG-002",
+      "short_name": "SOX",
+      "regulation_type": "Legislative",
+      "regulation_category": "Financial",
+      "applicability_status": "Applicable",
+      "effective_date": "2002-07-30"
+    },
+    {
+      "id": "reg-003",
+      "entity_type": "regulation",
+      "name": "PCI DSS v4.0",
+      "description": "Payment card industry data security standard",
+      "regulation_id": "REG-003",
+      "short_name": "PCI DSS",
+      "regulation_type": "Industry Standard",
+      "regulation_category": "Payment Security",
+      "applicability_status": "Applicable",
+      "effective_date": "2024-03-31"
+    }
+  ]
+}

--- a/examples/import-templates/risk.csv
+++ b/examples/import-templates/risk.csv
@@ -1,0 +1,6 @@
+name,description,risk_id,risk_category,inherent_risk_level,residual_risk_level,risk_status,risk_owner,risk_treatment
+Customer Data Breach,Unauthorized access to customer PII,RSK-001,Cybersecurity,High,Medium,Open,CISO,Mitigate
+Ransomware Attack,Encryption of critical business systems,RSK-002,Cybersecurity,Critical,High,Open,CISO,Mitigate
+Third-Party Data Leak,Data exposure through vendor compromise,RSK-003,Third Party,High,Medium,Open,Vendor Manager,Transfer
+Regulatory Non-Compliance,Failure to meet GDPR or SOX requirements,RSK-004,Compliance,Medium,Low,Monitoring,Compliance Officer,Mitigate
+Key Person Dependency,Critical knowledge in single individuals,RSK-005,Operational,Medium,Medium,Open,HR Director,Accept

--- a/examples/import-templates/risk.json
+++ b/examples/import-templates/risk.json
@@ -1,0 +1,43 @@
+{
+  "entities": [
+    {
+      "id": "rsk-001",
+      "entity_type": "risk",
+      "name": "Customer Data Breach",
+      "description": "Unauthorized access to customer PII",
+      "risk_id": "RSK-001",
+      "risk_category": "Cybersecurity",
+      "inherent_risk_level": "High",
+      "residual_risk_level": "Medium",
+      "risk_status": "Open",
+      "risk_owner": "CISO",
+      "risk_treatment": "Mitigate"
+    },
+    {
+      "id": "rsk-002",
+      "entity_type": "risk",
+      "name": "Ransomware Attack",
+      "description": "Encryption of critical business systems",
+      "risk_id": "RSK-002",
+      "risk_category": "Cybersecurity",
+      "inherent_risk_level": "Critical",
+      "residual_risk_level": "High",
+      "risk_status": "Open",
+      "risk_owner": "CISO",
+      "risk_treatment": "Mitigate"
+    },
+    {
+      "id": "rsk-003",
+      "entity_type": "risk",
+      "name": "Third-Party Data Leak",
+      "description": "Data exposure through vendor compromise",
+      "risk_id": "RSK-003",
+      "risk_category": "Third Party",
+      "inherent_risk_level": "High",
+      "residual_risk_level": "Medium",
+      "risk_status": "Open",
+      "risk_owner": "Vendor Manager",
+      "risk_treatment": "Transfer"
+    }
+  ]
+}

--- a/examples/import-templates/risks.csv
+++ b/examples/import-templates/risks.csv
@@ -1,6 +1,0 @@
-name,risk_id,risk_category,inherent_risk_level,residual_risk_level,risk_status,risk_owner,risk_treatment,description
-Customer Data Breach,RSK-001,Cybersecurity,High,Medium,Open,CISO,Mitigate,Unauthorized access to customer PII
-Ransomware Attack,RSK-002,Cybersecurity,Critical,High,Open,CISO,Mitigate,Encryption of critical business systems by ransomware
-Third-Party Data Leak,RSK-003,Third Party,High,Medium,Open,Vendor Manager,Transfer,Data exposure through vendor compromise
-Regulatory Non-Compliance,RSK-004,Compliance,Medium,Low,Monitoring,Compliance Officer,Mitigate,Failure to meet GDPR or SOX requirements
-Key Person Dependency,RSK-005,Operational,Medium,Medium,Open,HR Director,Accept,Critical knowledge concentrated in single individuals

--- a/examples/import-templates/role.csv
+++ b/examples/import-templates/role.csv
@@ -1,0 +1,6 @@
+name,description,role_id,role_type,access_level,is_privileged
+Software Engineer,Designs and develops software systems,ROLE-001,Technical,standard,false
+CISO,Executive responsible for information security,ROLE-002,Executive,privileged,true
+Security Analyst,Monitors and responds to security events,ROLE-003,Technical,elevated,true
+Product Manager,Defines product roadmap and requirements,ROLE-004,Management,standard,false
+DevOps Engineer,Manages CI/CD and infrastructure automation,ROLE-005,Technical,privileged,true

--- a/examples/import-templates/role.json
+++ b/examples/import-templates/role.json
@@ -1,0 +1,34 @@
+{
+  "entities": [
+    {
+      "id": "role-001",
+      "entity_type": "role",
+      "name": "Software Engineer",
+      "description": "Designs and develops software systems",
+      "role_id": "ROLE-001",
+      "role_type": "Technical",
+      "access_level": "standard",
+      "is_privileged": false
+    },
+    {
+      "id": "role-002",
+      "entity_type": "role",
+      "name": "CISO",
+      "description": "Executive responsible for information security",
+      "role_id": "ROLE-002",
+      "role_type": "Executive",
+      "access_level": "privileged",
+      "is_privileged": true
+    },
+    {
+      "id": "role-003",
+      "entity_type": "role",
+      "name": "Security Analyst",
+      "description": "Monitors and responds to security events",
+      "role_id": "ROLE-003",
+      "role_type": "Technical",
+      "access_level": "elevated",
+      "is_privileged": true
+    }
+  ]
+}

--- a/examples/import-templates/site.csv
+++ b/examples/import-templates/site.csv
@@ -1,0 +1,6 @@
+name,description,site_id,site_type,site_status,ownership_type,strategic_designation
+New York Headquarters,Primary corporate office,SITE-001,Headquarters,Active,Owned,Strategic
+London Office,EMEA regional headquarters,SITE-002,Regional Office,Active,Leased,Strategic
+Ashburn Data Center,Primary US East data center,SITE-003,Data Center,Active,Colocation,Critical
+Singapore Hub,APAC operations center,SITE-004,Regional Office,Active,Leased,Operational
+Denver DR Site,Disaster recovery facility,SITE-005,DR Facility,Standby,Leased,Critical

--- a/examples/import-templates/site.json
+++ b/examples/import-templates/site.json
@@ -1,0 +1,37 @@
+{
+  "entities": [
+    {
+      "id": "site-001",
+      "entity_type": "site",
+      "name": "New York Headquarters",
+      "description": "Primary corporate office",
+      "site_id": "SITE-001",
+      "site_type": "Headquarters",
+      "site_status": "Active",
+      "ownership_type": "Owned",
+      "strategic_designation": "Strategic"
+    },
+    {
+      "id": "site-002",
+      "entity_type": "site",
+      "name": "London Office",
+      "description": "EMEA regional headquarters",
+      "site_id": "SITE-002",
+      "site_type": "Regional Office",
+      "site_status": "Active",
+      "ownership_type": "Leased",
+      "strategic_designation": "Strategic"
+    },
+    {
+      "id": "site-003",
+      "entity_type": "site",
+      "name": "Ashburn Data Center",
+      "description": "Primary US East data center",
+      "site_id": "SITE-003",
+      "site_type": "Data Center",
+      "site_status": "Active",
+      "ownership_type": "Colocation",
+      "strategic_designation": "Critical"
+    }
+  ]
+}

--- a/examples/import-templates/system.csv
+++ b/examples/import-templates/system.csv
@@ -1,0 +1,6 @@
+name,system_type,hostname,ip_address,os,criticality,environment,is_internet_facing
+Customer Portal,application,portal-prod-01,10.1.1.100,Linux,high,production,true
+ERP System,application,erp-prod-01,10.1.2.50,Windows Server 2022,critical,production,false
+CI/CD Pipeline,infrastructure,cicd-prod-01,10.1.3.10,Linux,high,production,false
+Email Gateway,application,mail-gw-01,172.16.0.10,Linux,high,production,true
+Data Warehouse,database,dw-prod-01,10.1.4.20,Linux,high,production,false

--- a/examples/import-templates/system.json
+++ b/examples/import-templates/system.json
@@ -1,0 +1,40 @@
+{
+  "entities": [
+    {
+      "id": "sys-001",
+      "entity_type": "system",
+      "name": "Customer Portal",
+      "system_type": "application",
+      "hostname": "portal-prod-01",
+      "ip_address": "10.1.1.100",
+      "os": "Linux",
+      "criticality": "high",
+      "environment": "production",
+      "is_internet_facing": true
+    },
+    {
+      "id": "sys-002",
+      "entity_type": "system",
+      "name": "ERP System",
+      "system_type": "application",
+      "hostname": "erp-prod-01",
+      "ip_address": "10.1.2.50",
+      "os": "Windows Server 2022",
+      "criticality": "critical",
+      "environment": "production",
+      "is_internet_facing": false
+    },
+    {
+      "id": "sys-003",
+      "entity_type": "system",
+      "name": "CI/CD Pipeline",
+      "system_type": "infrastructure",
+      "hostname": "cicd-prod-01",
+      "ip_address": "10.1.3.10",
+      "os": "Linux",
+      "criticality": "high",
+      "environment": "production",
+      "is_internet_facing": false
+    }
+  ]
+}

--- a/examples/import-templates/systems.csv
+++ b/examples/import-templates/systems.csv
@@ -1,6 +1,0 @@
-name,system_type,hostname,ip_address,os,criticality,environment,is_internet_facing,description
-Customer Portal,application,portal-prod-01,10.1.1.100,Linux,high,production,true,Customer-facing web application
-ERP System,application,erp-prod-01,10.1.2.50,Windows Server 2022,critical,production,false,Enterprise resource planning system
-CI/CD Pipeline,infrastructure,cicd-prod-01,10.1.3.10,Linux,high,production,false,Build and deployment automation
-Email Gateway,application,mail-gw-01,172.16.0.10,Linux,high,production,true,Inbound and outbound email filtering
-Data Warehouse,database,dw-prod-01,10.1.4.20,Linux,high,production,false,Central analytics data warehouse

--- a/examples/import-templates/threat.csv
+++ b/examples/import-templates/threat.csv
@@ -1,0 +1,6 @@
+name,description,threat_id,threat_category,threat_source_type,relevance_to_enterprise,threat_trend
+Ransomware,Ransomware targeting enterprise systems,THR-001,Cyber,External,High,Increasing
+Supply Chain Compromise,Software supply chain attacks,THR-002,Cyber,External,High,Increasing
+Insider Threat,Malicious or negligent insider activity,THR-003,Insider,Internal,Medium,Stable
+Cloud Misconfiguration,Exploitation of cloud misconfigurations,THR-004,Cyber,External,High,Increasing
+Social Engineering,Targeted phishing and pretexting,THR-005,Cyber,External,Medium,Stable

--- a/examples/import-templates/threat.json
+++ b/examples/import-templates/threat.json
@@ -1,0 +1,37 @@
+{
+  "entities": [
+    {
+      "id": "thr-001",
+      "entity_type": "threat",
+      "name": "Ransomware",
+      "description": "Ransomware targeting enterprise systems",
+      "threat_id": "THR-001",
+      "threat_category": "Cyber",
+      "threat_source_type": "External",
+      "relevance_to_enterprise": "High",
+      "threat_trend": "Increasing"
+    },
+    {
+      "id": "thr-002",
+      "entity_type": "threat",
+      "name": "Supply Chain Compromise",
+      "description": "Software supply chain attacks",
+      "threat_id": "THR-002",
+      "threat_category": "Cyber",
+      "threat_source_type": "External",
+      "relevance_to_enterprise": "High",
+      "threat_trend": "Increasing"
+    },
+    {
+      "id": "thr-003",
+      "entity_type": "threat",
+      "name": "Insider Threat",
+      "description": "Malicious or negligent insider activity",
+      "threat_id": "THR-003",
+      "threat_category": "Insider",
+      "threat_source_type": "Internal",
+      "relevance_to_enterprise": "Medium",
+      "threat_trend": "Stable"
+    }
+  ]
+}

--- a/examples/import-templates/threat_actor.csv
+++ b/examples/import-templates/threat_actor.csv
@@ -1,0 +1,6 @@
+name,description,actor_type,sophistication,motivation,origin_country,first_seen
+APT29,State-sponsored group targeting government and tech,nation_state,advanced,espionage,RU,2014-01-01
+FIN7,Financially motivated cybercrime group,cybercrime,advanced,financial,RU,2013-06-01
+Lazarus Group,State-sponsored group targeting financial sector,nation_state,advanced,financial,KP,2009-01-01
+LockBit,Ransomware-as-a-service operation,cybercrime,intermediate,financial,,2019-09-01
+Insider-Risk-001,Disgruntled employee with privileged access,insider,basic,revenge,US,2024-01-15

--- a/examples/import-templates/threat_actor.json
+++ b/examples/import-templates/threat_actor.json
@@ -1,0 +1,37 @@
+{
+  "entities": [
+    {
+      "id": "ta-001",
+      "entity_type": "threat_actor",
+      "name": "APT29",
+      "description": "State-sponsored group targeting government and tech",
+      "actor_type": "nation_state",
+      "sophistication": "advanced",
+      "motivation": "espionage",
+      "origin_country": "RU",
+      "first_seen": "2014-01-01"
+    },
+    {
+      "id": "ta-002",
+      "entity_type": "threat_actor",
+      "name": "FIN7",
+      "description": "Financially motivated cybercrime group",
+      "actor_type": "cybercrime",
+      "sophistication": "advanced",
+      "motivation": "financial",
+      "origin_country": "RU",
+      "first_seen": "2013-06-01"
+    },
+    {
+      "id": "ta-003",
+      "entity_type": "threat_actor",
+      "name": "Lazarus Group",
+      "description": "State-sponsored group targeting financial sector",
+      "actor_type": "nation_state",
+      "sophistication": "advanced",
+      "motivation": "financial",
+      "origin_country": "KP",
+      "first_seen": "2009-01-01"
+    }
+  ]
+}

--- a/examples/import-templates/vendor.csv
+++ b/examples/import-templates/vendor.csv
@@ -1,0 +1,6 @@
+name,description,vendor_id,vendor_type,risk_tier,has_data_access,primary_contact
+CloudProvider Inc,Primary cloud infrastructure provider,VND-001,Cloud Services,critical,true,vendor-mgmt@cloudprovider.example.com
+SecureSoft Ltd,SIEM and endpoint detection vendor,VND-002,Security Tools,high,true,support@securesoft.example.com
+OfficeSupply Co,Office equipment and supplies,VND-003,Office Supplies,low,false,orders@officesupply.example.com
+ConsultCorp,IT consulting and staff augmentation,VND-004,Professional Services,medium,true,engage@consultcorp.example.com
+DataAnalytics Inc,Business intelligence platform,VND-005,Analytics,high,true,sales@dataanalytics.example.com

--- a/examples/import-templates/vendor.json
+++ b/examples/import-templates/vendor.json
@@ -1,0 +1,37 @@
+{
+  "entities": [
+    {
+      "id": "vnd-001",
+      "entity_type": "vendor",
+      "name": "CloudProvider Inc",
+      "description": "Primary cloud infrastructure provider",
+      "vendor_id": "VND-001",
+      "vendor_type": "Cloud Services",
+      "risk_tier": "critical",
+      "has_data_access": true,
+      "primary_contact": "vendor-mgmt@cloudprovider.example.com"
+    },
+    {
+      "id": "vnd-002",
+      "entity_type": "vendor",
+      "name": "SecureSoft Ltd",
+      "description": "SIEM and endpoint detection vendor",
+      "vendor_id": "VND-002",
+      "vendor_type": "Security Tools",
+      "risk_tier": "high",
+      "has_data_access": true,
+      "primary_contact": "support@securesoft.example.com"
+    },
+    {
+      "id": "vnd-003",
+      "entity_type": "vendor",
+      "name": "OfficeSupply Co",
+      "description": "Office equipment and supplies",
+      "vendor_id": "VND-003",
+      "vendor_type": "Office Supplies",
+      "risk_tier": "low",
+      "has_data_access": false,
+      "primary_contact": "orders@officesupply.example.com"
+    }
+  ]
+}

--- a/examples/import-templates/vendors.csv
+++ b/examples/import-templates/vendors.csv
@@ -1,6 +1,0 @@
-name,vendor_type,risk_tier,has_data_access,primary_contact,description
-CloudProvider Inc,Cloud Services,critical,true,vendor-mgmt@cloudprovider.example.com,Primary cloud infrastructure provider
-SecureSoft Ltd,Security Tools,high,true,support@securesoft.example.com,SIEM and endpoint detection vendor
-OfficeSupply Co,Office Supplies,low,false,orders@officesupply.example.com,Office equipment and supplies
-ConsultCorp,Professional Services,medium,true,engage@consultcorp.example.com,IT consulting and staff augmentation
-DataAnalytics Inc,Analytics,high,true,sales@dataanalytics.example.com,Business intelligence and analytics platform

--- a/examples/import-templates/vulnerabilities.csv
+++ b/examples/import-templates/vulnerabilities.csv
@@ -1,6 +1,0 @@
-name,cve_id,cvss_score,severity,status,exploit_available,patch_available,affected_component,description
-CVE-2024-29847,CVE-2024-29847,9.8,critical,open,true,true,Web Framework,Remote code execution in web framework dependency
-CVE-2024-21762,CVE-2024-21762,9.6,critical,remediated,true,true,VPN Gateway,Out-of-bounds write in SSL VPN
-CVE-2024-3400,CVE-2024-3400,10.0,critical,open,true,false,Firewall,Command injection in firewall management interface
-CVE-2024-1234,CVE-2024-1234,7.5,high,remediated,false,true,Database,SQL injection in stored procedure
-CVE-2024-5678,CVE-2024-5678,5.3,medium,open,false,true,Web Server,Information disclosure via error messages

--- a/examples/import-templates/vulnerability.csv
+++ b/examples/import-templates/vulnerability.csv
@@ -1,0 +1,6 @@
+name,description,cve_id,cvss_score,severity,status,exploit_available,patch_available
+CVE-2024-29847,Remote code execution in web framework,CVE-2024-29847,9.8,critical,open,true,true
+CVE-2024-21762,Out-of-bounds write in SSL VPN,CVE-2024-21762,9.6,critical,remediated,true,true
+CVE-2024-3400,Command injection in firewall,CVE-2024-3400,10.0,critical,open,true,false
+CVE-2024-1234,SQL injection in stored procedure,CVE-2024-1234,7.5,high,remediated,false,true
+CVE-2024-5678,Information disclosure via error messages,CVE-2024-5678,5.3,medium,open,false,true

--- a/examples/import-templates/vulnerability.json
+++ b/examples/import-templates/vulnerability.json
@@ -1,0 +1,40 @@
+{
+  "entities": [
+    {
+      "id": "vuln-001",
+      "entity_type": "vulnerability",
+      "name": "CVE-2024-29847",
+      "description": "Remote code execution in web framework",
+      "cve_id": "CVE-2024-29847",
+      "cvss_score": 9.8,
+      "severity": "critical",
+      "status": "open",
+      "exploit_available": true,
+      "patch_available": true
+    },
+    {
+      "id": "vuln-002",
+      "entity_type": "vulnerability",
+      "name": "CVE-2024-21762",
+      "description": "Out-of-bounds write in SSL VPN",
+      "cve_id": "CVE-2024-21762",
+      "cvss_score": 9.6,
+      "severity": "critical",
+      "status": "remediated",
+      "exploit_available": true,
+      "patch_available": true
+    },
+    {
+      "id": "vuln-003",
+      "entity_type": "vulnerability",
+      "name": "CVE-2024-3400",
+      "description": "Command injection in firewall",
+      "cve_id": "CVE-2024-3400",
+      "cvss_score": 10.0,
+      "severity": "critical",
+      "status": "open",
+      "exploit_available": true,
+      "patch_available": false
+    }
+  ]
+}

--- a/tests/integration/test_import_templates.py
+++ b/tests/integration/test_import_templates.py
@@ -9,244 +9,142 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from cli.main import cli
 from domain.base import EntityType
 
 TEMPLATES_DIR = Path(__file__).parent.parent.parent / "examples" / "import-templates"
+ALL_ENTITY_TYPES = [et.value for et in EntityType]
 
 
-class TestJsonTemplate:
-    """Tests for the organization.json template."""
+class TestOrganizationJson:
+    """Tests for the comprehensive organization.json multi-type template."""
 
     def test_valid_json(self) -> None:
-        path = TEMPLATES_DIR / "organization.json"
-        data = json.loads(path.read_text())
+        data = json.loads((TEMPLATES_DIR / "organization.json").read_text())
         assert "entities" in data
         assert "relationships" in data
 
     def test_contains_all_30_entity_types(self) -> None:
-        path = TEMPLATES_DIR / "organization.json"
-        data = json.loads(path.read_text())
+        data = json.loads((TEMPLATES_DIR / "organization.json").read_text())
         types_found = {e["entity_type"] for e in data["entities"]}
         all_types = {et.value for et in EntityType}
         missing = all_types - types_found
-        assert not missing, f"Missing entity types in template: {missing}"
+        assert not missing, f"Missing entity types: {missing}"
 
     def test_all_entities_have_required_fields(self) -> None:
-        path = TEMPLATES_DIR / "organization.json"
-        data = json.loads(path.read_text())
+        data = json.loads((TEMPLATES_DIR / "organization.json").read_text())
         for entity in data["entities"]:
-            assert "id" in entity, f"Entity missing id: {entity}"
-            assert "entity_type" in entity, f"Entity missing entity_type: {entity}"
-            assert "name" in entity, f"Entity missing name: {entity}"
+            assert "id" in entity, f"Missing id: {entity.get('name')}"
+            assert "entity_type" in entity, f"Missing entity_type: {entity.get('name')}"
+            assert "name" in entity, f"Missing name: {entity.get('id')}"
 
     def test_all_relationships_reference_valid_entities(self) -> None:
-        path = TEMPLATES_DIR / "organization.json"
-        data = json.loads(path.read_text())
+        data = json.loads((TEMPLATES_DIR / "organization.json").read_text())
         entity_ids = {e["id"] for e in data["entities"]}
         for rel in data["relationships"]:
             assert rel["source_id"] in entity_ids, (
-                f"Relationship references unknown source: {rel['source_id']}"
+                f"Unknown source: {rel['source_id']}"
             )
             assert rel["target_id"] in entity_ids, (
-                f"Relationship references unknown target: {rel['target_id']}"
+                f"Unknown target: {rel['target_id']}"
             )
 
-    def test_dry_run_succeeds(self, tmp_path: Path) -> None:
+    def test_dry_run_strict(self) -> None:
         runner = CliRunner()
         result = runner.invoke(
-            cli, ["import", str(TEMPLATES_DIR / "organization.json"), "--dry-run"]
+            cli,
+            ["import", str(TEMPLATES_DIR / "organization.json"), "--dry-run", "--strict"],
         )
-        assert result.exit_code == 0, f"Dry run failed: {result.output}"
+        assert result.exit_code == 0, f"Failed: {result.output}"
 
-    def test_import_succeeds(self, tmp_path: Path) -> None:
+    def test_import_produces_output(self, tmp_path: Path) -> None:
         output = tmp_path / "graph.json"
         runner = CliRunner()
         result = runner.invoke(
             cli,
             ["import", str(TEMPLATES_DIR / "organization.json"), "-o", str(output)],
         )
-        assert result.exit_code == 0, f"Import failed: {result.output}"
-        assert output.exists()
+        assert result.exit_code == 0, f"Failed: {result.output}"
         data = json.loads(output.read_text())
         assert len(data["entities"]) >= 30
 
     def test_round_trip(self, tmp_path: Path) -> None:
-        """Import → export → re-import produces consistent entity count."""
-        output1 = tmp_path / "first.json"
-        output2 = tmp_path / "second.json"
+        out1 = tmp_path / "first.json"
+        out2 = tmp_path / "second.json"
         runner = CliRunner()
-
-        # First import
-        result1 = runner.invoke(
+        r1 = runner.invoke(
             cli,
-            ["import", str(TEMPLATES_DIR / "organization.json"), "-o", str(output1)],
+            ["import", str(TEMPLATES_DIR / "organization.json"), "-o", str(out1)],
         )
-        assert result1.exit_code == 0
-
-        # Re-import the exported file
-        result2 = runner.invoke(
-            cli, ["import", str(output1), "-o", str(output2)]
+        assert r1.exit_code == 0
+        r2 = runner.invoke(cli, ["import", str(out1), "-o", str(out2)])
+        assert r2.exit_code == 0
+        assert len(json.loads(out1.read_text())["entities"]) == len(
+            json.loads(out2.read_text())["entities"]
         )
-        assert result2.exit_code == 0
-
-        data1 = json.loads(output1.read_text())
-        data2 = json.loads(output2.read_text())
-        assert len(data1["entities"]) == len(data2["entities"])
 
 
-CSV_TEMPLATES = [
-    "people.csv",
-    "departments.csv",
-    "systems.csv",
-    "vendors.csv",
-    "vulnerabilities.csv",
-    "risks.csv",
-    "controls.csv",
-    "incidents.csv",
-]
+class TestPerTypeJsonTemplates:
+    """Each entity type has a single-type JSON template that imports cleanly."""
+
+    def test_all_30_json_templates_exist(self) -> None:
+        for et in ALL_ENTITY_TYPES:
+            path = TEMPLATES_DIR / f"{et}.json"
+            assert path.exists(), f"Missing JSON template: {et}.json"
+
+    @pytest.mark.parametrize("entity_type", ALL_ENTITY_TYPES)
+    def test_json_template_dry_run_strict(self, entity_type: str) -> None:
+        path = TEMPLATES_DIR / f"{entity_type}.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["import", str(path), "--dry-run", "--strict"]
+        )
+        assert result.exit_code == 0, (
+            f"{entity_type}.json failed: {result.output}"
+        )
+
+    @pytest.mark.parametrize("entity_type", ALL_ENTITY_TYPES)
+    def test_json_template_has_entities(self, entity_type: str) -> None:
+        data = json.loads((TEMPLATES_DIR / f"{entity_type}.json").read_text())
+        assert "entities" in data
+        assert len(data["entities"]) >= 3, (
+            f"{entity_type}.json has < 3 entities"
+        )
+        for e in data["entities"]:
+            assert e["entity_type"] == entity_type
 
 
-class TestCsvTemplates:
-    """Tests for CSV template files."""
+class TestPerTypeCsvTemplates:
+    """Each entity type has a CSV template that imports cleanly."""
 
-    def test_all_csv_templates_exist(self) -> None:
-        for filename in CSV_TEMPLATES:
-            path = TEMPLATES_DIR / filename
-            assert path.exists(), f"Missing CSV template: {filename}"
+    def test_all_30_csv_templates_exist(self) -> None:
+        for et in ALL_ENTITY_TYPES:
+            path = TEMPLATES_DIR / f"{et}.csv"
+            assert path.exists(), f"Missing CSV template: {et}.csv"
 
-    def test_all_csv_templates_have_headers_and_data(self) -> None:
-        for filename in CSV_TEMPLATES:
-            path = TEMPLATES_DIR / filename
-            lines = path.read_text().strip().splitlines()
-            assert len(lines) >= 2, f"{filename} needs at least header + 1 data row"
+    @pytest.mark.parametrize("entity_type", ALL_ENTITY_TYPES)
+    def test_csv_has_header_and_data(self, entity_type: str) -> None:
+        lines = (TEMPLATES_DIR / f"{entity_type}.csv").read_text().strip().splitlines()
+        assert len(lines) >= 6, f"{entity_type}.csv has < 5 data rows"
 
-    def test_people_csv_import(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("entity_type", ALL_ENTITY_TYPES)
+    def test_csv_template_import(self, entity_type: str, tmp_path: Path) -> None:
         output = tmp_path / "graph.json"
         runner = CliRunner()
         result = runner.invoke(
             cli,
             [
                 "import",
-                str(TEMPLATES_DIR / "people.csv"),
-                "-t", "person",
+                str(TEMPLATES_DIR / f"{entity_type}.csv"),
+                "-t", entity_type,
                 "-o", str(output),
             ],
         )
-        assert result.exit_code == 0, f"Import failed: {result.output}"
-        data = json.loads(output.read_text())
-        assert len(data["entities"]) == 5
-
-    def test_departments_csv_import(self, tmp_path: Path) -> None:
-        output = tmp_path / "graph.json"
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            [
-                "import",
-                str(TEMPLATES_DIR / "departments.csv"),
-                "-t", "department",
-                "-o", str(output),
-            ],
+        assert result.exit_code == 0, (
+            f"{entity_type}.csv import failed: {result.output}"
         )
-        assert result.exit_code == 0, f"Import failed: {result.output}"
-        data = json.loads(output.read_text())
-        assert len(data["entities"]) == 5
-
-    def test_systems_csv_import(self, tmp_path: Path) -> None:
-        output = tmp_path / "graph.json"
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            [
-                "import",
-                str(TEMPLATES_DIR / "systems.csv"),
-                "-t", "system",
-                "-o", str(output),
-            ],
-        )
-        assert result.exit_code == 0, f"Import failed: {result.output}"
-        data = json.loads(output.read_text())
-        assert len(data["entities"]) == 5
-
-    def test_vendors_csv_import(self, tmp_path: Path) -> None:
-        output = tmp_path / "graph.json"
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            [
-                "import",
-                str(TEMPLATES_DIR / "vendors.csv"),
-                "-t", "vendor",
-                "-o", str(output),
-            ],
-        )
-        assert result.exit_code == 0, f"Import failed: {result.output}"
-        data = json.loads(output.read_text())
-        assert len(data["entities"]) == 5
-
-    def test_vulnerabilities_csv_import(self, tmp_path: Path) -> None:
-        output = tmp_path / "graph.json"
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            [
-                "import",
-                str(TEMPLATES_DIR / "vulnerabilities.csv"),
-                "-t", "vulnerability",
-                "-o", str(output),
-            ],
-        )
-        assert result.exit_code == 0, f"Import failed: {result.output}"
-        data = json.loads(output.read_text())
-        assert len(data["entities"]) == 5
-
-    def test_risks_csv_import(self, tmp_path: Path) -> None:
-        output = tmp_path / "graph.json"
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            [
-                "import",
-                str(TEMPLATES_DIR / "risks.csv"),
-                "-t", "risk",
-                "-o", str(output),
-            ],
-        )
-        assert result.exit_code == 0, f"Import failed: {result.output}"
-        data = json.loads(output.read_text())
-        assert len(data["entities"]) == 5
-
-    def test_controls_csv_import(self, tmp_path: Path) -> None:
-        output = tmp_path / "graph.json"
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            [
-                "import",
-                str(TEMPLATES_DIR / "controls.csv"),
-                "-t", "control",
-                "-o", str(output),
-            ],
-        )
-        assert result.exit_code == 0, f"Import failed: {result.output}"
-        data = json.loads(output.read_text())
-        assert len(data["entities"]) == 5
-
-    def test_incidents_csv_import(self, tmp_path: Path) -> None:
-        output = tmp_path / "graph.json"
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            [
-                "import",
-                str(TEMPLATES_DIR / "incidents.csv"),
-                "-t", "incident",
-                "-o", str(output),
-            ],
-        )
-        assert result.exit_code == 0, f"Import failed: {result.output}"
         data = json.loads(output.read_text())
         assert len(data["entities"]) == 5

--- a/tests/unit/ingest/test_validator.py
+++ b/tests/unit/ingest/test_validator.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from domain.base import EntityType
 from ingest.validator import ValidationResult, validate_csv_import, validate_json_import
 
@@ -44,7 +42,10 @@ class TestValidateJsonImport:
     def test_valid_data_with_relationships(self) -> None:
         data = {
             "entities": [
-                {"entity_type": "person", "id": "p1", "name": "Alice", "first_name": "Alice", "last_name": "Smith", "email": "a@b.com"},
+                {
+                    "entity_type": "person", "id": "p1", "name": "Alice",
+                    "first_name": "Alice", "last_name": "Smith", "email": "a@b.com",
+                },
                 {"entity_type": "department", "id": "d1", "name": "Eng"},
             ],
             "relationships": [


### PR DESCRIPTION
## Summary
- Replaces 8 plural-named CSV-only templates with symmetric JSON + CSV templates for all 30 entity types
- Each JSON template has 3 sample entities with validated field names; each CSV has 5 data rows
- Fixed unquoted comma-containing fields in 3 CSV templates (data_domain, organizational_unit, business_capability)
- Parametrized integration tests cover all 30 types in both formats (129 tests)
- Fixed unused import lint issue in test_validator.py

Closes #241

## Test plan
- [x] All 129 template integration tests pass
- [x] Full suite: 1124 passed, 1 skipped
- [x] Ruff lint clean
- [x] All 61 templates validated via `hckg import --dry-run --strict`