### PR TITLE
feat: MCP entity CRUD tools — add, update, remove (#251)

### DIFF
--- a/src/engine/networkx_engine.py
+++ b/src/engine/networkx_engine.py
@@ -53,7 +53,7 @@ class NetworkXGraphEngine(AbstractGraphEngine):
         candidate = dict(self._graph.nodes[entity_id])
         candidate.update(updates)
         candidate["updated_at"] = datetime.now(UTC)
-        candidate["version"] = candidate.get("version", 1) + 1
+        candidate["version"] = str(int(candidate.get("version") or 1) + 1)
 
         entity = self._deserialize_entity(dict(candidate))
         if entity is None:


### PR DESCRIPTION
## Summary
- Add three new MCP tools: `add_entity_tool`, `update_entity_tool`, `remove_entity_tool` for full entity lifecycle management
- Fix engine `update_entity` version increment bug (version field is str in Pydantic, was being incremented as int)
- Defense-in-depth: `update_entity_tool` catches TypeError alongside KeyError/ValueError

## Details
- `add_entity_tool`: Creates entities of any of the 30 types using EntityRegistry for concrete Pydantic classes, auto-generates UUID
- `update_entity_tool`: Validates entity existence, delegates to engine copy-validate-write pattern
- `remove_entity_tool`: Captures entity info before removal, engine cascades relationship deletion
- All three tools auto-persist to disk after mutation

## Test plan
- [x] 19 new tests (8 add + 6 update + 5 remove)
- [x] 46 write tool tests passing
- [x] 1223 total tests passing
- [x] Ruff clean

Closes #251