### PR TITLE
feat: MCP write tools — batch add + remove relationship

### DIFF
--- a/tests/unit/mcp_server/test_write_tools.py
+++ b/tests/unit/mcp_server/test_write_tools.py
@@ -1,4 +1,4 @@
-"""Tests for MCP write tools (add_relationship_tool)."""
+"""Tests for MCP write tools (add_relationship, batch, remove)."""
 
 from __future__ import annotations
 
@@ -217,3 +217,196 @@ class TestAddRelationshipTool:
         )
         stats_after = state._kg.statistics["relationship_count"]
         assert stats_after == stats_before + 1
+
+
+# -- add_relationships_batch --
+
+class TestAddRelationshipsBatch:
+    def test_valid_batch(self, tmp_path):
+        _build_test_kg(tmp_path)
+        result = _call_tool(
+            "add_relationships_batch",
+            relationships=[
+                {"relationship_type": "works_in", "source_id": "per-001", "target_id": "dept-001"},
+                {"relationship_type": "depends_on", "source_id": "sys-001", "target_id": "sys-002"},
+            ],
+        )
+        assert result["status"] == "ok"
+        assert result["committed"] == 2
+        assert len(result["relationships"]) == 2
+
+    def test_single_item_batch(self, tmp_path):
+        _build_test_kg(tmp_path)
+        result = _call_tool(
+            "add_relationships_batch",
+            relationships=[
+                {"relationship_type": "works_in", "source_id": "per-001", "target_id": "dept-001"},
+            ],
+        )
+        assert result["status"] == "ok"
+        assert result["committed"] == 1
+
+    def test_validation_failure_rejects_all(self, tmp_path):
+        """If any item fails validation, nothing is committed."""
+        _build_test_kg(tmp_path)
+        count_before = state._kg.statistics["relationship_count"]
+        result = _call_tool(
+            "add_relationships_batch",
+            relationships=[
+                {"relationship_type": "works_in", "source_id": "per-001", "target_id": "dept-001"},
+                {
+                    "relationship_type": "applies_to",
+                    "source_id": "per-001",
+                    "target_id": "dept-001",
+                },
+            ],
+        )
+        assert result["status"] == "error"
+        assert result["committed"] == 0
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["index"] == 1
+        # Verify nothing was committed
+        count_after = state._kg.statistics["relationship_count"]
+        assert count_after == count_before
+
+    def test_missing_required_field(self, tmp_path):
+        _build_test_kg(tmp_path)
+        result = _call_tool(
+            "add_relationships_batch",
+            relationships=[
+                {"relationship_type": "works_in", "source_id": "per-001"},
+            ],
+        )
+        assert result["status"] == "error"
+        assert "Missing required field" in result["errors"][0]["error"]
+
+    def test_empty_list(self, tmp_path):
+        _build_test_kg(tmp_path)
+        result = _call_tool("add_relationships_batch", relationships=[])
+        assert "error" in result
+        assert "Empty" in result["error"]
+
+    def test_batch_limit_exceeded(self, tmp_path):
+        _build_test_kg(tmp_path)
+        item = {"relationship_type": "works_in", "source_id": "per-001", "target_id": "dept-001"}
+        big_list = [item] * 501
+        result = _call_tool("add_relationships_batch", relationships=big_list)
+        assert "error" in result
+        assert "500" in result["error"]
+
+    def test_batch_persists_to_disk(self, tmp_path):
+        json_path = _build_test_kg(tmp_path)
+        _call_tool(
+            "add_relationships_batch",
+            relationships=[
+                {"relationship_type": "works_in", "source_id": "per-001", "target_id": "dept-001"},
+                {"relationship_type": "depends_on", "source_id": "sys-001", "target_id": "sys-002"},
+            ],
+        )
+        data = json.loads(Path(json_path).read_text())
+        rel_types = [r["relationship_type"] for r in data["relationships"]]
+        assert "works_in" in rel_types
+        assert "depends_on" in rel_types
+
+    def test_batch_with_weight_and_properties(self, tmp_path):
+        _build_test_kg(tmp_path)
+        result = _call_tool(
+            "add_relationships_batch",
+            relationships=[
+                {
+                    "relationship_type": "depends_on",
+                    "source_id": "sys-001",
+                    "target_id": "sys-002",
+                    "weight": 0.7,
+                    "confidence": 0.9,
+                    "properties": {"context": "auth"},
+                },
+            ],
+        )
+        assert result["status"] == "ok"
+        rel = result["relationships"][0]["relationship"]
+        assert rel["weight"] == 0.7
+        assert rel["confidence"] == 0.9
+        assert rel["properties"]["context"] == "auth"
+
+    def test_no_graph_loaded(self):
+        result = _call_tool(
+            "add_relationships_batch",
+            relationships=[
+                {"relationship_type": "works_in", "source_id": "per-001", "target_id": "dept-001"},
+            ],
+        )
+        assert "error" in result
+        assert "No graph loaded" in result["error"]
+
+    def test_multiple_validation_errors(self, tmp_path):
+        _build_test_kg(tmp_path)
+        result = _call_tool(
+            "add_relationships_batch",
+            relationships=[
+                {
+                    "relationship_type": "applies_to",
+                    "source_id": "per-001",
+                    "target_id": "dept-001",
+                },
+                {
+                    "relationship_type": "works_in",
+                    "source_id": "per-999",
+                    "target_id": "dept-001",
+                },
+            ],
+        )
+        assert result["status"] == "error"
+        assert len(result["errors"]) == 2
+        assert result["committed"] == 0
+
+
+# -- remove_relationship_tool --
+
+class TestRemoveRelationshipTool:
+    def test_remove_valid(self, tmp_path):
+        _build_test_kg(tmp_path)
+        # First add a relationship
+        add_result = _call_tool(
+            "add_relationship_tool",
+            relationship_type="works_in",
+            source_id="per-001",
+            target_id="dept-001",
+        )
+        rel_id = add_result["relationship_id"]
+        count_after_add = state._kg.statistics["relationship_count"]
+
+        # Now remove it
+        result = _call_tool("remove_relationship_tool", relationship_id=rel_id)
+        assert result["status"] == "ok"
+        assert result["removed"]["relationship_type"] == "works_in"
+        assert state._kg.statistics["relationship_count"] == count_after_add - 1
+
+    def test_remove_not_found(self, tmp_path):
+        _build_test_kg(tmp_path)
+        result = _call_tool("remove_relationship_tool", relationship_id="nonexistent-id")
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_remove_persists_to_disk(self, tmp_path):
+        json_path = _build_test_kg(tmp_path)
+        # Add then remove
+        add_result = _call_tool(
+            "add_relationship_tool",
+            relationship_type="works_in",
+            source_id="per-001",
+            target_id="dept-001",
+        )
+        rel_id = add_result["relationship_id"]
+
+        _call_tool("remove_relationship_tool", relationship_id=rel_id)
+
+        # Verify on disk
+        data = json.loads(Path(json_path).read_text())
+        rel_ids = [r.get("id", "") for r in data["relationships"]]
+        assert rel_id not in rel_ids
+
+    def test_remove_no_graph_loaded(self):
+        result = _call_tool("remove_relationship_tool", relationship_id="some-id")
+        assert "error" in result
+        assert "No graph loaded" in result["error"]


### PR DESCRIPTION
## Summary
- **`add_relationships_batch`** — Validates ALL inputs before committing ANY. Single persist at end. Max 500 per call.
- **`remove_relationship_tool`** — Removes by ID, returns removed relationship info, auto-persists.

## Test Plan
- 14 new tests (10 batch + 4 remove) — all passing
- 1204 total tests passing, lint clean
- Atomic batch semantics verified: partial validation failure commits nothing

Closes #249