### PR TITLE
feat: enhanced /health endpoint

### DIFF
--- a/src/serve/app.py
+++ b/src/serve/app.py
@@ -559,7 +559,10 @@ def create_app(graph_path: str | None = None) -> Any:
     configure_logging()
 
     import logging
+    import os
     import time
+
+    _app_start_time = time.monotonic()
 
     _logger = logging.getLogger("hckg.serve")
 
@@ -620,16 +623,43 @@ def create_app(graph_path: str | None = None) -> Any:
 
     @app.route("/health", methods=["GET"])
     def health():  # type: ignore[no-untyped-def]
+        from importlib.metadata import PackageNotFoundError
+        from importlib.metadata import version as pkg_version
+
+        try:
+            __version__ = pkg_version("hc-enterprise-kg")
+        except PackageNotFoundError:
+            __version__ = "0.0.0"
+
         has_graph = _kg is not None
         stats = _kg.statistics if _kg else {}
-        return _json_response(
-            {
-                "status": "ok",
-                "graph_loaded": has_graph,
-                "entity_count": stats.get("entity_count", 0),
-                "relationship_count": stats.get("relationship_count", 0),
-            }
-        )
+        uptime_s = round(time.monotonic() - _app_start_time, 1)
+
+        response: dict[str, Any] = {
+            "status": "ok",
+            "version": __version__,
+            "uptime_seconds": uptime_s,
+            "graph_loaded": has_graph,
+            "entity_count": stats.get("entity_count", 0),
+            "relationship_count": stats.get("relationship_count", 0),
+        }
+
+        if has_graph:
+            response["entity_types"] = stats.get("entity_types", {})
+            response["relationship_types"] = stats.get("relationship_types", {})
+
+            # Graph file metadata
+            graph_path = os.environ.get("HCKG_DEFAULT_GRAPH")
+            if graph_path and Path(graph_path).exists():
+                p = Path(graph_path)
+                stat = p.stat()
+                response["graph_file"] = {
+                    "path": str(p),
+                    "size_bytes": stat.st_size,
+                    "modified": stat.st_mtime,
+                }
+
+        return _json_response(response)
 
     @app.route("/statistics", methods=["GET"])
     def statistics():  # type: ignore[no-untyped-def]

--- a/tests/unit/serve/test_health.py
+++ b/tests/unit/serve/test_health.py
@@ -1,0 +1,93 @@
+"""Tests for enhanced /health endpoint."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+flask = pytest.importorskip("flask", reason="flask not installed")
+
+import serve.app as serve_module  # noqa: E402
+from export.json_export import JSONExporter  # noqa: E402
+from serve.app import create_app  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_serve_state():
+    serve_module._kg = None
+    yield
+    serve_module._kg = None
+
+
+@pytest.fixture()
+def graph_file(populated_kg):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "test_graph.json"
+        JSONExporter().export(populated_kg.engine, path)
+        yield str(path)
+
+
+@pytest.fixture()
+def client(graph_file):
+    app = create_app(graph_path=graph_file)
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+class TestEnhancedHealth:
+    def test_returns_version(self, client):
+        resp = client.get("/health")
+        data = json.loads(resp.data)
+        assert "version" in data
+        assert isinstance(data["version"], str)
+
+    def test_returns_uptime(self, client):
+        resp = client.get("/health")
+        data = json.loads(resp.data)
+        assert "uptime_seconds" in data
+        assert data["uptime_seconds"] >= 0
+
+    def test_returns_entity_types_when_loaded(self, client):
+        resp = client.get("/health")
+        data = json.loads(resp.data)
+        assert data["graph_loaded"] is True
+        assert "entity_types" in data
+        assert isinstance(data["entity_types"], dict)
+
+    def test_returns_relationship_types_when_loaded(self, client):
+        resp = client.get("/health")
+        data = json.loads(resp.data)
+        assert "relationship_types" in data
+        assert isinstance(data["relationship_types"], dict)
+
+    def test_no_type_breakdowns_without_graph(self):
+        app = create_app()
+        app.config["TESTING"] = True
+        with app.test_client() as c:
+            resp = c.get("/health")
+            data = json.loads(resp.data)
+            assert data["graph_loaded"] is False
+            assert "entity_types" not in data
+            assert "relationship_types" not in data
+            assert data["entity_count"] == 0
+
+    def test_graph_file_metadata(self, graph_file, monkeypatch):
+        monkeypatch.setenv("HCKG_DEFAULT_GRAPH", graph_file)
+        app = create_app(graph_path=graph_file)
+        app.config["TESTING"] = True
+        with app.test_client() as c:
+            resp = c.get("/health")
+            data = json.loads(resp.data)
+            assert "graph_file" in data
+            assert data["graph_file"]["path"] == graph_file
+            assert data["graph_file"]["size_bytes"] > 0
+            assert "modified" in data["graph_file"]
+
+    def test_no_graph_file_without_env_var(self, client):
+        resp = client.get("/health")
+        data = json.loads(resp.data)
+        assert "graph_file" not in data


### PR DESCRIPTION
## Summary
- Add version, uptime_seconds, entity/relationship type breakdowns to `/health`
- Include graph file metadata (path, size, modified) when `HCKG_DEFAULT_GRAPH` is set
- Type breakdowns only shown when a graph is loaded

## Test plan
- [x] 7 new tests in `tests/unit/serve/test_health.py`
- [x] Existing health tests still pass

Closes #284