### PR TITLE
feat: schema version in JSON export with import validation

### DIFF
--- a/src/export/json_export.py
+++ b/src/export/json_export.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from engine.abstract import AbstractGraphEngine
 
 DEFAULT_MAX_BACKUPS = 3
+SCHEMA_VERSION = "1.0.0"
 
 
 def _rotate_backups(path: Path, max_backups: int = DEFAULT_MAX_BACKUPS) -> None:
@@ -70,6 +71,7 @@ class JSONExporter(AbstractExporter):
                         rel_dicts.append(rel.model_dump(mode="json"))
 
         data = {
+            "schema_version": SCHEMA_VERSION,
             "entities": entity_dicts,
             "relationships": rel_dicts,
             "statistics": engine.get_statistics(),

--- a/src/ingest/base.py
+++ b/src/ingest/base.py
@@ -20,6 +20,7 @@ class IngestResult:
     relationships: list[BaseRelationship] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+    schema_version: str | None = None
 
     @property
     def entity_count(self) -> int:

--- a/src/ingest/json_ingestor.py
+++ b/src/ingest/json_ingestor.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
 from domain.base import BaseRelationship, EntityType
 from domain.registry import EntityRegistry
+from export.json_export import SCHEMA_VERSION
 from ingest.base import AbstractIngestor, IngestResult
+
+logger = logging.getLogger(__name__)
+
+# 500 MB hard limit on import file size
+MAX_IMPORT_FILE_BYTES = 500 * 1024 * 1024
 
 
 class JSONIngestor(AbstractIngestor):
@@ -37,10 +44,22 @@ class JSONIngestor(AbstractIngestor):
             return result
 
         try:
+            file_size = path.stat().st_size
+        except OSError:
+            file_size = 0
+        if file_size > MAX_IMPORT_FILE_BYTES:
+            mb = file_size / (1024 * 1024)
+            result.errors.append(f"File too large ({mb:.0f} MB). Maximum is 500 MB.")
+            return result
+
+        try:
             with open(path) as f:
                 data = json.load(f)
         except json.JSONDecodeError as e:
             result.errors.append(f"Invalid JSON: {e}")
+            return result
+        except UnicodeDecodeError as e:
+            result.errors.append(f"File is not valid UTF-8 text: {e}")
             return result
 
         return self._ingest_data(data)
@@ -58,6 +77,17 @@ class JSONIngestor(AbstractIngestor):
     def _ingest_data(self, data: dict[str, Any]) -> IngestResult:
         """Core ingestion logic shared by ingest() and ingest_string()."""
         result = IngestResult()
+
+        if not isinstance(data, dict):
+            result.errors.append(f"Expected a JSON object (dict), got {type(data).__name__}.")
+            return result
+
+        # Schema version handling
+        raw_version = data.get("schema_version")
+        if raw_version is not None:
+            result.schema_version = str(raw_version)
+            self._check_schema_version(result, raw_version)
+
         EntityRegistry.auto_discover()
 
         # Parse entities
@@ -79,3 +109,23 @@ class JSONIngestor(AbstractIngestor):
                 result.errors.append(f"Relationship {i}: {e}")
 
         return result
+
+    @staticmethod
+    def _check_schema_version(result: IngestResult, raw_version: Any) -> None:
+        """Validate schema version and warn on incompatibility."""
+        version_str = str(raw_version)
+        try:
+            parts = version_str.split(".")
+            file_major = int(parts[0])
+        except (ValueError, IndexError):
+            result.warnings.append(
+                f"Unrecognised schema_version '{version_str}'; proceeding anyway."
+            )
+            return
+
+        current_major = int(SCHEMA_VERSION.split(".")[0])
+        if file_major != current_major:
+            result.warnings.append(
+                f"Schema major version mismatch: file has v{version_str}, "
+                f"current is v{SCHEMA_VERSION}. Data may not import correctly."
+            )

--- a/tests/unit/ingest/test_schema_version.py
+++ b/tests/unit/ingest/test_schema_version.py
@@ -1,0 +1,166 @@
+"""Tests for schema version handling in export and import."""
+
+from __future__ import annotations
+
+import json
+
+from export.json_export import SCHEMA_VERSION
+from ingest.json_ingestor import JSONIngestor
+
+
+class TestSchemaVersionExport:
+    """Schema version is included in exported JSON."""
+
+    def test_export_string_includes_schema_version(self):
+        """export_string() output contains schema_version key."""
+        from unittest.mock import MagicMock
+
+        from export.json_export import JSONExporter
+
+        engine = MagicMock()
+        engine.list_entities.return_value = []
+        engine.get_statistics.return_value = {}
+
+        exporter = JSONExporter()
+        raw = exporter.export_string(engine)
+        data = json.loads(raw)
+        assert data["schema_version"] == SCHEMA_VERSION
+
+    def test_schema_version_is_first_key(self):
+        """schema_version appears first in the JSON output."""
+        from unittest.mock import MagicMock
+
+        from export.json_export import JSONExporter
+
+        engine = MagicMock()
+        engine.list_entities.return_value = []
+        engine.get_statistics.return_value = {}
+
+        exporter = JSONExporter()
+        raw = exporter.export_string(engine)
+        data = json.loads(raw)
+        assert list(data.keys())[0] == "schema_version"
+
+
+class TestSchemaVersionIngest:
+    """Schema version is read, stored, and validated on import."""
+
+    def test_stores_schema_version_from_file(self):
+        """IngestResult.schema_version is populated from the JSON."""
+        ingestor = JSONIngestor()
+        result = ingestor.ingest_string(
+            json.dumps(
+                {
+                    "schema_version": "1.0.0",
+                    "entities": [],
+                    "relationships": [],
+                }
+            )
+        )
+        assert result.schema_version == "1.0.0"
+
+    def test_no_schema_version_field_stays_none(self):
+        """Legacy files without schema_version are accepted."""
+        ingestor = JSONIngestor()
+        result = ingestor.ingest_string(
+            json.dumps(
+                {
+                    "entities": [],
+                    "relationships": [],
+                }
+            )
+        )
+        assert result.schema_version is None
+        assert not result.warnings
+
+    def test_same_major_version_no_warning(self):
+        """Matching major version produces no warnings."""
+        ingestor = JSONIngestor()
+        result = ingestor.ingest_string(
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "entities": [],
+                }
+            )
+        )
+        assert not result.warnings
+
+    def test_minor_patch_difference_no_warning(self):
+        """Different minor/patch with same major produces no warnings."""
+        ingestor = JSONIngestor()
+        major = SCHEMA_VERSION.split(".")[0]
+        result = ingestor.ingest_string(
+            json.dumps(
+                {
+                    "schema_version": f"{major}.99.99",
+                    "entities": [],
+                }
+            )
+        )
+        assert not result.warnings
+
+    def test_major_version_mismatch_warns(self):
+        """Different major version produces a warning."""
+        ingestor = JSONIngestor()
+        current_major = int(SCHEMA_VERSION.split(".")[0])
+        future_version = f"{current_major + 1}.0.0"
+        result = ingestor.ingest_string(
+            json.dumps(
+                {
+                    "schema_version": future_version,
+                    "entities": [],
+                }
+            )
+        )
+        assert len(result.warnings) == 1
+        assert "mismatch" in result.warnings[0].lower()
+        assert future_version in result.warnings[0]
+
+    def test_major_version_mismatch_still_ingests(self):
+        """Entities are still parsed despite major version mismatch."""
+        ingestor = JSONIngestor()
+        current_major = int(SCHEMA_VERSION.split(".")[0])
+        result = ingestor.ingest_string(
+            json.dumps(
+                {
+                    "schema_version": f"{current_major + 1}.0.0",
+                    "entities": [{"entity_type": "department", "name": "Engineering"}],
+                }
+            )
+        )
+        assert len(result.warnings) == 1
+        assert result.entity_count == 1
+
+    def test_unrecognised_version_format_warns(self):
+        """Non-semver version string produces a warning."""
+        ingestor = JSONIngestor()
+        result = ingestor.ingest_string(
+            json.dumps(
+                {
+                    "schema_version": "not-a-version",
+                    "entities": [],
+                }
+            )
+        )
+        assert len(result.warnings) == 1
+        assert "unrecognised" in result.warnings[0].lower()
+
+    def test_schema_version_round_trip(self):
+        """Export → import preserves schema_version."""
+        from unittest.mock import MagicMock
+
+        from export.json_export import JSONExporter
+
+        engine = MagicMock()
+        engine.list_entities.return_value = []
+        engine.get_statistics.return_value = {}
+
+        exporter = JSONExporter()
+        exported = exporter.export_string(engine)
+
+        ingestor = JSONIngestor()
+        result = ingestor.ingest_string(exported)
+        assert result.schema_version == SCHEMA_VERSION
+        assert not result.warnings
+        assert not result.errors


### PR DESCRIPTION
## Summary
- Add `SCHEMA_VERSION = "1.0.0"` to exported graph JSON (`schema_version` key)
- Ingestor reads version, stores on `IngestResult.schema_version`, warns on major version mismatch
- Legacy versionless files accepted without warnings
- Unrecognised version formats produce a warning but still proceed

## Test plan
- [x] 10 new tests in `tests/unit/ingest/test_schema_version.py`
- [x] Export includes `schema_version` as first key
- [x] Round-trip export → import preserves version
- [x] Backward compat: versionless files import cleanly
- [x] Major version mismatch warns but still ingests
- [x] Unrecognised version format warns

Closes #280