### PR TITLE
feat: advisory file locking for graph.json

### DIFF
--- a/src/export/file_lock.py
+++ b/src/export/file_lock.py
@@ -1,0 +1,141 @@
+"""Advisory file locking for graph persistence.
+
+Provides a context-manager that wraps ``fcntl.flock()`` on POSIX (with
+a ``msvcrt`` fallback on Windows) so concurrent readers and writers of
+``graph.json`` cooperate safely.
+
+Usage::
+
+    from export.file_lock import GraphFileLock
+
+    # Exclusive lock for writing
+    with GraphFileLock(path, exclusive=True):
+        path.write_text(content)
+
+    # Shared lock for reading
+    with GraphFileLock(path, exclusive=False):
+        data = path.read_text()
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+
+class LockTimeoutError(OSError):
+    """Raised when a file lock cannot be acquired within the timeout."""
+
+
+class GraphFileLock:
+    """Advisory file lock (shared or exclusive) with timeout.
+
+    Parameters
+    ----------
+    path:
+        Path to the file to lock.  A companion ``.lock`` file is created
+        in the same directory to avoid interfering with the data file.
+    exclusive:
+        ``True`` for an exclusive (write) lock, ``False`` for a shared
+        (read) lock.
+    timeout:
+        Maximum seconds to wait for the lock.  ``0`` means non-blocking
+        (fail immediately if the lock is held).
+    """
+
+    def __init__(
+        self,
+        path: Path | str,
+        *,
+        exclusive: bool = True,
+        timeout: float = 10.0,
+    ) -> None:
+        self._path = Path(path)
+        self._lock_path = self._path.with_suffix(self._path.suffix + ".lock")
+        self._exclusive = exclusive
+        self._timeout = timeout
+        self._fd: int | None = None
+
+    def acquire(self) -> None:
+        """Acquire the advisory lock, blocking up to *timeout* seconds."""
+        self._lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Open (or create) the lock file
+        flags = os.O_RDWR | os.O_CREAT
+        self._fd = os.open(str(self._lock_path), flags, 0o666)
+
+        deadline = time.monotonic() + self._timeout
+        poll_interval = 0.05  # 50 ms
+
+        while True:
+            try:
+                self._try_lock()
+                return  # success
+            except OSError:
+                if time.monotonic() >= deadline:
+                    # Clean up fd before raising
+                    os.close(self._fd)
+                    self._fd = None
+                    raise LockTimeoutError(
+                        f"Could not acquire {'exclusive' if self._exclusive else 'shared'} "
+                        f"lock on {self._path} within {self._timeout}s"
+                    ) from None
+                time.sleep(poll_interval)
+
+    def release(self) -> None:
+        """Release the advisory lock."""
+        if self._fd is not None:
+            try:
+                self._try_unlock()
+            finally:
+                os.close(self._fd)
+                self._fd = None
+
+    def __enter__(self) -> GraphFileLock:
+        self.acquire()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.release()
+
+    # ------------------------------------------------------------------
+    # Platform-specific lock primitives
+    # ------------------------------------------------------------------
+
+    def _try_lock(self) -> None:
+        """Non-blocking lock attempt.  Raises OSError if unavailable."""
+        if sys.platform == "win32":
+            self._try_lock_windows()
+        else:
+            self._try_lock_posix()
+
+    def _try_unlock(self) -> None:
+        if sys.platform == "win32":
+            self._try_unlock_windows()
+        else:
+            self._try_unlock_posix()
+
+    def _try_lock_posix(self) -> None:
+        import fcntl
+
+        flag = fcntl.LOCK_NB
+        flag |= fcntl.LOCK_EX if self._exclusive else fcntl.LOCK_SH
+        fcntl.flock(self._fd, flag)
+
+    def _try_unlock_posix(self) -> None:
+        import fcntl
+
+        fcntl.flock(self._fd, fcntl.LOCK_UN)
+
+    def _try_lock_windows(self) -> None:  # pragma: no cover
+        import msvcrt
+
+        # msvcrt.locking only supports exclusive locks
+        msvcrt.locking(self._fd, msvcrt.LK_NBLCK, 1)
+
+    def _try_unlock_windows(self) -> None:  # pragma: no cover
+        import msvcrt
+
+        msvcrt.locking(self._fd, msvcrt.LK_UNLCK, 1)

--- a/src/export/json_export.py
+++ b/src/export/json_export.py
@@ -6,6 +6,7 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from export.base import AbstractExporter, atomic_write_text
+from export.file_lock import GraphFileLock
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -26,7 +27,8 @@ class JSONExporter(AbstractExporter):
 
     def export(self, engine: AbstractGraphEngine, output_path: Path, **kwargs: Any) -> None:
         content = self.export_string(engine, **kwargs)
-        atomic_write_text(output_path, content)
+        with GraphFileLock(output_path, exclusive=True):
+            atomic_write_text(output_path, content)
 
     def export_string(self, engine: AbstractGraphEngine, **kwargs: Any) -> str:
         entities = engine.list_entities()

--- a/src/mcp_server/state.py
+++ b/src/mcp_server/state.py
@@ -10,6 +10,7 @@ import logging
 import os
 from pathlib import Path
 
+from export.file_lock import GraphFileLock
 from graph.knowledge_graph import KnowledgeGraph
 from ingest.json_ingestor import JSONIngestor
 
@@ -33,7 +34,8 @@ def load_graph(path: str) -> dict:
     global _kg, _loaded_path, _loaded_mtime  # noqa: PLW0603
 
     ingestor = JSONIngestor()
-    result = ingestor.ingest(path)
+    with GraphFileLock(path, exclusive=False):
+        result = ingestor.ingest(path)
 
     if not result.entities and result.errors:
         return {"error": f"Failed to load graph: {'; '.join(result.errors)}"}

--- a/tests/unit/export/test_file_lock.py
+++ b/tests/unit/export/test_file_lock.py
@@ -1,0 +1,169 @@
+"""Tests for advisory file locking."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from export.file_lock import GraphFileLock, LockTimeoutError
+
+
+class TestGraphFileLock:
+    """Core lock semantics."""
+
+    def test_exclusive_lock_acquires_and_releases(self, tmp_path: Path):
+        target = tmp_path / "graph.json"
+        target.write_text("{}")
+        with GraphFileLock(target, exclusive=True):
+            assert target.exists()
+        # Lock file created as companion
+        assert (tmp_path / "graph.json.lock").exists()
+
+    def test_shared_lock_acquires_and_releases(self, tmp_path: Path):
+        target = tmp_path / "graph.json"
+        target.write_text("{}")
+        with GraphFileLock(target, exclusive=False):
+            assert target.exists()
+
+    def test_multiple_shared_locks_allowed(self, tmp_path: Path):
+        target = tmp_path / "graph.json"
+        target.write_text("{}")
+        lock1 = GraphFileLock(target, exclusive=False)
+        lock2 = GraphFileLock(target, exclusive=False)
+        lock1.acquire()
+        lock2.acquire()  # Should not block
+        lock2.release()
+        lock1.release()
+
+    def test_exclusive_blocks_exclusive(self, tmp_path: Path):
+        target = tmp_path / "graph.json"
+        target.write_text("{}")
+        lock1 = GraphFileLock(target, exclusive=True)
+        lock1.acquire()
+
+        # Second exclusive lock should timeout quickly
+        with pytest.raises(LockTimeoutError):
+            GraphFileLock(target, exclusive=True, timeout=0.1).acquire()
+
+        lock1.release()
+
+    def test_exclusive_blocks_shared(self, tmp_path: Path):
+        target = tmp_path / "graph.json"
+        target.write_text("{}")
+        lock1 = GraphFileLock(target, exclusive=True)
+        lock1.acquire()
+
+        # Shared lock should timeout when exclusive is held
+        with pytest.raises(LockTimeoutError):
+            GraphFileLock(target, exclusive=False, timeout=0.1).acquire()
+
+        lock1.release()
+
+    def test_lock_released_on_exception(self, tmp_path: Path):
+        target = tmp_path / "graph.json"
+        target.write_text("{}")
+
+        with pytest.raises(ValueError, match="test error"), GraphFileLock(target, exclusive=True):
+            raise ValueError("test error")
+
+        # Lock should be released — another exclusive lock should succeed
+        with GraphFileLock(target, exclusive=True, timeout=0.1):
+            pass
+
+    def test_lock_creates_parent_dirs(self, tmp_path: Path):
+        target = tmp_path / "a" / "b" / "graph.json"
+        with GraphFileLock(target, exclusive=True):
+            pass
+        assert (tmp_path / "a" / "b" / "graph.json.lock").exists()
+
+    def test_timeout_zero_fails_immediately(self, tmp_path: Path):
+        target = tmp_path / "graph.json"
+        target.write_text("{}")
+        lock1 = GraphFileLock(target, exclusive=True)
+        lock1.acquire()
+
+        start = time.monotonic()
+        with pytest.raises(LockTimeoutError):
+            GraphFileLock(target, exclusive=True, timeout=0).acquire()
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.5  # Should fail fast
+
+        lock1.release()
+
+
+class TestFileLockConcurrency:
+    """Thread-based concurrency tests."""
+
+    def test_exclusive_serializes_writes(self, tmp_path: Path):
+        target = tmp_path / "graph.json"
+        target.write_text("0")
+        results: list[int] = []
+
+        def writer(value: int) -> None:
+            with GraphFileLock(target, exclusive=True):
+                current = int(target.read_text())
+                time.sleep(0.05)  # Simulate work
+                target.write_text(str(current + value))
+                results.append(value)
+
+        threads = [threading.Thread(target=writer, args=(i,)) for i in range(1, 4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        # All 3 writers completed
+        assert len(results) == 3
+        # Final value should be 1+2+3=6 (serialized, no race)
+        assert int(target.read_text()) == 6
+
+    def test_shared_allows_concurrent_reads(self, tmp_path: Path):
+        target = tmp_path / "graph.json"
+        target.write_text("test data")
+        read_count = 0
+        lock = threading.Lock()
+
+        def reader() -> None:
+            nonlocal read_count
+            with GraphFileLock(target, exclusive=False):
+                _ = target.read_text()
+                time.sleep(0.05)
+                with lock:
+                    read_count += 1
+
+        threads = [threading.Thread(target=reader) for _ in range(3)]
+        start = time.monotonic()
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+        elapsed = time.monotonic() - start
+
+        assert read_count == 3
+        # Concurrent reads should complete in ~50ms, not 150ms
+        assert elapsed < 0.3
+
+
+class TestLockTimeoutError:
+    """LockTimeoutError exception behavior."""
+
+    def test_is_os_error_subclass(self):
+        assert issubclass(LockTimeoutError, OSError)
+
+    def test_message_includes_path(self, tmp_path: Path):
+        target = tmp_path / "test.json"
+        target.write_text("{}")
+        lock = GraphFileLock(target, exclusive=True)
+        lock.acquire()
+
+        try:
+            with pytest.raises(LockTimeoutError, match="test.json"):
+                GraphFileLock(target, exclusive=True, timeout=0).acquire()
+        finally:
+            lock.release()


### PR DESCRIPTION
## Summary
- New `GraphFileLock` context manager in `src/export/file_lock.py` using `fcntl.flock()` (POSIX)
- Shared locks for reads, exclusive locks for writes, configurable timeout
- Integrated into `JSONExporter.export()` (exclusive) and `state.py load_graph()` (shared)
- 12 new tests including thread-based concurrency verification

## Test plan
- [x] `poetry run pytest tests/unit/export/ -v` — 32 passed
- [x] `poetry run ruff check src/export/ tests/unit/export/` — clean

Closes #274