### PR TITLE
feat: MCP write tool — add_relationship with validation and auto-persist

### DIFF
--- a/src/mcp_server/validation.py
+++ b/src/mcp_server/validation.py
@@ -1,0 +1,128 @@
+"""Input validation for MCP write tools.
+
+Centralises validation logic so every write tool enforces the same
+rules: enum membership, entity existence, domain/range schema, and
+basic field constraints.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from domain.base import EntityType, RelationshipType
+from domain.relationship_schema import validate_relationship
+
+if TYPE_CHECKING:
+    from graph.knowledge_graph import KnowledgeGraph
+
+MAX_NAME_LENGTH = 255
+MAX_DESCRIPTION_LENGTH = 4096
+SAFE_ID_RE = re.compile(r"^[a-zA-Z0-9_:.-]+$")
+
+
+def validate_id_format(value: str) -> tuple[bool, str]:
+    """Check that an ID contains only safe characters.
+
+    Returns (True, "") if valid, or (False, reason) if not.
+    """
+    if not value:
+        return False, "ID must not be empty."
+    if not SAFE_ID_RE.match(value):
+        return False, (
+            f"ID '{value}' contains invalid characters. "
+            "Only alphanumeric, underscore, colon, dot, and hyphen are allowed."
+        )
+    return True, ""
+
+
+def validate_relationship_type(value: str) -> tuple[bool, str]:
+    """Validate that a string is a valid RelationshipType enum value."""
+    try:
+        RelationshipType(value)
+    except ValueError:
+        valid = sorted(r.value for r in RelationshipType)
+        return False, f"Unknown relationship_type '{value}'. Valid types: {valid}"
+    return True, ""
+
+
+def validate_entity_type(value: str) -> tuple[bool, str]:
+    """Validate that a string is a valid EntityType enum value."""
+    try:
+        EntityType(value)
+    except ValueError:
+        valid = sorted(e.value for e in EntityType)
+        return False, f"Unknown entity_type '{value}'. Valid types: {valid}"
+    return True, ""
+
+
+def validate_relationship_input(
+    kg: KnowledgeGraph,
+    relationship_type: str,
+    source_id: str,
+    target_id: str,
+) -> tuple[bool, str]:
+    """Full validation for an add_relationship call.
+
+    Checks:
+    1. relationship_type is a valid enum value
+    2. source_id and target_id entities exist in the graph
+    3. The relationship satisfies domain/range schema constraints
+
+    Returns (True, "") if valid, or (False, reason) if not.
+    """
+    # 1. Enum check
+    ok, reason = validate_relationship_type(relationship_type)
+    if not ok:
+        return False, reason
+
+    # 2. Entity existence
+    source = kg.get_entity(source_id)
+    if source is None:
+        return False, f"Source entity '{source_id}' not found in graph."
+
+    target = kg.get_entity(target_id)
+    if target is None:
+        return False, f"Target entity '{target_id}' not found in graph."
+
+    # 3. Domain/range schema
+    rt = RelationshipType(relationship_type)
+    ok, reason = validate_relationship(rt, source.entity_type, target.entity_type)
+    if not ok:
+        return False, reason
+
+    return True, ""
+
+
+def validate_entity_input(
+    entity_type: str,
+    name: str,
+    description: str = "",
+) -> tuple[bool, str]:
+    """Validate basic fields for an add_entity call.
+
+    Checks:
+    1. entity_type is a valid enum value
+    2. name is non-empty and within length limit
+    3. description is within length limit
+    """
+    ok, reason = validate_entity_type(entity_type)
+    if not ok:
+        return False, reason
+
+    if not name or not name.strip():
+        return False, "Entity name must not be empty."
+
+    if len(name) > MAX_NAME_LENGTH:
+        return False, (
+            f"Entity name exceeds {MAX_NAME_LENGTH} characters "
+            f"({len(name)} given)."
+        )
+
+    if len(description) > MAX_DESCRIPTION_LENGTH:
+        return False, (
+            f"Entity description exceeds {MAX_DESCRIPTION_LENGTH} characters "
+            f"({len(description)} given)."
+        )
+
+    return True, ""

--- a/tests/unit/mcp_server/test_mcp_validation.py
+++ b/tests/unit/mcp_server/test_mcp_validation.py
@@ -1,0 +1,161 @@
+"""Tests for MCP write-tool input validation."""
+
+from __future__ import annotations
+
+import pytest
+
+mcp_available = pytest.importorskip("mcp", reason="mcp package not installed")
+
+from domain.base import EntityType  # noqa: E402
+from domain.registry import EntityRegistry  # noqa: E402
+from graph.knowledge_graph import KnowledgeGraph  # noqa: E402
+from mcp_server.validation import (  # noqa: E402
+    MAX_DESCRIPTION_LENGTH,
+    MAX_NAME_LENGTH,
+    validate_entity_input,
+    validate_entity_type,
+    validate_id_format,
+    validate_relationship_input,
+    validate_relationship_type,
+)
+
+EntityRegistry.auto_discover()
+
+
+# -- helpers --
+
+def _kg_with_person_and_dept() -> KnowledgeGraph:
+    """Build a minimal KG with one Person and one Department."""
+    person_cls = EntityRegistry.get(EntityType.PERSON)
+    dept_cls = EntityRegistry.get(EntityType.DEPARTMENT)
+
+    kg = KnowledgeGraph()
+    kg.add_entity(person_cls(
+        id="per-001", name="Alice", first_name="Alice",
+        last_name="Smith", email="alice@test.com",
+    ))
+    kg.add_entity(dept_cls(id="dept-001", name="Engineering"))
+    return kg
+
+
+# -- validate_id_format --
+
+class TestValidateIdFormat:
+    def test_valid_ids(self):
+        for val in ["abc-123", "sys_001", "geo:north-america", "v1.2.3"]:
+            ok, _ = validate_id_format(val)
+            assert ok, f"Expected '{val}' to be valid"
+
+    def test_empty_id(self):
+        ok, reason = validate_id_format("")
+        assert not ok
+        assert "empty" in reason.lower()
+
+    def test_invalid_chars(self):
+        ok, reason = validate_id_format("id with spaces")
+        assert not ok
+        assert "invalid characters" in reason.lower()
+
+    def test_injection_attempt(self):
+        ok, _ = validate_id_format("<script>alert(1)</script>")
+        assert not ok
+
+
+# -- validate_relationship_type --
+
+class TestValidateRelationshipType:
+    def test_valid(self):
+        ok, _ = validate_relationship_type("depends_on")
+        assert ok
+
+    def test_invalid(self):
+        ok, reason = validate_relationship_type("applies_to")
+        assert not ok
+        assert "Unknown relationship_type" in reason
+
+    def test_empty(self):
+        ok, _ = validate_relationship_type("")
+        assert not ok
+
+
+# -- validate_entity_type --
+
+class TestValidateEntityType:
+    def test_valid(self):
+        ok, _ = validate_entity_type("system")
+        assert ok
+
+    def test_invalid(self):
+        ok, reason = validate_entity_type("spaceship")
+        assert not ok
+        assert "Unknown entity_type" in reason
+
+
+# -- validate_relationship_input --
+
+class TestValidateRelationshipInput:
+    def test_valid(self):
+        kg = _kg_with_person_and_dept()
+        ok, _ = validate_relationship_input(kg, "works_in", "per-001", "dept-001")
+        assert ok
+
+    def test_bad_enum(self):
+        kg = _kg_with_person_and_dept()
+        ok, reason = validate_relationship_input(kg, "applies_to", "per-001", "dept-001")
+        assert not ok
+        assert "Unknown relationship_type" in reason
+
+    def test_missing_source(self):
+        kg = _kg_with_person_and_dept()
+        ok, reason = validate_relationship_input(kg, "works_in", "per-999", "dept-001")
+        assert not ok
+        assert "per-999" in reason
+        assert "not found" in reason.lower()
+
+    def test_missing_target(self):
+        kg = _kg_with_person_and_dept()
+        ok, reason = validate_relationship_input(kg, "works_in", "per-001", "dept-999")
+        assert not ok
+        assert "dept-999" in reason
+
+    def test_schema_violation(self):
+        """works_in requires Person->Department, not Department->Person."""
+        kg = _kg_with_person_and_dept()
+        ok, reason = validate_relationship_input(kg, "works_in", "dept-001", "per-001")
+        assert not ok
+        assert "department" in reason.lower() or "person" in reason.lower()
+
+
+# -- validate_entity_input --
+
+class TestValidateEntityInput:
+    def test_valid(self):
+        ok, _ = validate_entity_input("system", "My System", "A test system")
+        assert ok
+
+    def test_bad_type(self):
+        ok, reason = validate_entity_input("spaceship", "USS Enterprise")
+        assert not ok
+        assert "Unknown entity_type" in reason
+
+    def test_empty_name(self):
+        ok, reason = validate_entity_input("system", "")
+        assert not ok
+        assert "empty" in reason.lower()
+
+    def test_whitespace_name(self):
+        ok, reason = validate_entity_input("system", "   ")
+        assert not ok
+        assert "empty" in reason.lower()
+
+    def test_name_too_long(self):
+        ok, reason = validate_entity_input("system", "x" * (MAX_NAME_LENGTH + 1))
+        assert not ok
+        assert str(MAX_NAME_LENGTH) in reason
+
+    def test_description_too_long(self):
+        ok, reason = validate_entity_input(
+            "system", "Ok Name", "x" * (MAX_DESCRIPTION_LENGTH + 1),
+        )
+        assert not ok
+        assert str(MAX_DESCRIPTION_LENGTH) in reason

--- a/tests/unit/mcp_server/test_write_tools.py
+++ b/tests/unit/mcp_server/test_write_tools.py
@@ -1,0 +1,219 @@
+"""Tests for MCP write tools (add_relationship_tool)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+mcp_available = pytest.importorskip("mcp", reason="mcp package not installed")
+
+import mcp_server.state as state  # noqa: E402
+from domain.base import EntityType  # noqa: E402
+from domain.registry import EntityRegistry  # noqa: E402
+from export.json_export import JSONExporter  # noqa: E402
+from graph.knowledge_graph import KnowledgeGraph  # noqa: E402
+from mcp_server.server import mcp  # noqa: E402
+
+EntityRegistry.auto_discover()
+
+
+def _call_tool(name: str, **kwargs):
+    """Call an MCP tool by name via the FastMCP registry."""
+    for tool in mcp._tool_manager._tools.values():
+        if tool.name == name:
+            return tool.fn(**kwargs)
+    raise ValueError(f"Tool '{name}' not found")
+
+
+def _build_test_kg(tmp_path: Path) -> str:
+    """Create a minimal KG with Person + Department + System, export, load into state."""
+    person_cls = EntityRegistry.get(EntityType.PERSON)
+    dept_cls = EntityRegistry.get(EntityType.DEPARTMENT)
+    system_cls = EntityRegistry.get(EntityType.SYSTEM)
+
+    kg = KnowledgeGraph()
+    kg.add_entity(person_cls(
+        id="per-001", name="Alice", first_name="Alice",
+        last_name="Smith", email="alice@test.com",
+    ))
+    kg.add_entity(dept_cls(id="dept-001", name="Engineering"))
+    kg.add_entity(system_cls(id="sys-001", name="Auth Service"))
+    kg.add_entity(system_cls(id="sys-002", name="DB Service"))
+
+    json_path = tmp_path / "test_graph.json"
+    JSONExporter().export(kg.engine, json_path)
+    state._kg = kg
+    state._loaded_path = str(json_path)
+    state._loaded_mtime = json_path.stat().st_mtime
+    return str(json_path)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Clean server state before and after each test."""
+    state._kg = None
+    state._loaded_path = None
+    state._loaded_mtime = 0.0
+    yield
+    state._kg = None
+    state._loaded_path = None
+    state._loaded_mtime = 0.0
+
+
+# -- add_relationship_tool --
+
+class TestAddRelationshipTool:
+    def test_valid_relationship(self, tmp_path):
+        _build_test_kg(tmp_path)
+        result = _call_tool(
+            "add_relationship_tool",
+            relationship_type="works_in",
+            source_id="per-001",
+            target_id="dept-001",
+        )
+        assert result["status"] == "ok"
+        assert "relationship_id" in result
+        assert result["relationship"]["relationship_type"] == "works_in"
+        assert result["relationship"]["source_id"] == "per-001"
+        assert result["relationship"]["target_id"] == "dept-001"
+
+    def test_system_depends_on_system(self, tmp_path):
+        _build_test_kg(tmp_path)
+        result = _call_tool(
+            "add_relationship_tool",
+            relationship_type="depends_on",
+            source_id="sys-001",
+            target_id="sys-002",
+        )
+        assert result["status"] == "ok"
+
+    def test_invalid_relationship_type(self, tmp_path):
+        _build_test_kg(tmp_path)
+        result = _call_tool(
+            "add_relationship_tool",
+            relationship_type="applies_to",
+            source_id="per-001",
+            target_id="dept-001",
+        )
+        assert "error" in result
+        assert "Unknown relationship_type" in result["error"]
+
+    def test_missing_source_entity(self, tmp_path):
+        _build_test_kg(tmp_path)
+        result = _call_tool(
+            "add_relationship_tool",
+            relationship_type="works_in",
+            source_id="per-999",
+            target_id="dept-001",
+        )
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_missing_target_entity(self, tmp_path):
+        _build_test_kg(tmp_path)
+        result = _call_tool(
+            "add_relationship_tool",
+            relationship_type="works_in",
+            source_id="per-001",
+            target_id="dept-999",
+        )
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_schema_violation(self, tmp_path):
+        """works_in requires Person -> Department, not System -> System."""
+        _build_test_kg(tmp_path)
+        result = _call_tool(
+            "add_relationship_tool",
+            relationship_type="works_in",
+            source_id="sys-001",
+            target_id="sys-002",
+        )
+        assert "error" in result
+
+    def test_persists_to_disk(self, tmp_path):
+        json_path = _build_test_kg(tmp_path)
+        _call_tool(
+            "add_relationship_tool",
+            relationship_type="works_in",
+            source_id="per-001",
+            target_id="dept-001",
+        )
+        # Re-read from disk and verify relationship is there
+        data = json.loads(Path(json_path).read_text())
+        rel_types = [r["relationship_type"] for r in data["relationships"]]
+        assert "works_in" in rel_types
+
+    def test_with_properties(self, tmp_path):
+        _build_test_kg(tmp_path)
+        result = _call_tool(
+            "add_relationship_tool",
+            relationship_type="depends_on",
+            source_id="sys-001",
+            target_id="sys-002",
+            properties={"context": "authentication"},
+        )
+        assert result["status"] == "ok"
+        assert result["relationship"]["properties"]["context"] == "authentication"
+
+    def test_default_weight_and_confidence(self, tmp_path):
+        _build_test_kg(tmp_path)
+        result = _call_tool(
+            "add_relationship_tool",
+            relationship_type="works_in",
+            source_id="per-001",
+            target_id="dept-001",
+        )
+        assert result["relationship"]["weight"] == 1.0
+        assert result["relationship"]["confidence"] == 1.0
+
+    def test_custom_weight_and_confidence(self, tmp_path):
+        _build_test_kg(tmp_path)
+        result = _call_tool(
+            "add_relationship_tool",
+            relationship_type="works_in",
+            source_id="per-001",
+            target_id="dept-001",
+            weight=0.5,
+            confidence=0.8,
+        )
+        assert result["relationship"]["weight"] == 0.5
+        assert result["relationship"]["confidence"] == 0.8
+
+    def test_weight_clamped(self, tmp_path):
+        _build_test_kg(tmp_path)
+        result = _call_tool(
+            "add_relationship_tool",
+            relationship_type="works_in",
+            source_id="per-001",
+            target_id="dept-001",
+            weight=5.0,
+            confidence=-1.0,
+        )
+        assert result["status"] == "ok"
+        assert result["relationship"]["weight"] == 1.0
+        assert result["relationship"]["confidence"] == 0.0
+
+    def test_no_graph_loaded(self):
+        result = _call_tool(
+            "add_relationship_tool",
+            relationship_type="works_in",
+            source_id="per-001",
+            target_id="dept-001",
+        )
+        assert "error" in result
+        assert "No graph loaded" in result["error"]
+
+    def test_relationship_count_increases(self, tmp_path):
+        _build_test_kg(tmp_path)
+        stats_before = state._kg.statistics["relationship_count"]
+        _call_tool(
+            "add_relationship_tool",
+            relationship_type="works_in",
+            source_id="per-001",
+            target_id="dept-001",
+        )
+        stats_after = state._kg.statistics["relationship_count"]
+        assert stats_after == stats_before + 1


### PR DESCRIPTION
## Summary
- Add `add_relationship_tool` MCP write tool with full validation (enum, entity existence, domain/range schema) and auto-persist
- New `validation.py` module for reusable input validation across future write tools
- New `persist_graph()` helper in `state.py` with mtime sync to prevent auto-reload race
- 33 new tests (20 validation + 13 write tool), 1190 total passing, lint clean

Closes #247

## Test plan
- [x] 33 new tests pass (validation + write tool)
- [x] Full suite: 1190 passed, 1 skipped
- [x] Ruff lint clean