### PR TITLE
feat: in-memory rate limiting for REST API

### DIFF
--- a/src/serve/app.py
+++ b/src/serve/app.py
@@ -560,6 +560,11 @@ def create_app(graph_path: str | None = None, api_key: str | None = None) -> Any
 
     init_auth(app, api_key=api_key)
 
+    # --- Rate limiting ---
+    from serve.rate_limit import init_rate_limit
+
+    init_rate_limit(app)
+
     # --- Logging ---
     from cli.logging_config import configure_logging
 

--- a/src/serve/rate_limit.py
+++ b/src/serve/rate_limit.py
@@ -1,0 +1,113 @@
+"""In-memory token-bucket rate limiter for the hckg REST API.
+
+Configuration via environment variables:
+    HCKG_RATE_LIMIT  — requests per second (default 10, 0 = disabled)
+    HCKG_RATE_BURST  — max burst size (default 20)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from flask import Flask
+
+logger = logging.getLogger(__name__)
+
+
+class TokenBucket:
+    """Token bucket for rate limiting a single client."""
+
+    __slots__ = ("_rate", "_burst", "_tokens", "_last_refill")
+
+    def __init__(self, rate: float, burst: int) -> None:
+        self._rate = rate
+        self._burst = burst
+        self._tokens = float(burst)
+        self._last_refill = time.monotonic()
+
+    def consume(self) -> bool:
+        """Try to consume one token.  Returns True if allowed."""
+        now = time.monotonic()
+        elapsed = now - self._last_refill
+        self._tokens = min(self._burst, self._tokens + elapsed * self._rate)
+        self._last_refill = now
+
+        if self._tokens >= 1.0:
+            self._tokens -= 1.0
+            return True
+        return False
+
+    @property
+    def retry_after(self) -> float:
+        """Seconds until the next token is available."""
+        if self._tokens >= 1.0:
+            return 0.0
+        return (1.0 - self._tokens) / self._rate
+
+
+class RateLimiter:
+    """Per-IP rate limiter using token buckets."""
+
+    def __init__(self, rate: float, burst: int) -> None:
+        self._rate = rate
+        self._burst = burst
+        self._buckets: dict[str, TokenBucket] = {}
+
+    def allow(self, client_ip: str) -> tuple[bool, float]:
+        """Check if a request from *client_ip* is allowed.
+
+        Returns ``(allowed, retry_after_seconds)``.
+        """
+        if client_ip not in self._buckets:
+            self._buckets[client_ip] = TokenBucket(self._rate, self._burst)
+        bucket = self._buckets[client_ip]
+        allowed = bucket.consume()
+        return allowed, bucket.retry_after
+
+
+def init_rate_limit(app: Flask, rate: float | None = None, burst: int | None = None) -> None:
+    """Register a ``before_request`` hook that enforces per-IP rate limiting.
+
+    Parameters
+    ----------
+    app:
+        Flask application instance.
+    rate:
+        Requests per second.  Falls back to ``HCKG_RATE_LIMIT`` env var,
+        then 10.  Set to 0 to disable.
+    burst:
+        Maximum burst size.  Falls back to ``HCKG_RATE_BURST`` env var,
+        then 20.
+    """
+    if rate is None:
+        rate = float(os.environ.get("HCKG_RATE_LIMIT", "10"))
+    if burst is None:
+        burst = int(os.environ.get("HCKG_RATE_BURST", "20"))
+
+    if rate <= 0:
+        logger.info("Rate limiting disabled (HCKG_RATE_LIMIT=0)")
+        return
+
+    logger.info("Rate limiting enabled: %.1f req/s, burst %d", rate, burst)
+    limiter = RateLimiter(rate, burst)
+
+    @app.before_request
+    def _check_rate_limit() -> object | None:
+        from flask import Response
+        from flask import request as flask_request
+
+        client_ip = flask_request.remote_addr or "unknown"
+        allowed, retry_after = limiter.allow(client_ip)
+
+        if not allowed:
+            return Response(
+                '{"error": "Rate limit exceeded"}',
+                status=429,
+                content_type="application/json",
+                headers={"Retry-After": str(int(retry_after) + 1)},
+            )
+        return None

--- a/tests/unit/serve/test_rate_limit.py
+++ b/tests/unit/serve/test_rate_limit.py
@@ -1,0 +1,107 @@
+"""Tests for in-memory rate limiting."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+flask = pytest.importorskip("flask", reason="flask not installed")
+
+import serve.app as serve_module  # noqa: E402
+from export.json_export import JSONExporter  # noqa: E402
+from serve.app import create_app  # noqa: E402
+from serve.rate_limit import RateLimiter, TokenBucket  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_serve_state():
+    serve_module._kg = None
+    yield
+    serve_module._kg = None
+
+
+@pytest.fixture()
+def graph_file(populated_kg):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "test_graph.json"
+        JSONExporter().export(populated_kg.engine, path)
+        yield str(path)
+
+
+class TestTokenBucket:
+    def test_allows_burst(self):
+        bucket = TokenBucket(rate=1.0, burst=3)
+        assert bucket.consume() is True
+        assert bucket.consume() is True
+        assert bucket.consume() is True
+
+    def test_rejects_after_burst(self):
+        bucket = TokenBucket(rate=1.0, burst=2)
+        bucket.consume()
+        bucket.consume()
+        assert bucket.consume() is False
+
+    def test_retry_after_positive(self):
+        bucket = TokenBucket(rate=1.0, burst=1)
+        bucket.consume()
+        bucket.consume()  # exhausted
+        assert bucket.retry_after > 0
+
+    def test_refills_over_time(self, monkeypatch):
+        import time
+
+        bucket = TokenBucket(rate=10.0, burst=1)
+        bucket.consume()  # exhaust
+        assert bucket.consume() is False
+
+        # Simulate time passing
+        original_monotonic = time.monotonic
+        offset = 0.2  # 200ms at 10/s = 2 tokens refilled
+        monkeypatch.setattr(time, "monotonic", lambda: original_monotonic() + offset)
+
+        assert bucket.consume() is True
+
+
+class TestRateLimiter:
+    def test_per_ip_isolation(self):
+        limiter = RateLimiter(rate=1.0, burst=1)
+        allowed_a, _ = limiter.allow("1.1.1.1")
+        allowed_b, _ = limiter.allow("2.2.2.2")
+        assert allowed_a is True
+        assert allowed_b is True
+
+    def test_same_ip_limited(self):
+        limiter = RateLimiter(rate=1.0, burst=1)
+        limiter.allow("1.1.1.1")
+        allowed, retry_after = limiter.allow("1.1.1.1")
+        assert allowed is False
+        assert retry_after > 0
+
+
+class TestRateLimitIntegration:
+    def test_returns_429_when_exceeded(self, graph_file, monkeypatch):
+        monkeypatch.setenv("HCKG_RATE_LIMIT", "1")
+        monkeypatch.setenv("HCKG_RATE_BURST", "1")
+        app = create_app(graph_path=graph_file)
+        app.config["TESTING"] = True
+        with app.test_client() as c:
+            resp1 = c.get("/health")
+            assert resp1.status_code == 200
+
+            resp2 = c.get("/health")
+            assert resp2.status_code == 429
+            data = json.loads(resp2.data)
+            assert "error" in data
+            assert "Retry-After" in resp2.headers
+
+    def test_disabled_with_zero(self, graph_file, monkeypatch):
+        monkeypatch.setenv("HCKG_RATE_LIMIT", "0")
+        app = create_app(graph_path=graph_file)
+        app.config["TESTING"] = True
+        with app.test_client() as c:
+            for _ in range(10):
+                resp = c.get("/health")
+                assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Add `src/serve/rate_limit.py` — per-IP token bucket rate limiter
- Configurable via `HCKG_RATE_LIMIT` (req/s, default 10) and `HCKG_RATE_BURST` (default 20)
- Returns 429 with `Retry-After` header when exceeded
- Disabled with `HCKG_RATE_LIMIT=0`

## Test plan
- [x] 8 new tests in `tests/unit/serve/test_rate_limit.py`
- [x] Token bucket: burst, rejection, refill, retry-after
- [x] Per-IP isolation
- [x] Integration: 429 response, disabled mode

Closes #288