### PR TITLE
feat: persistent JSONL audit log

### DIFF
--- a/src/graph/audit.py
+++ b/src/graph/audit.py
@@ -1,0 +1,76 @@
+"""Persistent JSONL audit logger for knowledge graph mutations."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from export.file_lock import GraphFileLock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from domain.temporal import GraphEvent
+
+logger = logging.getLogger(__name__)
+
+
+def derive_audit_path(graph_path: Path) -> Path:
+    """Derive audit log path from graph file path.
+
+    ``graph.json`` → ``graph.audit.jsonl``
+    """
+    return graph_path.with_suffix(".audit.jsonl")
+
+
+class AuditLogger:
+    """Appends GraphEvent records as JSONL to an audit log file.
+
+    Each event is serialized as a single JSON line and appended
+    atomically with an exclusive file lock.
+
+    Usage::
+
+        audit = AuditLogger(Path("graph.audit.jsonl"))
+        kg.subscribe(audit)
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def __call__(self, event: GraphEvent) -> None:
+        """Write a single event to the audit log (EventBus handler)."""
+        line = event.model_dump_json() + "\n"
+        try:
+            with GraphFileLock(self._path, exclusive=True, timeout=5.0), open(self._path, "a") as f:
+                f.write(line)
+        except Exception:
+            logger.exception("Failed to write audit event %s", event.id)
+
+    def read_events(self) -> list[dict]:
+        """Read all events from the audit log (for diagnostics)."""
+        if not self._path.exists():
+            return []
+        events = []
+        with GraphFileLock(self._path, exclusive=False, timeout=5.0), open(self._path) as f:
+            for line in f:
+                stripped = line.strip()
+                if stripped:
+                    events.append(json.loads(stripped))
+        return events
+
+    def event_count(self) -> int:
+        """Return the number of events in the audit log."""
+        if not self._path.exists():
+            return 0
+        count = 0
+        with open(self._path) as f:
+            for line in f:
+                if line.strip():
+                    count += 1
+        return count

--- a/src/mcp_server/state.py
+++ b/src/mcp_server/state.py
@@ -11,6 +11,7 @@ import os
 from pathlib import Path
 
 from export.file_lock import GraphFileLock
+from graph.audit import AuditLogger, derive_audit_path
 from graph.knowledge_graph import KnowledgeGraph
 from ingest.json_ingestor import JSONIngestor
 
@@ -45,6 +46,11 @@ def load_graph(path: str) -> dict:
         kg.add_entities_bulk(result.entities)
     if result.relationships:
         kg.add_relationships_bulk(result.relationships)
+
+    # Subscribe audit logger before assigning to module state
+    audit_path = derive_audit_path(Path(path).resolve())
+    audit_logger = AuditLogger(audit_path)
+    kg.subscribe(audit_logger)
 
     _kg = kg
     resolved = str(Path(path).resolve())

--- a/tests/unit/graph/test_audit.py
+++ b/tests/unit/graph/test_audit.py
@@ -1,0 +1,148 @@
+"""Tests for persistent JSONL audit logger."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from domain.temporal import GraphEvent, MutationType
+from graph.audit import AuditLogger, derive_audit_path
+
+
+class TestDeriveAuditPath:
+    """Tests for derive_audit_path()."""
+
+    def test_json_extension(self):
+        assert derive_audit_path(Path("/tmp/graph.json")) == Path("/tmp/graph.audit.jsonl")
+
+    def test_no_extension(self):
+        assert derive_audit_path(Path("/tmp/graph")) == Path("/tmp/graph.audit.jsonl")
+
+    def test_nested_path(self):
+        result = derive_audit_path(Path("/home/user/data/kg.json"))
+        assert result == Path("/home/user/data/kg.audit.jsonl")
+
+
+class TestAuditLogger:
+    """Tests for AuditLogger event persistence."""
+
+    def _make_event(self, **kwargs) -> GraphEvent:
+        defaults = {
+            "mutation_type": MutationType.CREATE,
+            "entity_type": "person",
+            "entity_id": "test-123",
+            "source": "test",
+        }
+        defaults.update(kwargs)
+        return GraphEvent(**defaults)
+
+    def test_creates_file_on_first_event(self, tmp_path: Path):
+        audit_path = tmp_path / "graph.audit.jsonl"
+        audit = AuditLogger(audit_path)
+        audit(self._make_event())
+        assert audit_path.exists()
+
+    def test_writes_valid_jsonl(self, tmp_path: Path):
+        audit_path = tmp_path / "graph.audit.jsonl"
+        audit = AuditLogger(audit_path)
+        audit(self._make_event())
+
+        lines = audit_path.read_text().strip().split("\n")
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["mutation_type"] == "create"
+        assert data["entity_type"] == "person"
+        assert data["entity_id"] == "test-123"
+
+    def test_appends_multiple_events(self, tmp_path: Path):
+        audit_path = tmp_path / "graph.audit.jsonl"
+        audit = AuditLogger(audit_path)
+        audit(self._make_event(entity_id="a"))
+        audit(self._make_event(entity_id="b"))
+        audit(self._make_event(entity_id="c"))
+
+        lines = audit_path.read_text().strip().split("\n")
+        assert len(lines) == 3
+        ids = [json.loads(line)["entity_id"] for line in lines]
+        assert ids == ["a", "b", "c"]
+
+    def test_read_events_returns_dicts(self, tmp_path: Path):
+        audit_path = tmp_path / "graph.audit.jsonl"
+        audit = AuditLogger(audit_path)
+        audit(self._make_event(entity_id="x"))
+        audit(self._make_event(entity_id="y"))
+
+        events = audit.read_events()
+        assert len(events) == 2
+        assert events[0]["entity_id"] == "x"
+        assert events[1]["entity_id"] == "y"
+
+    def test_read_events_empty_file(self, tmp_path: Path):
+        audit_path = tmp_path / "graph.audit.jsonl"
+        audit = AuditLogger(audit_path)
+        assert audit.read_events() == []
+
+    def test_event_count(self, tmp_path: Path):
+        audit_path = tmp_path / "graph.audit.jsonl"
+        audit = AuditLogger(audit_path)
+        assert audit.event_count() == 0
+
+        audit(self._make_event())
+        assert audit.event_count() == 1
+
+        audit(self._make_event())
+        audit(self._make_event())
+        assert audit.event_count() == 3
+
+    def test_captures_all_mutation_types(self, tmp_path: Path):
+        audit_path = tmp_path / "graph.audit.jsonl"
+        audit = AuditLogger(audit_path)
+
+        for mt in MutationType:
+            audit(self._make_event(mutation_type=mt))
+
+        events = audit.read_events()
+        assert len(events) == len(MutationType)
+        types = {e["mutation_type"] for e in events}
+        assert types == {mt.value for mt in MutationType}
+
+    def test_captures_before_after_snapshots(self, tmp_path: Path):
+        audit_path = tmp_path / "graph.audit.jsonl"
+        audit = AuditLogger(audit_path)
+        event = self._make_event(
+            mutation_type=MutationType.UPDATE,
+            before_snapshot={"name": "old"},
+            after_snapshot={"name": "new"},
+        )
+        audit(event)
+
+        events = audit.read_events()
+        assert events[0]["before_snapshot"] == {"name": "old"}
+        assert events[0]["after_snapshot"] == {"name": "new"}
+
+    def test_path_property(self, tmp_path: Path):
+        audit_path = tmp_path / "graph.audit.jsonl"
+        audit = AuditLogger(audit_path)
+        assert audit.path == audit_path
+
+
+class TestAuditLoggerWithKnowledgeGraph:
+    """Integration: AuditLogger subscribed to KnowledgeGraph EventBus."""
+
+    def test_kg_subscribe_records_events(self, tmp_path: Path):
+        from domain.entities.department import Department
+        from graph.knowledge_graph import KnowledgeGraph
+
+        audit_path = tmp_path / "graph.audit.jsonl"
+        audit = AuditLogger(audit_path)
+
+        kg = KnowledgeGraph()
+        kg.subscribe(audit)
+
+        dept = Department(name="Engineering")
+        kg.add_entity(dept)
+
+        events = audit.read_events()
+        assert len(events) == 1
+        assert events[0]["mutation_type"] == "create"
+        assert events[0]["entity_id"] == dept.id


### PR DESCRIPTION
## Summary
- Create `AuditLogger` class in `src/graph/audit.py` — subscribes to EventBus, appends JSONL
- Audit log path derived from graph path (`graph.json` → `graph.audit.jsonl`)
- Auto-subscribed when MCP server loads a graph
- Uses `GraphFileLock` for safe concurrent writes
- `read_events()` and `event_count()` for diagnostics

## Test plan
- [x] 13 new tests in `tests/unit/graph/test_audit.py`
- [x] Path derivation (3 tests)
- [x] Event persistence: create, append, read, count (7 tests)
- [x] All 5 mutation types captured
- [x] Before/after snapshots preserved
- [x] Integration with KnowledgeGraph EventBus

Closes #282