### PR TITLE
feat: install reliability improvements — v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.31.0] - 2026-02-26
+
+### Added
+- **`hckg install claude --auto-install`** — New flag that automatically runs `poetry install --extras mcp` (or pip fallback) when the MCP pre-flight detects a missing `mcp` package, then re-runs checks. Eliminates a manual step for new users (#262)
+- **Apple CLT Python detection** — Pre-flight check now recognises Python from `/Library/Developer/CommandLineTools/` (macOS system Python ≤3.9) and emits a targeted fix message: `brew install poetry` rather than the generic re-install hint (#261)
+- **macOS Quick Start prerequisites** in README — Homebrew-first install note, shell alias snippet, and Claude Desktop integration block all promoted to the top-level Quick Start section so users have the full path in one place (#264)
+- **Apple CLT Python symlink error** documented in `docs/troubleshooting.md` with root cause explanation and `brew install poetry` fix (#261, #264)
+
+### Fixed
+- **`hckg install doctor` neutral-state language** — Pre-registration state (no `mcpServers` key in config) now exits 0 and prints `Not yet registered with Claude Desktop.` instead of the alarming `Config file has no valid 'mcpServers' object.` error message (#263)
+
 ## [0.30.2] - 2026-02-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 ## Quick Commands
 
 ```bash
-poetry run pytest tests/ -v          # Run all tests (~1012)
+poetry run pytest tests/ -v          # Run all tests (~1013)
 poetry run pytest tests/performance/ -v  # Performance regression tests
 poetry run ruff check src/ tests/    # Lint
 poetry run hckg demo --clean         # Generate fresh graph.json
@@ -96,6 +96,8 @@ The MCP server (`src/mcp_server/`) provides 16 tools for Claude Desktop:
 **Auto-reload** ([ADR-009](docs/adr/009-mcp-mtime-auto-reload.md))**:** The server detects graph file changes via mtime checking on every tool call. After `hckg demo --clean`, Claude Desktop tools automatically pick up the new graph.
 
 **Write tool validation** (`src/mcp_server/validation.py`)**:** All write tools validate inputs (enum membership, entity existence, domain/range schema) before mutation. `persist_graph()` in `state.py` auto-saves to disk and syncs mtime to prevent reload races.
+
+**Install reliability (v0.31.0):** `hckg install claude --auto-install` installs missing MCP extras automatically. `hckg install doctor` now exits 0 (not an error) when not yet registered. Apple CLT Python is detected in the pre-flight with a targeted `brew install poetry` fix message.
 
 ## Architecture Decision Records
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ This is the tool you reach for *before* a full-scale engagement, to validate hyp
 
 ## Quick Start
 
+**Prerequisites — install Poetry first:**
+
+```bash
+# macOS (recommended)
+brew install poetry
+
+# Any platform
+pipx install poetry
+```
+
+> **macOS note:** The `curl | python3 -` Poetry installer fails on Apple's Command Line Tools Python. Use `brew install poetry` instead. See [Troubleshooting](docs/troubleshooting.md) for details.
+
+**Clone and install:**
+
 ```bash
 git clone https://github.com/thehipsterciso/hc-enterprise-kg.git
 cd hc-enterprise-kg
@@ -34,7 +48,28 @@ That generates a complete enterprise knowledge graph with ~277 entities and ~543
 poetry run hckg inspect graph.json
 ```
 
-Customize the organization:
+**Optional: set a shell alias** so you can type `hckg` directly instead of `poetry run hckg`:
+
+```bash
+# zsh (default on macOS)
+echo 'alias hckg="poetry run hckg"' >> ~/.zshrc && source ~/.zshrc
+
+# bash
+echo 'alias hckg="poetry run hckg"' >> ~/.bashrc && source ~/.bashrc
+```
+
+**Claude Desktop integration:**
+
+```bash
+poetry install --extras mcp      # install MCP server dependencies
+poetry run hckg install claude   # register with Claude Desktop
+# — or in one step —
+poetry run hckg install claude --auto-install
+```
+
+Restart Claude Desktop, then ask: *"Show me graph statistics"*
+
+**Customize the organization:**
 
 ```bash
 # Healthcare org with 500 employees
@@ -131,20 +166,6 @@ tests/          740+ tests (unit, integration, stress, performance)
 | [Architecture Decision Records](docs/adr/) | Design rationale for all major architectural choices (12 ADRs) |
 | [Contributing](CONTRIBUTING.md) | Development setup, code style, adding entity types |
 | [Changelog](CHANGELOG.md) | Release history |
-
----
-
-## Shell Alias
-
-To avoid typing `poetry run` every time:
-
-```bash
-# zsh (default on macOS)
-echo 'alias hckg="poetry run hckg"' >> ~/.zshrc && source ~/.zshrc
-
-# bash
-echo 'alias hckg="poetry run hckg"' >> ~/.bashrc && source ~/.bashrc
-```
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -27,11 +27,34 @@ echo 'alias hckg="poetry run hckg"' >> ~/.bashrc && source ~/.bashrc
 Install Poetry:
 
 ```bash
-# macOS
+# macOS (recommended)
 brew install poetry
 
 # Any platform
 pipx install poetry
+```
+
+### Poetry curl installer fails: "This build of python cannot create venvs without using symlinks"
+
+You are using Apple's Command Line Tools Python (`/Library/Developer/CommandLineTools/`), which is intentionally restricted and cannot create virtualenvs without symlinks. The `curl | python3 -` installer path does not work with this Python.
+
+**Fix — use Homebrew instead:**
+
+```bash
+brew install poetry
+```
+
+Homebrew's poetry brings a compatible Python (3.14+) and sets up the virtualenv correctly. After installation, add poetry to your PATH if prompted:
+
+```bash
+export PATH="/opt/homebrew/bin:$PATH"
+```
+
+Then proceed with:
+
+```bash
+poetry install
+poetry run hckg demo
 ```
 
 ### `poetry shell` doesn't work

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hc-enterprise-kg"
-version = "0.30.3"
+version = "0.31.0"
 description = "Enterprise knowledge graph platform for rapid organizational modelling, scenario analysis, and data & AI leadership"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/unit/cli/test_mcp_cmd.py
+++ b/tests/unit/cli/test_mcp_cmd.py
@@ -715,10 +715,12 @@ class TestInstallDoctor:
         assert result.exit_code == 0, result.output
 
     def test_not_registered(self, tmp_path: Path):
+        # Not-yet-registered is a normal pre-install state, not an error —
+        # doctor should exit 0 and print a friendly message.
         config_path = _make_config(str(tmp_path))  # empty servers
         result = self._run_doctor(config_path)
-        assert result.exit_code != 0
-        assert "not registered" in result.output
+        assert result.exit_code == 0
+        assert "not yet registered" in result.output.lower()
 
     def test_config_file_missing(self, tmp_path: Path):
         config_path = tmp_path / "nope.json"


### PR DESCRIPTION
## Summary

Closes #261, #262, #263, #264

Four install reliability improvements based on a real-world install session log that surfaced friction across the full first-run journey.

- **`--auto-install` flag** (`hckg install claude --auto-install`) — detects missing MCP extras and installs them automatically via `poetry install --extras mcp` or pip fallback, then re-runs pre-flight. Eliminates one manual step for new users.
- **Apple CLT Python detection** — pre-flight now identifies the macOS Apple Command Line Tools Python (the one that can't create venvs without symlinks) and emits a targeted `brew install poetry` fix message instead of the generic hint.
- **`doctor` neutral-state language** — exits 0 with `Not yet registered with Claude Desktop.` instead of the alarming `Config file has no valid 'mcpServers' object.` error when the user simply hasn't registered yet.
- **README Quick Start overhaul** — Prerequisites block, shell alias, and Claude Desktop integration path all promoted to the top-level Quick Start; redundant standalone Shell Alias section removed.
- **`docs/troubleshooting.md`** — Apple CLT Python symlink error documented with root cause explanation and Homebrew fix.

## Test plan

- [x] All 279 CLI + MCP unit tests pass
- [x] `test_not_registered` updated to assert exit 0 and match new message text
- [x] `ruff check src/ tests/unit/cli/test_mcp_cmd.py` — clean
- [x] Manual: `hckg install doctor` on fresh config shows friendly message, exits 0
- [x] Manual: `hckg install claude --auto-install` triggers install and retries checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)