### PR TITLE
docs: rename hc-kg-* references to hc-enterprise-kg-* taxonomy

### DIFF
--- a/AGENCY.md
+++ b/AGENCY.md
@@ -1,0 +1,323 @@
+# DevOps Agency — hc-enterprise-kg Platform
+
+**Version:** 1.0.0
+**Date:** 2026-03-10
+**Purpose:** Define the autonomous agent agency that develops, operates, and evolves the hc-enterprise-kg platform ecosystem.
+
+---
+
+## Agency Mission
+
+Develop and maintain an enterprise knowledge graph platform that structurally represents all 18 modules of the CMU Heinz College CDAIO Certificate Program, using modern enterprise architecture patterns with pluggable, substitutable components.
+
+---
+
+## Agent Profiles
+
+### 1. Enterprise Architect (EA)
+
+**Industry Standard:** TOGAF 10, ArchiMate 3.2, C4 Model, IEEE 42010
+**Responsibility:** Overall system design, architecture decision records, integration patterns, technology selection, and enterprise design governance.
+
+| Attribute | Detail |
+|-----------|--------|
+| Standards | TOGAF ADM, ArchiMate viewpoints, C4 diagrams, 12-Factor App |
+| Deliverables | Architecture blueprints, ADRs, integration specs, capability maps |
+| Tools | Structurizr (C4), draw.io, PlantUML |
+| Quality Gates | ADR review, architectural fitness functions, dependency analysis |
+
+**CDAIO Module Coverage:** All 18 modules (cross-cutting)
+
+---
+
+### 2. Platform Engineer (PE)
+
+**Industry Standard:** Domain-Driven Design (Evans), SOLID principles, Hexagonal Architecture (Ports & Adapters)
+**Responsibility:** Core platform development — entity models, graph engine abstractions, plugin system, and domain logic.
+
+| Attribute | Detail |
+|-----------|--------|
+| Standards | DDD (bounded contexts, aggregates), Pydantic v2, Python 3.11+ |
+| Deliverables | Entity models, engine interfaces, registry system, domain events |
+| Tools | Poetry, pytest, ruff, mypy |
+| Quality Gates | 100% entity coverage, schema validation, backward compatibility |
+
+**Pluggable Standards:**
+
+| Capability | Primary | Alternative | Interface |
+|-----------|---------|-------------|-----------|
+| Graph Backend | NetworkX | Neo4j, Amazon Neptune, TigerGraph | `AbstractGraphEngine` |
+| Validation | Pydantic v2 | attrs, marshmallow | `BaseEntity` |
+| Serialization | JSON | GraphML, RDF/OWL, Parquet | `AbstractExporter` |
+| Search | rapidfuzz | Elasticsearch, Meilisearch, pgvector | `search_entities()` |
+
+**CDAIO Module Coverage:** M1 (EDM), M2 (Strategy), M4 (Data Engineering), M12 (CDAIO Org)
+
+---
+
+### 3. Data Engineer (DE)
+
+**Industry Standard:** dbt, Great Expectations, Apache Arrow, Data Mesh (Dehghani)
+**Responsibility:** Schema evolution, data ingestion pipelines, data quality gates, synthetic data generation, and analytics pipelines.
+
+| Attribute | Detail |
+|-----------|--------|
+| Standards | Data Mesh principles, DCAM 2.2, DAMA-DMBOK, Kimball methodology |
+| Deliverables | Entity generators, ingestors, quality scoring, data pipeline models |
+| Tools | Polars/Pandas, Great Expectations, dbt patterns |
+| Quality Gates | Quality score >= 0.7, semantic coherence, no lorem ipsum |
+
+**Pluggable Standards:**
+
+| Capability | Primary | Alternative | Interface |
+|-----------|---------|-------------|-----------|
+| Data Quality | Great Expectations | Soda, Monte Carlo, Atlan | `QualityReport` |
+| Orchestration | Prefect | Airflow, Dagster, Mage | `DataPipeline` entity |
+| Transformation | dbt | Spark, Polars, SQLMesh | `DataFlow` entity |
+| Catalog | Custom KG | DataHub, OpenMetadata, Amundsen | `DataDomain` entity |
+
+**CDAIO Module Coverage:** M1 (EDM), M3 (Maturity), M4 (Data Engineering), M6 (DataOps), M7 (Infonomics), M8 (Data Products)
+
+---
+
+### 4. ML Engineer (MLE)
+
+**Industry Standard:** MLflow, ONNX, Kubeflow, NIST AI RMF 1.0, EU AI Act
+**Responsibility:** AI/ML model lifecycle, model registry, experiment tracking, bias/fairness assessment, and responsible AI governance.
+
+| Attribute | Detail |
+|-----------|--------|
+| Standards | NIST AI RMF, EU AI Act risk categories, ISO/IEC 42001, OECD AI Principles |
+| Deliverables | AIModel entity, ML pipeline models, fairness metrics, model governance |
+| Tools | MLflow, Weights & Biases, SHAP, Aequitas |
+| Quality Gates | Bias assessment, model documentation, EU AI Act classification |
+
+**Pluggable Standards:**
+
+| Capability | Primary | Alternative | Interface |
+|-----------|---------|-------------|-----------|
+| Model Registry | MLflow | Weights & Biases, Neptune, Comet | `AIModel` entity |
+| Experiment Tracking | MLflow | W&B, ClearML, Sacred | `MLExperiment` sub-model |
+| Model Serving | Custom | Seldon, BentoML, TorchServe | `deployed_in` relationship |
+| Fairness | Aequitas | Fairlearn, AI Fairness 360, What-If Tool | `FairnessAssessment` sub-model |
+| Explainability | SHAP | LIME, Captum, InterpretML | `ExplainabilityProfile` sub-model |
+
+**CDAIO Module Coverage:** M9 (Data Science), M10 (AI Foundations), M11 (AI Strategy), M13 (AI Factory), M14 (MLOps), M15 (Responsible AI), M16 (GenAI)
+
+---
+
+### 5. API Engineer (AE)
+
+**Industry Standard:** OpenAPI 3.1, GraphQL (Strawberry), REST Level 3 (HATEOAS), OAuth 2.0/OIDC
+**Responsibility:** API gateway design, endpoint implementation, SDK generation, and API documentation.
+
+| Attribute | Detail |
+|-----------|--------|
+| Standards | OpenAPI 3.1, JSON:API, GraphQL Federation, RFC 7807 (Problem Details) |
+| Deliverables | API gateway (FastAPI), GraphQL schema, OpenAPI specs, client SDKs |
+| Tools | FastAPI, Strawberry GraphQL, Swagger UI, Redoc |
+| Quality Gates | 100% endpoint coverage, schema validation, rate limiting, CORS |
+
+**Pluggable Standards:**
+
+| Capability | Primary | Alternative | Interface |
+|-----------|---------|-------------|-----------|
+| REST Framework | FastAPI | Flask, Django REST, Litestar | `AbstractAPIRouter` |
+| GraphQL | Strawberry | Ariadne, Graphene, Tartiflette | `GraphQLSchema` |
+| Auth | OAuth 2.0/OIDC | JWT, API Keys, mTLS | `AuthProvider` |
+| Docs | Swagger/Redoc | Stoplight, ReadMe, Mintlify | OpenAPI spec |
+
+**CDAIO Module Coverage:** M4 (Infrastructure), M5 (Analytics/BI), M18 (Communication)
+
+---
+
+### 6. DevSecOps Engineer (DSE)
+
+**Industry Standard:** OWASP Top 10, NIST CSF 2.0, CIS Benchmarks, SLSA, SBOM (CycloneDX)
+**Responsibility:** CI/CD pipelines, security scanning, compliance automation, infrastructure as code, and supply chain security.
+
+| Attribute | Detail |
+|-----------|--------|
+| Standards | OWASP, NIST CSF 2.0, CIS Controls v8, SLSA Level 3, SSDF |
+| Deliverables | CI/CD workflows, SAST/DAST scans, SBOM generation, container images |
+| Tools | GitHub Actions, Trivy, Bandit, Safety, CodeQL, Docker |
+| Quality Gates | Zero critical vulns, SBOM current, signed images, dependency audit |
+
+**Pluggable Standards:**
+
+| Capability | Primary | Alternative | Interface |
+|-----------|---------|-------------|-----------|
+| CI/CD | GitHub Actions | GitLab CI, Jenkins, CircleCI | `.github/workflows/` |
+| SAST | CodeQL + Bandit | Semgrep, SonarQube, Snyk | Pre-commit hooks |
+| Container | Docker | Podman, containerd, Buildah | `Dockerfile` |
+| IaC | Terraform | Pulumi, OpenTofu, CDK | `hc-enterprise-kg-infra/` |
+| Secrets | GitHub Secrets | Vault, Doppler, 1Password | `SecretProvider` |
+
+**CDAIO Module Coverage:** M17 (Cybersecurity), M6 (DataOps)
+
+---
+
+### 7. Frontend Engineer (FE)
+
+**Industry Standard:** React 19, Next.js 15, D3.js v7, Tailwind CSS, WCAG 2.2 AA
+**Responsibility:** Web dashboard, interactive graph visualization, maturity assessment UI, and accessibility compliance.
+
+| Attribute | Detail |
+|-----------|--------|
+| Standards | WCAG 2.2 AA, WAI-ARIA, Responsive Design, Progressive Enhancement |
+| Deliverables | Dashboard app, graph explorer, chart components, maturity radar |
+| Tools | React, Next.js, D3.js, Tailwind CSS, Vitest |
+| Quality Gates | Lighthouse >= 90, WCAG audit, responsive breakpoints |
+
+**Pluggable Standards:**
+
+| Capability | Primary | Alternative | Interface |
+|-----------|---------|-------------|-----------|
+| Framework | React/Next.js | Vue/Nuxt, Svelte/SvelteKit, Angular | `hc-enterprise-kg-web/` |
+| Graph Viz | D3.js | Cytoscape.js, vis.js, Sigma.js | `GraphRenderer` |
+| Charts | Recharts | Chart.js, ECharts, Nivo | `ChartRenderer` |
+| State | Zustand | Redux Toolkit, Jotai, TanStack Query | `useGraphStore` |
+
+**CDAIO Module Coverage:** M5 (Analytics/BI), M18 (Communication/Leadership)
+
+---
+
+### 8. QA Lead (QA)
+
+**Industry Standard:** pytest, Hypothesis (property-based), k6 (load testing), Contract Testing
+**Responsibility:** Test strategy, coverage enforcement, performance regression testing, and data quality validation.
+
+| Attribute | Detail |
+|-----------|--------|
+| Standards | pytest, Hypothesis, k6, Pact (contract testing), Coverage >= 85% |
+| Deliverables | Test suites (unit, integration, stress, performance), coverage reports |
+| Tools | pytest, pytest-cov, hypothesis, k6, locust |
+| Quality Gates | 1200+ tests passing, coverage >= 85%, no performance regression |
+
+**CDAIO Module Coverage:** M3 (Maturity), M6 (DataOps)
+
+---
+
+### 9. Site Reliability Engineer (SRE)
+
+**Industry Standard:** OpenTelemetry, Prometheus, Grafana, SLO/SLI/SLA framework
+**Responsibility:** Observability, monitoring, deployment reliability, incident management, and capacity planning.
+
+| Attribute | Detail |
+|-----------|--------|
+| Standards | OpenTelemetry, Prometheus, SLO framework, Chaos Engineering |
+| Deliverables | Monitoring dashboards, SLO definitions, runbooks, health checks |
+| Tools | OpenTelemetry, Prometheus, Grafana, PagerDuty |
+| Quality Gates | SLO compliance >= 99.9%, MTTR < 15min, health endpoint passing |
+
+**Pluggable Standards:**
+
+| Capability | Primary | Alternative | Interface |
+|-----------|---------|-------------|-----------|
+| Metrics | Prometheus | Datadog, New Relic, CloudWatch | OpenTelemetry SDK |
+| Tracing | Jaeger | Zipkin, Tempo, X-Ray | OpenTelemetry SDK |
+| Logging | Loki | ELK Stack, Splunk, Fluentd | Structured JSON |
+| Dashboards | Grafana | Datadog, Kibana, Chronograf | Dashboard-as-Code |
+
+**CDAIO Module Coverage:** M14 (MLOps), M6 (DataOps)
+
+---
+
+### 10. Technical Writer (TW)
+
+**Industry Standard:** Diataxis framework, OpenAPI docs, Architecture Decision Records
+**Responsibility:** Documentation strategy, API reference, user guides, and architecture documentation.
+
+| Attribute | Detail |
+|-----------|--------|
+| Standards | Diataxis (tutorials, how-to, reference, explanation), ADR format |
+| Deliverables | API reference, user guides, architecture docs, CHANGELOG |
+| Tools | MkDocs Material, Swagger UI, Mermaid diagrams |
+| Quality Gates | All public APIs documented, no broken links, versioned docs |
+
+**CDAIO Module Coverage:** M18 (Communication/Leadership)
+
+---
+
+## Module Coverage Matrix
+
+| CDAIO Module | Agents | Platform Component | Industry Standards |
+|-------------|--------|-------------------|-------------------|
+| M1: EDM Foundations | PE, DE | `DataAsset`, `DataDomain`, `DataFlow` | DAMA-DMBOK, DCAM 2.2 |
+| M2: Data Strategy & Governance | PE, DE | `Policy`, `Control`, `Risk`, governance chains | COBIT 2019, DAMA |
+| M3: Maturity Assessment | DE, QA | `DataDomain.maturity_dimensions`, `QualityReport` | DCAM 2.2, CMMI |
+| M4: Data Engineering | PE, DE | `System`, `Integration`, `DataPipeline` (new) | dbt, Great Expectations |
+| M5: Analytics/BI | FE, AE | `analysis/`, dashboard, charts | D3.js, OpenAPI 3.1 |
+| M6: DataOps | DE, DSE, SRE | `DataPipeline` (new), CI/CD, monitoring | DataOps Manifesto, GitOps |
+| M7: Infonomics | DE | `DataAsset` valuation fields (new) | Infonomics (Laney), GAAP |
+| M8: Data Products | DE, PE | `DataProduct` (new entity) | Data Mesh (Dehghani) |
+| M9: Data Science/ML | MLE | `AIModel` (new entity), experiment tracking | CRISP-DM, MLflow |
+| M10: AI Foundations | MLE, PE | `AIModel`, AI application registry | NIST AI RMF |
+| M11: AI Strategy | MLE, EA | `Initiative` + AI value fields, governance | NIST AI RMF, Val IT |
+| M12: CDAIO Organization | PE | `Department`, `OrgUnit`, `Role` with CDAIO fields | TOGAF, operating models |
+| M13: AI Factory | MLE, DE | `AIModel` + `DataPipeline` + ML pipeline | Kubeflow, MLflow |
+| M14: MLOps | MLE, SRE | Model monitoring, drift detection, deployment | MLOps maturity model |
+| M15: Responsible AI | MLE | `AIModel` ethics/bias fields, `EthicsReview` | EU AI Act, NIST AI RMF |
+| M16: GenAI/LLM | MLE, PE | `AIModel` (LLM variant), `mcp_server/` | LangChain, MCP |
+| M17: Cybersecurity | DSE, PE | `Vulnerability`, `ThreatActor`, `Risk`, blast radius | MITRE ATT&CK, NIST CSF 2.0 |
+| M18: Leadership/Comms | FE, TW | Dashboard, visualization, documentation | Diataxis, WCAG 2.2 |
+
+---
+
+## Enterprise Architecture Pattern
+
+**Pattern:** Modular Monorepo → Extractable Microservices
+**Standard:** Hexagonal Architecture (Ports & Adapters) with Domain-Driven Design
+
+```
+hc-platform/                          # Workspace root
+├── hc-enterprise-kg/                 # Core domain + engine (this repo)
+│   ├── src/domain/                   # Entity models (30+ types)
+│   ├── src/engine/                   # Pluggable graph backends
+│   ├── src/graph/                    # KnowledgeGraph facade
+│   ├── src/synthetic/                # Synthetic data generation
+│   ├── src/analysis/                 # Analytics engine
+│   ├── src/ingest/                   # Data ingestion
+│   ├── src/export/                   # Export formats
+│   └── src/mcp_server/              # MCP server (Claude Desktop)
+├── hc-enterprise-kg-gateway/                    # API Gateway (FastAPI + GraphQL)
+│   ├── src/routes/                   # REST endpoints
+│   ├── src/graphql/                  # GraphQL schema
+│   └── src/middleware/               # Auth, CORS, rate limiting
+├── hc-enterprise-kg-web/                        # Web Dashboard (React + D3.js)
+│   ├── src/components/               # UI components
+│   ├── src/views/                    # Page views
+│   └── src/graph-explorer/           # Interactive graph viz
+└── hc-enterprise-kg-infra/                      # Infrastructure
+    ├── docker/                       # Dockerfiles
+    ├── terraform/                    # IaC
+    ├── k8s/                          # Kubernetes manifests
+    └── monitoring/                   # Observability config
+```
+
+**Pluggability Contract:** Every major capability is behind an abstract interface. Swap implementations by:
+1. Implementing the interface (e.g., `AbstractGraphEngine`)
+2. Registering with the factory (e.g., `GraphEngineFactory.register("neo4j", Neo4jEngine)`)
+3. Configuring the backend (e.g., `KnowledgeGraph(backend="neo4j")`)
+
+No code changes required in consuming modules.
+
+---
+
+## Orchestration Model
+
+Agents are orchestrated in dependency waves:
+
+```
+Wave 1: EA + PE (architecture + domain models)
+    ↓
+Wave 2: DE + MLE (generators + AI models) [parallel]
+    ↓
+Wave 3: AE + FE (API gateway + dashboard) [parallel]
+    ↓
+Wave 4: DSE + SRE (infra + monitoring) [parallel]
+    ↓
+Wave 5: QA + TW (testing + docs)
+```
+
+Each wave produces artifacts consumed by subsequent waves. Within a wave, agents operate in parallel on independent deliverables.

--- a/ENTERPRISE_ARCHITECTURE.md
+++ b/ENTERPRISE_ARCHITECTURE.md
@@ -1,0 +1,222 @@
+# Enterprise Architecture Blueprint
+
+**Version:** 1.0.0
+**Date:** 2026-03-10
+**Pattern:** Modular Monorepo with Extractable Services
+**Standard:** Hexagonal Architecture (Ports & Adapters), Domain-Driven Design
+
+---
+
+## Design Philosophy
+
+This platform is a **knowledge graph for CDAIO insight** — not a technology execution platform. It models what a Chief Data & AI Officer needs to understand: organizational structure, data assets, AI models, data pipelines, governance posture, risk exposure, and strategic initiatives. The entities and their relationships ARE the product. Every module in the CMU CDAIO program is addressed by making the graph queryable for the questions a data leader asks.
+
+---
+
+## System Topology
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     hc-platform (workspace)                  │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│  ┌──────────────────────┐    ┌──────────────────────┐       │
+│  │  hc-enterprise-kg    │    │  hc-enterprise-kg-gateway       │       │
+│  │  (Core Domain)       │◄───│  (API Gateway)       │       │
+│  │                      │    │  FastAPI + GraphQL    │       │
+│  │  33 entity types     │    │  OpenAPI 3.1          │       │
+│  │  66 relationship     │    └──────────────────────┘       │
+│  │  types               │                                    │
+│  │  Pluggable engine    │    ┌──────────────────────┐       │
+│  │  MCP server          │    │  hc-enterprise-kg-web           │       │
+│  └──────────┬───────────┘    │  (Dashboard)         │       │
+│             │                │  React + D3.js       │       │
+│             │                │  Next.js             │       │
+│             ▼                └──────────────────────┘       │
+│  ┌──────────────────────┐                                    │
+│  │  hc-enterprise-kg-infra         │    Industry Standards:             │
+│  │  (Infrastructure)    │    ● Docker / Kubernetes           │
+│  │  Docker Compose      │    ● Terraform / OpenTofu          │
+│  │  K8s manifests       │    ● Prometheus / Grafana          │
+│  │  Terraform           │    ● OpenTelemetry                 │
+│  │  Monitoring          │    ● OWASP / NIST CSF 2.0         │
+│  └──────────────────────┘                                    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Pluggable Capability Matrix
+
+Every major capability is behind an abstract interface. Swap implementations without changing consuming code.
+
+| Capability | Interface | Primary | Alternatives | Standard |
+|-----------|-----------|---------|-------------|----------|
+| **Graph Backend** | `AbstractGraphEngine` | NetworkX | Neo4j, Amazon Neptune, TigerGraph | IEEE Graph DB |
+| **Entity Validation** | `BaseEntity` (Pydantic v2) | Pydantic | attrs, marshmallow | JSON Schema |
+| **Serialization** | `AbstractExporter` | JSON | GraphML, RDF/OWL, Parquet | JSON-LD, W3C |
+| **Fuzzy Search** | `search_entities()` | rapidfuzz | Elasticsearch, pgvector | BM25, ANN |
+| **AI Interface** | MCP Server | Claude Desktop | Any MCP client | Model Context Protocol |
+| **REST API** | FastAPI Router | FastAPI | Flask, Litestar | OpenAPI 3.1 |
+| **GraphQL** | Strawberry Schema | Strawberry | Ariadne, Graphene | GraphQL Spec |
+| **Visualization** | D3.js Components | D3.js | Cytoscape.js, Sigma.js | SVG/Canvas |
+| **Auth** | Middleware | OAuth 2.0/OIDC | JWT, API Keys, mTLS | RFC 6749 |
+| **Monitoring** | OpenTelemetry | Prometheus | Datadog, New Relic | OTLP |
+| **IaC** | Terraform | Terraform | Pulumi, OpenTofu, CDK | HCL |
+| **Container** | Dockerfile | Docker | Podman, containerd | OCI |
+| **Orchestration** | K8s manifests | Kubernetes | Docker Swarm, ECS | CNCF |
+| **Data Quality** | `QualityReport` | Custom scoring | Great Expectations, Soda | DCAM 2.2 |
+
+---
+
+## Repository Structure
+
+### hc-enterprise-kg (Core Domain) — This repo
+
+The knowledge graph engine, entity models, synthetic generation, analysis, and MCP server.
+
+```
+src/
+  domain/           33 Pydantic v2 entity models, 66 relationship types
+    entities/        ai_model.py, data_product.py, data_pipeline.py (new)
+    base.py          EntityType + RelationshipType enums
+    registry.py      EntityRegistry (plugin discovery)
+    relationship_schema.py  Domain/range constraints
+    shared.py        Reusable sub-models
+  engine/           Pluggable graph backend
+    abstract.py      AbstractGraphEngine (swap NetworkX for Neo4j)
+    networkx_engine.py
+    factory.py       GraphEngineFactory.register("neo4j", Neo4jEngine)
+  graph/            KnowledgeGraph facade, event bus, QueryBuilder
+  synthetic/        Profile-driven generation (tech, financial, healthcare)
+    generators/      30 v0.1 + 3 CDAIO generators
+    profiles/        Industry-specific scaling coefficients
+    relationships.py 33+ weaver methods including CDAIO relationships
+  analysis/         Centrality, risk scoring, blast radius, charts
+  mcp_server/       16 tools for Claude Desktop (read + write + provenance)
+  ingest/           CSV/JSON ingestion with schema mapping
+  export/           JSON + GraphML export
+  rag/              GraphRAG retrieval pipeline
+  cli/              Click CLI (demo, generate, inspect, auto, serve, install)
+  serve/            REST API (Flask)
+```
+
+### hc-enterprise-kg-gateway (API Gateway)
+
+FastAPI + Strawberry GraphQL gateway exposing the knowledge graph via REST and GraphQL.
+
+```
+hc-enterprise-kg-gateway/
+  src/
+    main.py           FastAPI app, CORS, router mounting
+    config.py          pydantic-settings configuration
+    routes/            REST endpoints (entities, relationships, analysis, health)
+    graphql/           Strawberry schema + resolvers
+    middleware/         OAuth 2.0 auth middleware
+  Dockerfile
+```
+
+### hc-enterprise-kg-web (Dashboard)
+
+React + Next.js + D3.js interactive dashboard for CDAIO insight.
+
+```
+hc-enterprise-kg-web/
+  src/
+    app/               Next.js App Router pages
+      entities/         Entity explorer
+      graph/            Force-directed graph visualization
+      maturity/         Maturity radar chart
+      ai-models/        AI model registry view
+    components/         GraphExplorer, EntityTable, MaturityRadar, Sidebar
+    lib/                API client, TypeScript types
+```
+
+### hc-enterprise-kg-infra (Infrastructure)
+
+Docker Compose, Kubernetes, Terraform, and monitoring configuration.
+
+```
+hc-enterprise-kg-infra/
+  docker/              docker-compose.yml (6 services), Dockerfiles
+  k8s/                 Namespace, deployments, services
+  terraform/           Provider config, variables, modules
+  monitoring/          Prometheus scrape config, Grafana dashboards
+  .github/workflows/   CI pipeline
+```
+
+---
+
+## CDAIO Module Coverage — 18/18
+
+| # | CDAIO Module | How the KG Addresses It |
+|---|-------------|------------------------|
+| 1 | **EDM Foundations** | `DataAsset`, `DataDomain`, `DataFlow` + governance chains (`Policy` → `Control` → `Risk`). Quality dimensions, lifecycle, classification, retention. |
+| 2 | **Data Strategy & Governance** | `Initiative` with `value_category`, `lifecycle_stage`, `value_confidence`. Decision rights on `Role`. Governance traversal via `governs`, `implements`, `subject_to`. |
+| 3 | **Maturity Assessment** | `DataDomain.maturity_dimensions` (DCAM 2.2). `BusinessCapability.maturity`. `Department.data_fluency_level`. Quality radar charts. |
+| 4 | **Data Engineering** | `DataPipeline` entity — pipeline type, orchestration platform, medallion/lambda/kappa patterns, source/target lineage, execution profiles. `ORCHESTRATES`, `CONSUMES`, `PRODUCES` relationships. |
+| 5 | **Analytics/BI** | Analysis module (centrality, PageRank, blast radius). Charts module (8 chart types). Dashboard scaffold (hc-enterprise-kg-web) with D3.js. |
+| 6 | **DataOps** | `DataPipeline` with CI/CD fields (`version_controlled`, `ci_cd_enabled`, `test_coverage_pct`), quality framework integration, SLA tracking, observability flags. |
+| 7 | **Infonomics** | `DataAsset` with `economic_value_method` (cost/market/income/utility), `estimated_economic_value`, `monetization_status`. `DataProduct` with `estimated_annual_value`, `cost_to_produce`, `margin_pct`. |
+| 8 | **Data Products** | `DataProduct` entity — ownership, SLA, FAIR compliance scores, quality contracts, consumer tracking, monetization status, access protocols. `PUBLISHES`, `BELONGS_TO` relationships. |
+| 9 | **Data Science/ML** | `AIModel` entity — training data lineage (`TRAINED_ON`), performance metrics, validation methodology, hyperparameters. |
+| 10 | **AI Foundations** | `AIModel` with model type taxonomy (classification, regression, NLP, generative, etc.), framework tracking (pytorch, tensorflow, huggingface), deployment status. |
+| 11 | **AI Strategy** | `Initiative` with `data_ai_alignment`. `AIModel` with `projected_annual_value`, `value_confidence`. `CREATES_VALUE_FOR` relationship linking initiatives to business capabilities. |
+| 12 | **CDAIO Organization** | `Department` and `OrgUnit` with `data_fluency_level`, `data_culture_score`, `ai_readiness_tier`. `Role` with `cdaio_function`, `decision_domains`, `decision_authority`. |
+| 13 | **AI Factory** | `AIModel` + `DataPipeline` together model the AI factory — training pipelines (`CONSUMES` data, `PRODUCES` models), serving infrastructure, compute profiles. |
+| 14 | **MLOps** | `AIModel` with `deployment_status`, `drift_detection_enabled`, `drift_status`, `model_health`, `monitoring_enabled`, `rollback_version`. `DEPLOYED_IN` relationship to systems. |
+| 15 | **Responsible AI** | `AIModel` with `eu_ai_act_risk_category`, `nist_ai_rmf_profile`, `fairness_metrics`, `bias_assessment_completed`, `ethics_review_status`, `human_oversight_required`, `explainability_method`. |
+| 16 | **GenAI/LLM** | `AIModel` with `is_generative`, `base_model_provider` (openai, anthropic, etc.), `context_window_tokens`, `fine_tuning_method`, `guardrails_enabled`, `guardrail_types`. MCP server for Claude Desktop. |
+| 17 | **Cybersecurity** | `Vulnerability`, `ThreatActor`, `Incident`, `Risk`, `Threat`. Blast radius analysis, attack path finding, centrality scoring. `EXPLOITS`, `TARGETS`, `MITIGATES`, `AFFECTS` relationships. |
+| 18 | **Leadership/Comms** | Dashboard (hc-enterprise-kg-web), interactive visualization (`hckg visualize`), quality radar charts, MCP natural-language querying. The graph IS the communication artifact. |
+
+---
+
+## CDAIO Insight Queries Enabled
+
+The relationship graph enables these CDAIO questions through traversal:
+
+**Strategy & Value:**
+- "Which initiatives have demonstrated value over $1M?" → Initiative.value_confidence + expected_outcomes
+- "What's stuck in POC?" → Initiative.lifecycle_stage == "poc"
+- "Which quick wins can show value in 3 months?" → Initiative.initiative_nature + time_to_value
+
+**Data Architecture:**
+- "How many data assets are published as products?" → DataProduct count vs DataAsset count
+- "Which data products lack SLAs?" → DataProduct.data_product_sla == None
+- "What's our FAIR compliance?" → DataProduct.findable_score, accessible_score, etc.
+
+**AI/ML Governance:**
+- "Which AI models are high-risk under EU AI Act?" → AIModel.eu_ai_act_risk_category == "high"
+- "Which models lack bias assessment?" → AIModel.bias_assessment_completed == False
+- "What data feeds our fraud detection model?" → TRAINED_ON traversal
+- "Which systems host production AI models?" → DEPLOYED_IN traversal
+
+**DataOps Health:**
+- "Which pipelines are failing SLAs?" → DataPipeline.sla_breach_count_30d > 0
+- "What's our CI/CD coverage for data pipelines?" → DataPipeline.ci_cd_enabled
+- "Which pipelines feed our data products?" → PUBLISHES traversal
+
+**Organizational Readiness:**
+- "Which departments have low data fluency?" → Department.data_fluency_level < 3
+- "Who has decision authority over data classification?" → Role.decision_domains + decision_authority
+- "What's the blast radius if this vendor fails?" → blast_radius(vendor_id)
+
+---
+
+## Domain Model Summary
+
+**33 Entity Types** across 12+ generation layers:
+- v0.1 (12): Person, Department, Role, System, Network, DataAsset, Policy, Vendor, Location, Vulnerability, ThreatActor, Incident
+- Enterprise (18): Regulation, Control, Risk, Threat, Integration, DataDomain, DataFlow, OrganizationalUnit, BusinessCapability, Site, Geography, Jurisdiction, ProductPortfolio, Product, MarketSegment, Customer, Contract, Initiative
+- CDAIO (3): **AIModel**, **DataProduct**, **DataPipeline**
+
+**66 Relationship Types** including 8 new CDAIO types:
+- `trained_on` — AIModel → DataAsset/DataProduct
+- `deployed_in` — AIModel → System
+- `produces` — DataPipeline/AIModel → DataAsset/DataProduct
+- `consumes` — DataPipeline/AIModel/DataProduct → DataAsset/DataProduct
+- `creates_value_for` — Initiative/DataProduct/AIModel → BusinessCapability/DataDomain/Department
+- `monitors` — System/DataPipeline → AIModel/DataPipeline/System
+- `publishes` — DataPipeline/System → DataProduct
+- `orchestrates` — System → DataPipeline


### PR DESCRIPTION
## Summary
- Rename all `hc-kg-*` references to `hc-enterprise-kg-*` in ENTERPRISE_ARCHITECTURE.md and AGENCY.md
- Companion repos created and pushed: hc-enterprise-kg-gateway, hc-enterprise-kg-web, hc-enterprise-kg-infra

Closes #294