### PR TITLE
feat: bearer token authentication for REST API

### DIFF
--- a/src/cli/serve_cmd.py
+++ b/src/cli/serve_cmd.py
@@ -23,12 +23,19 @@ import click
     default=False,
     help="Enable auto-reload for development.",
 )
+@click.option(
+    "--api-key",
+    default=None,
+    envvar="HCKG_API_KEY",
+    help="API key for bearer-token auth. Also reads HCKG_API_KEY env var.",
+)
 def serve_cmd(
     source: str,
     host: str,
     port: int,
     use_stdio: bool,
     use_reload: bool,
+    api_key: str | None,
 ) -> None:
     """Start the knowledge graph server.
 
@@ -56,7 +63,7 @@ def serve_cmd(
     if use_stdio:
         _run_stdio(source)
     else:
-        _run_rest(source, host, port, use_reload)
+        _run_rest(source, host, port, use_reload, api_key)
 
 
 def _run_stdio(source: str) -> None:
@@ -81,7 +88,9 @@ def _run_stdio(source: str) -> None:
     mcp.run(transport="stdio")
 
 
-def _run_rest(source: str, host: str, port: int, use_reload: bool) -> None:
+def _run_rest(
+    source: str, host: str, port: int, use_reload: bool, api_key: str | None = None
+) -> None:
     """Start the REST API server."""
     try:
         from serve.app import create_app
@@ -95,7 +104,7 @@ def _run_rest(source: str, host: str, port: int, use_reload: bool) -> None:
         raise SystemExit(1) from None
 
     click.echo(f"Loading graph from {source}...")
-    app = create_app(graph_path=source)
+    app = create_app(graph_path=source, api_key=api_key)
 
     click.echo(
         f"\n"

--- a/src/serve/app.py
+++ b/src/serve/app.py
@@ -532,11 +532,13 @@ OPENAI_TOOLS: list[dict] = [
 # ---------------------------------------------------------------------------
 
 
-def create_app(graph_path: str | None = None) -> Any:
+def create_app(graph_path: str | None = None, api_key: str | None = None) -> Any:
     """Create and configure the Flask application.
 
     Args:
         graph_path: Optional path to a JSON graph file to load on startup.
+        api_key: Optional API key for bearer-token auth.  Falls back to
+            ``HCKG_API_KEY`` env var.  If neither is set, auth is disabled.
 
     Returns:
         A Flask app instance.
@@ -552,6 +554,11 @@ def create_app(graph_path: str | None = None) -> Any:
         ) from exc
 
     app = Flask(__name__)
+
+    # --- Authentication ---
+    from serve.auth import init_auth
+
+    init_auth(app, api_key=api_key)
 
     # --- Logging ---
     from cli.logging_config import configure_logging

--- a/src/serve/auth.py
+++ b/src/serve/auth.py
@@ -1,0 +1,73 @@
+"""Bearer token authentication for the hckg REST API.
+
+If ``HCKG_API_KEY`` is set (env var or passed to ``create_app``), all
+routes except ``/`` and ``/health`` require a valid ``Authorization:
+Bearer <token>`` header.  If unset, the API runs open (backward
+compatible).
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from flask import Flask
+
+logger = logging.getLogger(__name__)
+
+# Routes that are always accessible without authentication
+EXEMPT_PATHS = frozenset({"/", "/health"})
+
+
+def init_auth(app: Flask, api_key: str | None = None) -> None:
+    """Register a ``before_request`` hook that enforces bearer-token auth.
+
+    Parameters
+    ----------
+    app:
+        The Flask application instance.
+    api_key:
+        The expected API key.  Falls back to the ``HCKG_API_KEY``
+        environment variable.  If neither is set, authentication is
+        disabled and all requests are allowed through.
+    """
+    resolved_key = api_key or os.environ.get("HCKG_API_KEY")
+
+    if not resolved_key:
+        logger.info("HCKG_API_KEY not set — API authentication disabled")
+        return
+
+    logger.info("API authentication enabled")
+
+    @app.before_request
+    def _check_auth() -> object | None:
+        from flask import request as flask_request
+
+        if flask_request.path in EXEMPT_PATHS:
+            return None
+
+        auth_header = flask_request.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            from flask import Response
+
+            return Response(
+                '{"error": "Missing or invalid Authorization header. '
+                'Use: Authorization: Bearer <token>"}',
+                status=401,
+                content_type="application/json",
+            )
+
+        token = auth_header[7:]  # Strip "Bearer " prefix
+        if not hmac.compare_digest(token, resolved_key):
+            from flask import Response
+
+            return Response(
+                '{"error": "Invalid API key"}',
+                status=403,
+                content_type="application/json",
+            )
+
+        return None

--- a/tests/unit/serve/test_auth.py
+++ b/tests/unit/serve/test_auth.py
@@ -1,0 +1,132 @@
+"""Tests for REST API bearer-token authentication."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+flask = pytest.importorskip("flask", reason="flask not installed")
+
+import serve.app as serve_module  # noqa: E402
+from export.json_export import JSONExporter  # noqa: E402
+from serve.app import create_app  # noqa: E402
+
+TEST_API_KEY = "test-secret-key-12345"
+
+
+@pytest.fixture(autouse=True)
+def _reset_serve_state():
+    serve_module._kg = None
+    yield
+    serve_module._kg = None
+
+
+@pytest.fixture()
+def graph_file(populated_kg):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "test_graph.json"
+        JSONExporter().export(populated_kg.engine, path)
+        yield str(path)
+
+
+@pytest.fixture()
+def authed_client(graph_file):
+    """Client with API key authentication enabled."""
+    app = create_app(graph_path=graph_file, api_key=TEST_API_KEY)
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture()
+def open_client(graph_file):
+    """Client without API key (open access)."""
+    app = create_app(graph_path=graph_file)
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+class TestAuthEnabled:
+    """When HCKG_API_KEY is set, protected routes require a valid token."""
+
+    def test_health_exempt(self, authed_client):
+        resp = authed_client.get("/health")
+        assert resp.status_code == 200
+
+    def test_index_exempt(self, authed_client):
+        resp = authed_client.get("/")
+        assert resp.status_code == 200
+
+    def test_statistics_requires_auth(self, authed_client):
+        resp = authed_client.get("/statistics")
+        assert resp.status_code == 401
+        data = json.loads(resp.data)
+        assert "error" in data
+
+    def test_valid_token_passes(self, authed_client):
+        resp = authed_client.get(
+            "/statistics",
+            headers={"Authorization": f"Bearer {TEST_API_KEY}"},
+        )
+        assert resp.status_code == 200
+
+    def test_invalid_token_rejected(self, authed_client):
+        resp = authed_client.get(
+            "/statistics",
+            headers={"Authorization": "Bearer wrong-key"},
+        )
+        assert resp.status_code == 403
+        data = json.loads(resp.data)
+        assert "error" in data
+
+    def test_missing_bearer_prefix(self, authed_client):
+        resp = authed_client.get(
+            "/statistics",
+            headers={"Authorization": TEST_API_KEY},
+        )
+        assert resp.status_code == 401
+
+    def test_entities_requires_auth(self, authed_client):
+        resp = authed_client.get("/entities")
+        assert resp.status_code == 401
+
+    def test_entities_with_auth(self, authed_client):
+        resp = authed_client.get(
+            "/entities",
+            headers={"Authorization": f"Bearer {TEST_API_KEY}"},
+        )
+        assert resp.status_code == 200
+
+
+class TestAuthDisabled:
+    """When no API key is configured, all routes are open."""
+
+    def test_statistics_open(self, open_client):
+        resp = open_client.get("/statistics")
+        assert resp.status_code == 200
+
+    def test_entities_open(self, open_client):
+        resp = open_client.get("/entities")
+        assert resp.status_code == 200
+
+
+class TestAuthViaEnvVar:
+    """API key can be set via HCKG_API_KEY environment variable."""
+
+    def test_env_var_enables_auth(self, graph_file, monkeypatch):
+        monkeypatch.setenv("HCKG_API_KEY", "env-key-xyz")
+        app = create_app(graph_path=graph_file)
+        app.config["TESTING"] = True
+        with app.test_client() as c:
+            resp = c.get("/statistics")
+            assert resp.status_code == 401
+
+            resp = c.get(
+                "/statistics",
+                headers={"Authorization": "Bearer env-key-xyz"},
+            )
+            assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Add `src/serve/auth.py` — bearer-token auth via `HCKG_API_KEY` env var or `--api-key` CLI flag
- `/` and `/health` always exempt (no auth required)
- Uses `hmac.compare_digest` for timing-safe comparison
- Backward compatible — runs open if no key configured
- `create_app()` accepts `api_key` parameter

## Test plan
- [x] 11 new tests in `tests/unit/serve/test_auth.py`
- [x] Exempt routes pass without auth
- [x] Protected routes return 401 without auth, 403 with wrong key, 200 with correct key
- [x] Auth disabled when no key set
- [x] Env var activation

Closes #286