### PR TITLE
feat: structured logging with JSON formatter

### DIFF
--- a/src/cli/logging_config.py
+++ b/src/cli/logging_config.py
@@ -1,0 +1,96 @@
+"""Centralised logging configuration for hckg.
+
+Provides ``configure_logging()`` which sets up the root logger with
+either a human-readable text formatter (for CLI use) or a structured
+JSON formatter (for MCP/REST production use).
+
+Environment variables
+---------------------
+HCKG_LOG_LEVEL
+    Logging level name (default ``INFO``).
+HCKG_LOG_FORMAT
+    ``json`` or ``text`` (default ``text``).
+HCKG_LOG_FILE
+    Optional path — if set, logs are *also* written to this file.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from datetime import UTC, datetime
+
+
+class JsonFormatter(logging.Formatter):
+    """Emit each log record as a single JSON line."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        entry = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info and record.exc_info[1] is not None:
+            entry["exception"] = self.formatException(record.exc_info)
+        # Propagate any extra keys the caller attached
+        for key in ("method", "path", "status", "duration_ms", "caller"):
+            value = getattr(record, key, None)
+            if value is not None:
+                entry[key] = value
+        return json.dumps(entry, default=str)
+
+
+_TEXT_FORMAT = "%(asctime)s %(levelname)-8s %(name)s  %(message)s"
+_TEXT_DATEFMT = "%Y-%m-%d %H:%M:%S"
+
+
+def configure_logging(
+    *,
+    level: str | None = None,
+    json_format: bool | None = None,
+    log_file: str | None = None,
+) -> None:
+    """Configure the root logger for hckg.
+
+    Parameters
+    ----------
+    level:
+        Logging level name.  Defaults to ``HCKG_LOG_LEVEL`` env var,
+        then ``INFO``.
+    json_format:
+        If ``True``, use JSON formatter.  Defaults to ``HCKG_LOG_FORMAT``
+        env var (``json`` → True, anything else → False), then ``False``.
+    log_file:
+        Optional file path.  Defaults to ``HCKG_LOG_FILE`` env var.
+    """
+    resolved_level = (level or os.environ.get("HCKG_LOG_LEVEL", "INFO")).upper()
+    if json_format is None:
+        json_format = os.environ.get("HCKG_LOG_FORMAT", "text").lower() == "json"
+    resolved_file = log_file or os.environ.get("HCKG_LOG_FILE")
+
+    root = logging.getLogger()
+    root.setLevel(resolved_level)
+
+    # Remove any existing handlers to avoid duplicates on re-configure
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+
+    # Console handler (stderr)
+    console = logging.StreamHandler(sys.stderr)
+    if json_format:
+        console.setFormatter(JsonFormatter())
+    else:
+        console.setFormatter(logging.Formatter(_TEXT_FORMAT, datefmt=_TEXT_DATEFMT))
+    root.addHandler(console)
+
+    # Optional file handler
+    if resolved_file:
+        file_handler = logging.FileHandler(resolved_file)
+        if json_format:
+            file_handler.setFormatter(JsonFormatter())
+        else:
+            file_handler.setFormatter(logging.Formatter(_TEXT_FORMAT, datefmt=_TEXT_DATEFMT))
+        root.addHandler(file_handler)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -8,9 +8,22 @@ import click
 @click.group()
 @click.version_option(package_name="hc-enterprise-kg")
 @click.option("--backend", default="networkx", help="Graph backend to use.")
+@click.option("--log-level", default=None, help="Logging level (DEBUG, INFO, WARNING, ERROR).")
+@click.option(
+    "--log-format",
+    type=click.Choice(["text", "json"]),
+    default=None,
+    help="Log output format.",
+)
 @click.pass_context
-def cli(ctx: click.Context, backend: str) -> None:
+def cli(ctx: click.Context, backend: str, log_level: str | None, log_format: str | None) -> None:
     """hckg — Enterprise Knowledge Graph CLI"""
+    from cli.logging_config import configure_logging
+
+    configure_logging(
+        level=log_level,
+        json_format=log_format == "json" if log_format else None,
+    )
     ctx.ensure_object(dict)
     ctx.obj["backend"] = backend
 

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -20,6 +20,9 @@ register_tools(mcp)
 
 def main() -> None:
     """Run the MCP server over stdio transport."""
+    from cli.logging_config import configure_logging
+
+    configure_logging(json_format=True)
     auto_load_default_graph()
     mcp.run(transport="stdio")
 

--- a/src/serve/app.py
+++ b/src/serve/app.py
@@ -553,6 +553,38 @@ def create_app(graph_path: str | None = None) -> Any:
 
     app = Flask(__name__)
 
+    # --- Logging ---
+    from cli.logging_config import configure_logging
+
+    configure_logging()
+
+    import logging
+    import time
+
+    _logger = logging.getLogger("hckg.serve")
+
+    @app.before_request
+    def _start_timer() -> None:  # type: ignore[no-untyped-def]
+        flask_request._start_time = time.monotonic()  # type: ignore[attr-defined]
+
+    @app.after_request
+    def _log_request(response):  # type: ignore[no-untyped-def]
+        start = getattr(flask_request, "_start_time", None)
+        duration_ms = round((time.monotonic() - start) * 1000, 1) if start else None
+        _logger.info(
+            "%s %s %s",
+            flask_request.method,
+            flask_request.path,
+            response.status_code,
+            extra={
+                "method": flask_request.method,
+                "path": flask_request.path,
+                "status": response.status_code,
+                "duration_ms": duration_ms,
+            },
+        )
+        return response
+
     if graph_path:
         with app.app_context():
             result = load_graph_from_path(graph_path)

--- a/tests/unit/cli/test_logging_config.py
+++ b/tests/unit/cli/test_logging_config.py
@@ -1,0 +1,149 @@
+"""Tests for centralized logging configuration."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from cli.logging_config import JsonFormatter, configure_logging
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestConfigureLogging:
+    """Tests for configure_logging()."""
+
+    def _reset_root_logger(self) -> None:
+        root = logging.getLogger()
+        for h in root.handlers[:]:
+            root.removeHandler(h)
+        root.setLevel(logging.WARNING)
+
+    def test_sets_root_level(self):
+        self._reset_root_logger()
+        configure_logging(level="DEBUG")
+        assert logging.getLogger().level == logging.DEBUG
+        self._reset_root_logger()
+
+    def test_default_level_is_info(self):
+        self._reset_root_logger()
+        configure_logging()
+        assert logging.getLogger().level == logging.INFO
+        self._reset_root_logger()
+
+    def test_adds_console_handler(self):
+        self._reset_root_logger()
+        configure_logging()
+        root = logging.getLogger()
+        assert len(root.handlers) == 1
+        assert isinstance(root.handlers[0], logging.StreamHandler)
+        self._reset_root_logger()
+
+    def test_json_format_uses_json_formatter(self):
+        self._reset_root_logger()
+        configure_logging(json_format=True)
+        root = logging.getLogger()
+        assert isinstance(root.handlers[0].formatter, JsonFormatter)
+        self._reset_root_logger()
+
+    def test_text_format_uses_standard_formatter(self):
+        self._reset_root_logger()
+        configure_logging(json_format=False)
+        root = logging.getLogger()
+        assert isinstance(root.handlers[0].formatter, logging.Formatter)
+        assert not isinstance(root.handlers[0].formatter, JsonFormatter)
+        self._reset_root_logger()
+
+    def test_file_handler_created(self, tmp_path: Path):
+        self._reset_root_logger()
+        log_file = str(tmp_path / "test.log")
+        configure_logging(log_file=log_file)
+        root = logging.getLogger()
+        assert len(root.handlers) == 2
+        file_handler = root.handlers[1]
+        assert isinstance(file_handler, logging.FileHandler)
+        self._reset_root_logger()
+
+    def test_env_var_level(self, monkeypatch: object):
+        self._reset_root_logger()
+        import os
+
+        monkeypatch.setattr(os, "environ", {**os.environ, "HCKG_LOG_LEVEL": "DEBUG"})  # type: ignore[attr-defined]
+        configure_logging()
+        assert logging.getLogger().level == logging.DEBUG
+        self._reset_root_logger()
+
+    def test_reconfigure_removes_old_handlers(self):
+        self._reset_root_logger()
+        configure_logging()
+        configure_logging()
+        root = logging.getLogger()
+        assert len(root.handlers) == 1
+        self._reset_root_logger()
+
+
+class TestJsonFormatter:
+    """Tests for the JSON log formatter."""
+
+    def test_output_is_valid_json(self):
+        formatter = JsonFormatter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="hello %s",
+            args=("world",),
+            exc_info=None,
+        )
+        output = formatter.format(record)
+        data = json.loads(output)
+        assert data["message"] == "hello world"
+        assert data["level"] == "INFO"
+        assert data["logger"] == "test"
+        assert "timestamp" in data
+
+    def test_includes_extra_fields(self):
+        formatter = JsonFormatter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="req",
+            args=(),
+            exc_info=None,
+        )
+        record.method = "GET"  # type: ignore[attr-defined]
+        record.path = "/health"  # type: ignore[attr-defined]
+        record.status = 200  # type: ignore[attr-defined]
+        record.duration_ms = 12.5  # type: ignore[attr-defined]
+        output = formatter.format(record)
+        data = json.loads(output)
+        assert data["method"] == "GET"
+        assert data["path"] == "/health"
+        assert data["status"] == 200
+        assert data["duration_ms"] == 12.5
+
+    def test_includes_exception(self):
+        formatter = JsonFormatter()
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            import sys
+
+            record = logging.LogRecord(
+                name="test",
+                level=logging.ERROR,
+                pathname="",
+                lineno=0,
+                msg="fail",
+                args=(),
+                exc_info=sys.exc_info(),
+            )
+        output = formatter.format(record)
+        data = json.loads(output)
+        assert "exception" in data
+        assert "ValueError: boom" in data["exception"]


### PR DESCRIPTION
## Summary
- New `configure_logging()` in `src/cli/logging_config.py` with JSON and text formatters
- Integrated into CLI (`--log-level`, `--log-format` flags), MCP server (JSON default), REST API
- REST API request logging middleware: method, path, status, duration_ms
- Env vars: `HCKG_LOG_LEVEL`, `HCKG_LOG_FORMAT`, `HCKG_LOG_FILE`
- 11 new tests

## Test plan
- [x] `poetry run pytest tests/unit/cli/test_logging_config.py -v` — 11 passed
- [x] `poetry run ruff check` + `ruff format --check` — clean

Closes #278