### PR TITLE
feat: remap OSINT enrichment types + test safety fixture

### DIFF
--- a/src/domain/base.py
+++ b/src/domain/base.py
@@ -133,6 +133,7 @@ class RelationshipType(StrEnum):
     FLOWS_TO = "flows_to"
     ORIGINATES_FROM = "originates_from"
     CLASSIFIED_AS = "classified_as"
+    SUBJECT_OF = "subject_of"
 
     # --- L04-L05: Organization & People ---
     APPLIES_TO = "applies_to"

--- a/src/domain/relationship_schema.py
+++ b/src/domain/relationship_schema.py
@@ -148,6 +148,7 @@ RELATIONSHIP_SCHEMA: dict[RelationshipType, tuple[set[EntityType], set[EntityTyp
     RelationshipType.SERVES: (
         {
             EntityType.PRODUCT,
+            EntityType.PRODUCT_PORTFOLIO,
             EntityType.SYSTEM,
             EntityType.DEPARTMENT,
             EntityType.ORGANIZATIONAL_UNIT,
@@ -264,6 +265,10 @@ RELATIONSHIP_SCHEMA: dict[RelationshipType, tuple[set[EntityType], set[EntityTyp
         {EntityType.DATA_ASSET},
         {EntityType.DATA_DOMAIN},
     ),
+    RelationshipType.SUBJECT_OF: (
+        {EntityType.CUSTOMER, EntityType.PERSON},
+        {EntityType.DATA_ASSET},
+    ),
     # --- L04-L05: Organization & People ---
     RelationshipType.APPLIES_TO: (
         {EntityType.CONTROL, EntityType.POLICY, EntityType.REGULATION},
@@ -297,7 +302,7 @@ RELATIONSHIP_SCHEMA: dict[RelationshipType, tuple[set[EntityType], set[EntityTyp
     ),
     RelationshipType.SUPPLIES: (
         {EntityType.VENDOR},
-        {EntityType.SYSTEM, EntityType.PRODUCT},
+        {EntityType.SYSTEM, EntityType.PRODUCT, EntityType.PRODUCT_PORTFOLIO},
     ),
     # --- L11: Strategic Initiatives ---
     RelationshipType.IMPACTS: (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 from domain.base import BaseRelationship, RelationshipType
 from domain.entities.department import Department
@@ -19,6 +24,20 @@ def _auto_discover() -> None:
     """Auto-discover entity types and engine backends before each test."""
     EntityRegistry.auto_discover()
     GraphEngineFactory.auto_discover()
+
+
+@pytest.fixture(autouse=True)
+def _no_claude_sync(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect HOME so CLI commands can't find the real Claude Desktop config.
+
+    ``sync_claude_graph_path`` calls ``_detect_claude_config_path`` which
+    resolves ``~/Library/Application Support/Claude/...``.  With HOME set
+    to a temp dir the file won't exist and sync returns False.
+
+    Tests that exercise sync explicitly should mock
+    ``_detect_claude_config_path`` to return a temp-dir config path.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Add `subject_of` relationship type (customer/person → data_asset) for GDPR/privacy modeling
- Widen `serves` source set to include `product_portfolio`
- Widen `supplies` target set to include `product_portfolio`
- Add autouse conftest fixture that redirects HOME during tests, permanently preventing pytest from overwriting the real Claude Desktop config

## Test plan
- [x] 1,223 tests pass, 0 failures
- [x] Ruff lint + format clean
- [x] Verified Claude Desktop config survives full test run
- [x] Verified ingestor loads 5,591 OSINT relationships with 0 errors

Closes #253