### PR TITLE
feat: rotating backup copies before graph.json overwrite

### DIFF
--- a/src/export/json_export.py
+++ b/src/export/json_export.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from typing import TYPE_CHECKING, Any
 
 from export.base import AbstractExporter, atomic_write_text
@@ -12,6 +13,25 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from engine.abstract import AbstractGraphEngine
+
+DEFAULT_MAX_BACKUPS = 3
+
+
+def _rotate_backups(path: Path, max_backups: int = DEFAULT_MAX_BACKUPS) -> None:
+    """Rotate ``path`` → ``path.1`` → ``path.2`` → … before overwrite.
+
+    Does nothing if *max_backups* is 0 or the file does not yet exist.
+    """
+    if max_backups <= 0 or not path.exists():
+        return
+    # Shift existing backups: .3 → deleted, .2 → .3, .1 → .2
+    for i in range(max_backups, 1, -1):
+        src = path.with_name(f"{path.name}.{i - 1}")
+        dst = path.with_name(f"{path.name}.{i}")
+        if src.exists():
+            shutil.copy2(src, dst)
+    # Current file becomes .1
+    shutil.copy2(path, path.with_name(f"{path.name}.1"))
 
 
 class JSONExporter(AbstractExporter):
@@ -27,7 +47,9 @@ class JSONExporter(AbstractExporter):
 
     def export(self, engine: AbstractGraphEngine, output_path: Path, **kwargs: Any) -> None:
         content = self.export_string(engine, **kwargs)
+        max_backups = kwargs.get("max_backups", DEFAULT_MAX_BACKUPS)
         with GraphFileLock(output_path, exclusive=True):
+            _rotate_backups(output_path, max_backups)
             atomic_write_text(output_path, content)
 
     def export_string(self, engine: AbstractGraphEngine, **kwargs: Any) -> str:

--- a/tests/unit/export/test_backup.py
+++ b/tests/unit/export/test_backup.py
@@ -1,0 +1,105 @@
+"""Tests for backup-on-write rotation."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from domain.base import BaseRelationship, RelationshipType
+from domain.entities.department import Department
+from domain.entities.person import Person
+from engine.networkx_engine import NetworkXGraphEngine
+from export.json_export import JSONExporter, _rotate_backups
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _build_engine(extra_dept: str | None = None) -> NetworkXGraphEngine:
+    engine = NetworkXGraphEngine()
+    person = Person(
+        id="p1", first_name="Alice", last_name="Smith", name="Alice Smith", email="a@b.com"
+    )
+    dept = Department(id="d1", name="Engineering")
+    engine.add_entity(person)
+    engine.add_entity(dept)
+    if extra_dept:
+        engine.add_entity(Department(id=extra_dept, name=extra_dept))
+    engine.add_relationship(
+        BaseRelationship(
+            relationship_type=RelationshipType.WORKS_IN, source_id="p1", target_id="d1"
+        )
+    )
+    return engine
+
+
+class TestRotateBackups:
+    """Tests for the _rotate_backups utility."""
+
+    def test_no_backup_when_file_missing(self, tmp_path: Path):
+        target = tmp_path / "graph.json"
+        _rotate_backups(target)
+        assert not (tmp_path / "graph.json.1").exists()
+
+    def test_first_overwrite_creates_backup_1(self, tmp_path: Path):
+        target = tmp_path / "graph.json"
+        target.write_text("v1")
+        _rotate_backups(target)
+        assert (tmp_path / "graph.json.1").exists()
+        assert (tmp_path / "graph.json.1").read_text() == "v1"
+
+    def test_second_overwrite_shifts_backups(self, tmp_path: Path):
+        target = tmp_path / "graph.json"
+        target.write_text("v1")
+        _rotate_backups(target)
+        target.write_text("v2")
+        _rotate_backups(target)
+        assert (tmp_path / "graph.json.1").read_text() == "v2"
+        assert (tmp_path / "graph.json.2").read_text() == "v1"
+
+    def test_rotation_caps_at_max_backups(self, tmp_path: Path):
+        target = tmp_path / "graph.json"
+        for i in range(5):
+            target.write_text(f"v{i}")
+            _rotate_backups(target, max_backups=3)
+        assert (tmp_path / "graph.json.1").exists()
+        assert (tmp_path / "graph.json.2").exists()
+        assert (tmp_path / "graph.json.3").exists()
+        assert not (tmp_path / "graph.json.4").exists()
+
+    def test_max_backups_zero_disables(self, tmp_path: Path):
+        target = tmp_path / "graph.json"
+        target.write_text("v1")
+        _rotate_backups(target, max_backups=0)
+        assert not (tmp_path / "graph.json.1").exists()
+
+
+class TestJSONExporterBackup:
+    """Integration: JSONExporter creates backups during export."""
+
+    def test_export_creates_backup(self, tmp_path: Path):
+        engine = _build_engine()
+        path = tmp_path / "graph.json"
+        exporter = JSONExporter()
+
+        # First export — no backup (no prior file)
+        exporter.export(engine, path)
+        assert not (tmp_path / "graph.json.1").exists()
+
+        # Second export — backup of first version
+        engine2 = _build_engine(extra_dept="d2")
+        exporter.export(engine2, path)
+        assert (tmp_path / "graph.json.1").exists()
+        backup_data = json.loads((tmp_path / "graph.json.1").read_text())
+        assert len(backup_data["entities"]) == 2  # original had 2
+
+        current_data = json.loads(path.read_text())
+        assert len(current_data["entities"]) == 3  # new has 3
+
+    def test_export_max_backups_zero_skips(self, tmp_path: Path):
+        engine = _build_engine()
+        path = tmp_path / "graph.json"
+        exporter = JSONExporter()
+        exporter.export(engine, path)
+        exporter.export(engine, path, max_backups=0)
+        assert not (tmp_path / "graph.json.1").exists()


### PR DESCRIPTION
## Summary
- Add `_rotate_backups()` to JSONExporter — shifts `graph.json` → `.1` → `.2` → `.3` before each overwrite
- Default 3 backup slots, configurable via `max_backups` kwarg (0 disables)
- 7 new tests covering rotation, capping, and integration with exporter

## Test plan
- [x] `poetry run pytest tests/unit/export/test_backup.py -v` — 7 passed
- [x] `poetry run ruff check src/export/ tests/unit/export/` — clean

Closes #276