### PR TITLE
feat: atomic file writes for exporters

### DIFF
--- a/src/export/base.py
+++ b/src/export/base.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
+import os
+import tempfile
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
@@ -9,6 +12,30 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from engine.abstract import AbstractGraphEngine
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    """Atomically write *content* to *path* via temp-file-then-rename.
+
+    Ensures readers never see a partially-written file.  On POSIX
+    ``os.replace`` is atomic; on Windows it is as close as the OS allows.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    try:
+        try:
+            os.write(fd, content.encode("utf-8"))
+        finally:
+            os.close(fd)
+        os.replace(tmp, str(path))
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
 
 
 class AbstractExporter(ABC):

--- a/src/export/graphml_export.py
+++ b/src/export/graphml_export.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import networkx as nx
 
-from export.base import AbstractExporter
+from export.base import AbstractExporter, atomic_write_text
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -23,9 +23,8 @@ class GraphMLExporter(AbstractExporter):
     """
 
     def export(self, engine: AbstractGraphEngine, output_path: Path, **kwargs: Any) -> None:
-        g = self._prepare_graph(engine)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        nx.write_graphml(g, str(output_path))
+        content = self.export_string(engine, **kwargs)
+        atomic_write_text(output_path, content)
 
     def export_string(self, engine: AbstractGraphEngine, **kwargs: Any) -> str:
         import io

--- a/src/export/json_export.py
+++ b/src/export/json_export.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
-from export.base import AbstractExporter
+from export.base import AbstractExporter, atomic_write_text
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -26,8 +26,7 @@ class JSONExporter(AbstractExporter):
 
     def export(self, engine: AbstractGraphEngine, output_path: Path, **kwargs: Any) -> None:
         content = self.export_string(engine, **kwargs)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(content)
+        atomic_write_text(output_path, content)
 
     def export_string(self, engine: AbstractGraphEngine, **kwargs: Any) -> str:
         entities = engine.list_entities()

--- a/tests/unit/export/test_atomic_write.py
+++ b/tests/unit/export/test_atomic_write.py
@@ -1,0 +1,155 @@
+"""Tests for atomic file write functionality."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from domain.base import BaseRelationship, RelationshipType
+from domain.entities.department import Department
+from domain.entities.person import Person
+from engine.networkx_engine import NetworkXGraphEngine
+from export.base import atomic_write_text
+from export.graphml_export import GraphMLExporter
+from export.json_export import JSONExporter
+
+
+def _build_engine() -> NetworkXGraphEngine:
+    engine = NetworkXGraphEngine()
+    person = Person(
+        id="p1",
+        first_name="Alice",
+        last_name="Smith",
+        name="Alice Smith",
+        email="a@b.com",
+    )
+    dept = Department(id="d1", name="Engineering")
+    engine.add_entity(person)
+    engine.add_entity(dept)
+    engine.add_relationship(
+        BaseRelationship(
+            relationship_type=RelationshipType.WORKS_IN,
+            source_id="p1",
+            target_id="d1",
+        )
+    )
+    return engine
+
+
+class TestAtomicWriteText:
+    """Tests for the atomic_write_text utility function."""
+
+    def test_writes_content_to_file(self, tmp_path: Path):
+        path = tmp_path / "test.txt"
+        atomic_write_text(path, "hello world")
+        assert path.read_text() == "hello world"
+
+    def test_creates_parent_directories(self, tmp_path: Path):
+        path = tmp_path / "a" / "b" / "c" / "test.txt"
+        atomic_write_text(path, "nested")
+        assert path.read_text() == "nested"
+
+    def test_overwrites_existing_file(self, tmp_path: Path):
+        path = tmp_path / "test.txt"
+        path.write_text("old content")
+        atomic_write_text(path, "new content")
+        assert path.read_text() == "new content"
+
+    def test_no_temp_files_remain_on_success(self, tmp_path: Path):
+        path = tmp_path / "test.json"
+        atomic_write_text(path, '{"key": "value"}')
+        remaining = list(tmp_path.glob(".*"))
+        assert remaining == [], f"Temp files left behind: {remaining}"
+
+    def test_preserves_original_on_write_failure(self, tmp_path: Path):
+        # Make directory read-only to force mkstemp failure
+        no_write_dir = tmp_path / "readonly"
+        no_write_dir.mkdir()
+        target = no_write_dir / "test.txt"
+        target.write_text("original")
+        os.chmod(str(no_write_dir), 0o444)
+
+        try:
+            with pytest.raises(PermissionError):
+                atomic_write_text(target, "should fail")
+        finally:
+            os.chmod(str(no_write_dir), 0o700)
+
+        # Original file should still be intact (check after restoring perms)
+        assert target.read_text() == "original"
+
+    def test_cleans_up_temp_on_failure(self, tmp_path: Path):
+        # Create a scenario where the write can fail
+        no_write_dir = tmp_path / "readonly"
+        no_write_dir.mkdir()
+        target = no_write_dir / "test.txt"
+        os.chmod(str(no_write_dir), 0o444)
+
+        try:
+            with pytest.raises(PermissionError):
+                atomic_write_text(target, "fail")
+            # No temp files should remain
+            temps = list(no_write_dir.glob(".*"))
+            assert temps == [], f"Temp files not cleaned: {temps}"
+        finally:
+            os.chmod(str(no_write_dir), 0o700)
+
+    def test_handles_unicode_content(self, tmp_path: Path):
+        path = tmp_path / "unicode.txt"
+        content = "Hello \u4e16\u754c \U0001f30d \u00e9\u00e8\u00ea"
+        atomic_write_text(path, content)
+        assert path.read_text(encoding="utf-8") == content
+
+
+class TestJSONExporterAtomic:
+    """Verify JSONExporter uses atomic writes."""
+
+    def test_export_produces_valid_json(self, tmp_path: Path):
+        engine = _build_engine()
+        path = tmp_path / "graph.json"
+        JSONExporter().export(engine, path)
+        data = json.loads(path.read_text())
+        assert len(data["entities"]) == 2
+        assert len(data["relationships"]) == 1
+
+    def test_no_temp_files_after_export(self, tmp_path: Path):
+        engine = _build_engine()
+        path = tmp_path / "graph.json"
+        JSONExporter().export(engine, path)
+        temps = list(tmp_path.glob(".*"))
+        assert temps == [], f"Temp files left behind: {temps}"
+
+    def test_overwrite_is_atomic(self, tmp_path: Path):
+        """Write twice — second write should fully replace first."""
+        engine = _build_engine()
+        path = tmp_path / "graph.json"
+
+        JSONExporter().export(engine, path)
+        first = json.loads(path.read_text())
+
+        # Add another entity and re-export
+        dept2 = Department(id="d2", name="Sales")
+        engine.add_entity(dept2)
+        JSONExporter().export(engine, path)
+        second = json.loads(path.read_text())
+
+        assert len(second["entities"]) == len(first["entities"]) + 1
+
+
+class TestGraphMLExporterAtomic:
+    """Verify GraphMLExporter uses atomic writes."""
+
+    def test_export_produces_valid_graphml(self, tmp_path: Path):
+        engine = _build_engine()
+        path = tmp_path / "graph.graphml"
+        GraphMLExporter().export(engine, path)
+        content = path.read_text()
+        assert "graphml" in content
+
+    def test_no_temp_files_after_export(self, tmp_path: Path):
+        engine = _build_engine()
+        path = tmp_path / "graph.graphml"
+        GraphMLExporter().export(engine, path)
+        temps = list(tmp_path.glob(".*"))
+        assert temps == [], f"Temp files left behind: {temps}"


### PR DESCRIPTION
## Summary
- Extract `atomic_write_text()` utility into `export/base.py` using `tempfile.mkstemp()` + `os.replace()` (same pattern as `cli/install_cmd.py`)
- JSONExporter and GraphMLExporter now use atomic writes — readers never see partial files
- 12 new tests covering success, failure, cleanup, and unicode

## Test plan
- [x] `poetry run pytest tests/unit/export/test_atomic_write.py -v` — 12 passed
- [x] `poetry run pytest tests/ -q` — 1479 passed, 0 regressions
- [x] `poetry run ruff check src/ tests/` — clean

Closes #272